### PR TITLE
feat: reduce false positives in mutex and waitgroup analysis

### DIFF
--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -1,6 +1,7 @@
 package analyzer
 
 import (
+	"maps"
 	"go/ast"
 	"go/token"
 	"go/types"
@@ -54,14 +55,15 @@ func analyzeFunctions(file *ast.File, pass *analysis.Pass, errorCollector *repor
 		}
 
 		primitives := findSyncPrimitives(fn, pass)
+		localWaitGroups := copyPrimitiveNames(primitives.waitGroups)
 		mergePrimitives(primitives, pkgPrimitives)
 
 		if hasMutexes(primitives) {
-			analyzeMutexUsage(fn, primitives, errorCollector, commentFilter)
+			analyzeMutexUsage(fn, primitives, errorCollector, commentFilter, pass)
 		}
 
 		if hasWaitGroups(primitives) {
-			analyzeWaitGroupUsage(fn, primitives, errorCollector, commentFilter, pass)
+			analyzeWaitGroupUsage(fn, primitives, localWaitGroups, pkgPrimitives.waitGroups, errorCollector, commentFilter, pass)
 		}
 	}
 }
@@ -104,6 +106,12 @@ func mergePrimitives(dst, src *syncPrimitive) {
 	for k, v := range src.waitGroups {
 		dst.waitGroups[k] = v
 	}
+}
+
+func copyPrimitiveNames(src map[string]bool) map[string]bool {
+	dst := make(map[string]bool, len(src))
+	maps.Copy(dst, src)
+	return dst
 }
 
 // findSyncPrimitives identifies all sync primitives declared in a function,
@@ -237,13 +245,13 @@ func hasWaitGroups(primitives *syncPrimitive) bool {
 }
 
 // analyzeMutexUsage handles mutex and rwmutex analysis
-func analyzeMutexUsage(fn *ast.FuncDecl, primitives *syncPrimitive, errorCollector *report.ErrorCollector, cf *commnetfilter.CommentFilter) {
-	analyzer := mutex.NewAnalyzer(primitives.mutexes, primitives.rwMutexes, errorCollector, cf)
+func analyzeMutexUsage(fn *ast.FuncDecl, primitives *syncPrimitive, errorCollector *report.ErrorCollector, cf *commnetfilter.CommentFilter, pass *analysis.Pass) {
+	analyzer := mutex.NewAnalyzer(primitives.mutexes, primitives.rwMutexes, errorCollector, cf, pass.Files)
 	analyzer.AnalyzeFunction(fn)
 }
 
 // analyzeWaitGroupUsage handles waitgroup analysis
-func analyzeWaitGroupUsage(fn *ast.FuncDecl, primitives *syncPrimitive, errorCollector *report.ErrorCollector, cf *commnetfilter.CommentFilter, pass *analysis.Pass) {
-	analyzer := waitgroup.NewAnalyzer(primitives.waitGroups, errorCollector, cf, pass)
+func analyzeWaitGroupUsage(fn *ast.FuncDecl, primitives *syncPrimitive, localWaitGroups, packageLevelWaitGroups map[string]bool, errorCollector *report.ErrorCollector, cf *commnetfilter.CommentFilter, pass *analysis.Pass) {
+	analyzer := waitgroup.NewAnalyzer(primitives.waitGroups, localWaitGroups, packageLevelWaitGroups, errorCollector, cf, pass)
 	analyzer.AnalyzeFunction(fn)
 }

--- a/pkg/analyzer/mutex/analyzer.go
+++ b/pkg/analyzer/mutex/analyzer.go
@@ -3,19 +3,24 @@ package mutex
 import (
 	"go/ast"
 	"go/token"
+	"strings"
 
+	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/common"
 	commnetfilter "github.com/sanbricio/goconcurrencylint/pkg/analyzer/common/commentfilter"
 	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/common/report"
 )
 
 // Analyzer handles the analysis of mutex and rwmutex usage
 type Analyzer struct {
-	mutexNames     map[string]bool
-	rwMutexNames   map[string]bool
-	errorCollector *report.ErrorCollector
-	stats          map[string]*Stats
-	deferErrors    *deferErrorCollector
-	commentFilter  *commnetfilter.CommentFilter
+	mutexNames      map[string]bool
+	rwMutexNames    map[string]bool
+	errorCollector  *report.ErrorCollector
+	stats           map[string]*Stats
+	deferErrors     *deferErrorCollector
+	commentFilter   *commnetfilter.CommentFilter
+	function        *ast.FuncDecl
+	receiverMethods map[string]map[string]*ast.FuncDecl
+	functions       []*ast.FuncDecl
 }
 
 // Stats tracks the state of a mutex within a block
@@ -35,12 +40,14 @@ type deferErrorCollector struct {
 }
 
 // NewAnalyzer creates a new mutex analyzer
-func NewAnalyzer(mutexNames, rwMutexNames map[string]bool, errorCollector *report.ErrorCollector, cf *commnetfilter.CommentFilter) *Analyzer {
+func NewAnalyzer(mutexNames, rwMutexNames map[string]bool, errorCollector *report.ErrorCollector, cf *commnetfilter.CommentFilter, files []*ast.File) *Analyzer {
 	return &Analyzer{
-		mutexNames:     mutexNames,
-		rwMutexNames:   rwMutexNames,
-		errorCollector: errorCollector,
-		commentFilter:  cf,
+		mutexNames:      mutexNames,
+		rwMutexNames:    rwMutexNames,
+		errorCollector:  errorCollector,
+		commentFilter:   cf,
+		receiverMethods: buildReceiverMethodMap(files),
+		functions:       collectFunctionDecls(files),
 		deferErrors: &deferErrorCollector{
 			badDeferUnlock:  make(map[string]bool),
 			badDeferRUnlock: make(map[string]bool),
@@ -50,9 +57,474 @@ func NewAnalyzer(mutexNames, rwMutexNames map[string]bool, errorCollector *repor
 
 // AnalyzeFunction analyzes mutex usage in a function
 func (ma *Analyzer) AnalyzeFunction(fn *ast.FuncDecl) {
+	ma.function = fn
 	ma.initializeStats()
 	finalStats := ma.analyzeBlock(fn.Body, ma.stats)
 	ma.reportUnmatchedLocks(finalStats)
+}
+
+func buildReceiverMethodMap(files []*ast.File) map[string]map[string]*ast.FuncDecl {
+	methods := make(map[string]map[string]*ast.FuncDecl)
+
+	for _, file := range files {
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Body == nil || fn.Recv == nil {
+				continue
+			}
+
+			receiverType := receiverTypeName(fn)
+			if receiverType == "" {
+				continue
+			}
+
+			if methods[receiverType] == nil {
+				methods[receiverType] = make(map[string]*ast.FuncDecl)
+			}
+			methods[receiverType][fn.Name.Name] = fn
+		}
+	}
+
+	return methods
+}
+
+func collectFunctionDecls(files []*ast.File) []*ast.FuncDecl {
+	var functions []*ast.FuncDecl
+
+	for _, file := range files {
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Body == nil {
+				continue
+			}
+			functions = append(functions, fn)
+		}
+	}
+
+	return functions
+}
+
+func receiverName(fn *ast.FuncDecl) string {
+	if fn == nil || fn.Recv == nil || len(fn.Recv.List) == 0 {
+		return ""
+	}
+	if len(fn.Recv.List[0].Names) == 0 {
+		return ""
+	}
+	return fn.Recv.List[0].Names[0].Name
+}
+
+func receiverTypeName(fn *ast.FuncDecl) string {
+	if fn == nil || fn.Recv == nil || len(fn.Recv.List) == 0 {
+		return ""
+	}
+
+	return baseTypeName(fn.Recv.List[0].Type)
+}
+
+func baseTypeName(expr ast.Expr) string {
+	switch e := expr.(type) {
+	case *ast.Ident:
+		return e.Name
+	case *ast.StarExpr:
+		return baseTypeName(e.X)
+	case *ast.IndexExpr:
+		return baseTypeName(e.X)
+	case *ast.IndexListExpr:
+		return baseTypeName(e.X)
+	case *ast.SelectorExpr:
+		return e.Sel.Name
+	default:
+		return ""
+	}
+}
+
+func (ma *Analyzer) isBorrowedWrapperCall(varName, methodName string) bool {
+	if ma.function == nil || ma.function.Name == nil {
+		return false
+	}
+
+	currentReceiver := receiverName(ma.function)
+	if currentReceiver == "" {
+		return false
+	}
+
+	suffix, ok := strings.CutPrefix(varName, currentReceiver)
+	if !ok || !strings.HasPrefix(suffix, ".") {
+		return false
+	}
+
+	oppositeMethods := oppositeMutexMethods(methodName)
+	if len(oppositeMethods) == 0 || ma.currentMethodContainsFieldCall(varName, oppositeMethods) {
+		return false
+	}
+
+	switch ma.function.Name.Name {
+	case "Lock", "TryLock":
+		return (methodName == "Lock" || methodName == "TryLock") &&
+			ma.siblingMethodContainsFieldCall(suffix, []string{"Unlock"}, []string{"Unlock"})
+	case "Unlock":
+		return methodName == "Unlock" &&
+			ma.siblingMethodContainsFieldCall(suffix, []string{"Lock", "TryLock"}, []string{"Lock", "TryLock"})
+	case "RLock", "TryRLock":
+		return (methodName == "RLock" || methodName == "TryRLock") &&
+			ma.siblingMethodContainsFieldCall(suffix, []string{"RUnlock"}, []string{"RUnlock"})
+	case "RUnlock":
+		return methodName == "RUnlock" &&
+			ma.siblingMethodContainsFieldCall(suffix, []string{"RLock", "TryRLock"}, []string{"RLock", "TryRLock"})
+	default:
+		if !methodNameLooksLikeWrapper(ma.function.Name.Name, methodName) {
+			return false
+		}
+		return ma.anySiblingMethodContainsFieldCall(suffix, ma.function.Name.Name, oppositeMethods, oppositeMethods)
+	}
+}
+
+func (ma *Analyzer) currentMethodContainsFieldCall(varName string, methodNames []string) bool {
+	return functionBodyContainsFieldCall(ma.function.Body, varName, methodNames)
+}
+
+func (ma *Analyzer) siblingMethodContainsFieldCall(fieldSuffix string, siblingMethods, fieldMethods []string) bool {
+	receiverType := receiverTypeName(ma.function)
+	if receiverType == "" {
+		return false
+	}
+
+	methods := ma.receiverMethods[receiverType]
+	if len(methods) == 0 {
+		return false
+	}
+
+	for _, siblingMethod := range siblingMethods {
+		fn := methods[siblingMethod]
+		if fn == nil || fn.Body == nil {
+			continue
+		}
+
+		siblingReceiver := receiverName(fn)
+		if siblingReceiver == "" {
+			continue
+		}
+
+		targetVar := siblingReceiver + fieldSuffix
+		if functionBodyContainsFieldCall(fn.Body, targetVar, fieldMethods) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (ma *Analyzer) anySiblingMethodContainsFieldCall(fieldSuffix, excludeMethod string, fieldMethods, nameHints []string) bool {
+	receiverType := receiverTypeName(ma.function)
+	if receiverType == "" {
+		return false
+	}
+
+	methods := ma.receiverMethods[receiverType]
+	if len(methods) == 0 {
+		return false
+	}
+
+	for methodName, fn := range methods {
+		if methodName == excludeMethod || fn == nil || fn.Body == nil {
+			continue
+		}
+		if !methodNameMatchesAnyHint(methodName, nameHints) {
+			continue
+		}
+
+		siblingReceiver := receiverName(fn)
+		if siblingReceiver == "" {
+			continue
+		}
+
+		targetVar := siblingReceiver + fieldSuffix
+		if functionBodyContainsFieldCall(fn.Body, targetVar, fieldMethods) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func oppositeMutexMethods(methodName string) []string {
+	switch methodName {
+	case "Lock", "TryLock":
+		return []string{"Unlock"}
+	case "Unlock":
+		return []string{"Lock", "TryLock"}
+	case "RLock", "TryRLock":
+		return []string{"RUnlock"}
+	case "RUnlock":
+		return []string{"RLock", "TryRLock"}
+	default:
+		return nil
+	}
+}
+
+func methodNameLooksLikeWrapper(fnName, syncMethod string) bool {
+	return methodNameMatchesAnyHint(fnName, []string{syncMethod})
+}
+
+func methodNameMatchesAnyHint(fnName string, hints []string) bool {
+	lowerName := strings.ToLower(fnName)
+	for _, hint := range hints {
+		if hint == "" {
+			continue
+		}
+		if strings.Contains(lowerName, strings.ToLower(hint)) {
+			return true
+		}
+	}
+	return false
+}
+
+func functionBodyContainsFieldCall(body *ast.BlockStmt, varName string, methodNames []string) bool {
+	if body == nil {
+		return false
+	}
+
+	found := false
+	ast.Inspect(body, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+
+		if containsMethod(methodNames, sel.Sel.Name) && common.GetVarName(sel.X) == varName {
+			found = true
+			return false
+		}
+
+		return true
+	})
+
+	return found
+}
+
+func containsMethod(methodNames []string, methodName string) bool {
+	for _, candidate := range methodNames {
+		if candidate == methodName {
+			return true
+		}
+	}
+	return false
+}
+
+func splitBaseAndSuffix(varName string) (string, string, bool) {
+	parts := strings.Split(varName, ".")
+	if len(parts) < 2 {
+		return "", "", false
+	}
+	return parts[0], strings.Join(parts[1:], "."), true
+}
+
+func compositeLiteralFromExpr(expr ast.Expr) *ast.CompositeLit {
+	switch e := expr.(type) {
+	case *ast.CompositeLit:
+		return e
+	case *ast.UnaryExpr:
+		if e.Op == token.AND {
+			if lit, ok := e.X.(*ast.CompositeLit); ok {
+				return lit
+			}
+		}
+	}
+	return nil
+}
+
+func compositeLiteralTypeName(lit *ast.CompositeLit) string {
+	if lit == nil {
+		return ""
+	}
+	return baseTypeName(lit.Type)
+}
+
+func compositeLiteralFieldVarName(lit *ast.CompositeLit, fieldName string) string {
+	if lit == nil {
+		return ""
+	}
+
+	for _, elt := range lit.Elts {
+		kv, ok := elt.(*ast.KeyValueExpr)
+		if !ok {
+			continue
+		}
+
+		key, ok := kv.Key.(*ast.Ident)
+		if !ok || key.Name != fieldName {
+			continue
+		}
+
+		return common.GetVarName(kv.Value)
+	}
+
+	return ""
+}
+
+func (ma *Analyzer) returnedCompositeLiterals(fn *ast.FuncDecl) []*ast.CompositeLit {
+	if fn == nil || fn.Body == nil {
+		return nil
+	}
+
+	localValues := make(map[string]ast.Expr)
+	var returned []*ast.CompositeLit
+
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		switch node := n.(type) {
+		case *ast.AssignStmt:
+			for i, lhs := range node.Lhs {
+				ident, ok := lhs.(*ast.Ident)
+				if !ok || i >= len(node.Rhs) {
+					continue
+				}
+				localValues[ident.Name] = node.Rhs[i]
+			}
+		case *ast.ValueSpec:
+			for i, name := range node.Names {
+				if i >= len(node.Values) {
+					continue
+				}
+				localValues[name.Name] = node.Values[i]
+			}
+		case *ast.ReturnStmt:
+			for _, result := range node.Results {
+				if lit := compositeLiteralFromExpr(result); lit != nil {
+					returned = append(returned, lit)
+					continue
+				}
+
+				ident, ok := result.(*ast.Ident)
+				if !ok {
+					continue
+				}
+
+				if lit := compositeLiteralFromExpr(localValues[ident.Name]); lit != nil {
+					returned = append(returned, lit)
+				}
+			}
+		}
+		return true
+	})
+
+	return returned
+}
+
+func (ma *Analyzer) lifecycleReleaseMethodUnlocks(returnedType, fieldName, suffix string, methodNames []string) bool {
+	methods := ma.receiverMethods[returnedType]
+	if len(methods) == 0 {
+		return false
+	}
+
+	for methodName, fn := range methods {
+		if fn == nil || fn.Body == nil || !methodNameMatchesAnyHint(methodName, []string{"Close", "Unlock", "Release"}) {
+			continue
+		}
+
+		recv := receiverName(fn)
+		if recv == "" {
+			continue
+		}
+
+		targetVar := recv + "." + fieldName + "." + suffix
+		if functionBodyContainsFieldCall(fn.Body, targetVar, methodNames) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (ma *Analyzer) functionReturnsLifecycleHandleFor(mutexName string, methodNames []string) bool {
+	baseVar, suffix, ok := splitBaseAndSuffix(mutexName)
+	if !ok || ma.function == nil {
+		return false
+	}
+
+	for _, lit := range ma.returnedCompositeLiterals(ma.function) {
+		returnedType := compositeLiteralTypeName(lit)
+		if returnedType == "" {
+			continue
+		}
+
+		for _, elt := range lit.Elts {
+			kv, ok := elt.(*ast.KeyValueExpr)
+			if !ok {
+				continue
+			}
+
+			key, ok := kv.Key.(*ast.Ident)
+			if !ok {
+				continue
+			}
+
+			if common.GetVarName(kv.Value) != baseVar {
+				continue
+			}
+
+			if ma.lifecycleReleaseMethodUnlocks(returnedType, key.Name, suffix, methodNames) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func (ma *Analyzer) functionIsLifecycleReleaseFor(mutexName string, methodNames []string) bool {
+	if ma.function == nil || ma.function.Name == nil || !methodNameMatchesAnyHint(ma.function.Name.Name, []string{"Close", "Unlock", "Release"}) {
+		return false
+	}
+
+	currentReceiver := receiverName(ma.function)
+	currentType := receiverTypeName(ma.function)
+	if currentReceiver == "" || currentType == "" {
+		return false
+	}
+
+	prefix := currentReceiver + "."
+	if !strings.HasPrefix(mutexName, prefix) {
+		return false
+	}
+
+	path := strings.TrimPrefix(mutexName, prefix)
+	parts := strings.Split(path, ".")
+	if len(parts) < 2 {
+		return false
+	}
+
+	fieldName := parts[0]
+	suffix := strings.Join(parts[1:], ".")
+
+	for _, fn := range ma.functions {
+		if fn == nil || fn.Body == nil || fn == ma.function {
+			continue
+		}
+
+		for _, lit := range ma.returnedCompositeLiterals(fn) {
+			if compositeLiteralTypeName(lit) != currentType {
+				continue
+			}
+
+			sourceVar := compositeLiteralFieldVarName(lit, fieldName)
+			if sourceVar == "" || sourceVar == "?" {
+				continue
+			}
+
+			targetVar := sourceVar + "." + suffix
+			if functionBodyContainsFieldCall(fn.Body, targetVar, methodNames) {
+				return true
+			}
+		}
+	}
+
+	return false
 }
 
 // initializeStats initializes the stats map for all known mutexes

--- a/pkg/analyzer/mutex/stats.go
+++ b/pkg/analyzer/mutex/stats.go
@@ -89,6 +89,10 @@ func (ma *Analyzer) analyzeExpressionStatement(stmt *ast.ExprStmt, stats map[str
 
 // handleMutexCall processes mutex method calls
 func (ma *Analyzer) handleMutexCall(varName, methodName string, pos token.Pos, stats map[string]*Stats) {
+	if ma.isBorrowedWrapperCall(varName, methodName) {
+		return
+	}
+
 	switch methodName {
 	case "Lock", "TryLock":
 		if stats[varName].borrowedLock > 0 {
@@ -111,6 +115,10 @@ func (ma *Analyzer) handleMutexCall(varName, methodName string, pos token.Pos, s
 
 // handleRWMutexCall processes rwmutex method calls
 func (ma *Analyzer) handleRWMutexCall(varName, methodName string, pos token.Pos, stats map[string]*Stats) {
+	if ma.isBorrowedWrapperCall(varName, methodName) {
+		return
+	}
+
 	switch methodName {
 	case "Lock", "TryLock":
 		if stats[varName].borrowedLock > 0 {

--- a/pkg/analyzer/mutex/validation.go
+++ b/pkg/analyzer/mutex/validation.go
@@ -197,7 +197,98 @@ func (ma *Analyzer) analyzeForStatement(stmt *ast.ForStmt, stats map[string]*Sta
 	}
 
 	forStats := ma.analyzeBlock(stmt.Body, stats)
+	ma.applyLoopExitLocks(stmt, stats, forStats)
 	ma.replaceStats(stats, forStats)
+}
+
+func (ma *Analyzer) applyLoopExitLocks(stmt *ast.ForStmt, initial, final map[string]*Stats) {
+	for mutexName := range ma.mutexNames {
+		if pos, ok := ma.loopMayBreakHoldingMutex(stmt.Body.List, mutexName, []string{"Lock", "TryLock"}, []string{"Unlock"}, 0, token.NoPos); ok {
+			if final[mutexName].lock <= initial[mutexName].lock {
+				final[mutexName].lock++
+				final[mutexName].lockPos = append(final[mutexName].lockPos, pos)
+			}
+		}
+	}
+
+	for rwMutexName := range ma.rwMutexNames {
+		if pos, ok := ma.loopMayBreakHoldingMutex(stmt.Body.List, rwMutexName, []string{"Lock", "TryLock"}, []string{"Unlock"}, 0, token.NoPos); ok {
+			if final[rwMutexName].lock <= initial[rwMutexName].lock {
+				final[rwMutexName].lock++
+				final[rwMutexName].lockPos = append(final[rwMutexName].lockPos, pos)
+			}
+		}
+		if pos, ok := ma.loopMayBreakHoldingMutex(stmt.Body.List, rwMutexName, []string{"RLock", "TryRLock"}, []string{"RUnlock"}, 0, token.NoPos); ok {
+			if final[rwMutexName].rlock <= initial[rwMutexName].rlock {
+				final[rwMutexName].rlock++
+				final[rwMutexName].rlockPos = append(final[rwMutexName].rlockPos, pos)
+			}
+		}
+	}
+}
+
+func (ma *Analyzer) loopMayBreakHoldingMutex(stmts []ast.Stmt, varName string, lockMethods, unlockMethods []string, depth int, lastLockPos token.Pos) (token.Pos, bool) {
+	currentDepth := depth
+	currentLockPos := lastLockPos
+
+	for _, stmt := range stmts {
+		if ma.commentFilter.ShouldSkipStatement(stmt) {
+			continue
+		}
+
+		switch s := stmt.(type) {
+		case *ast.ExprStmt:
+			call, ok := s.X.(*ast.CallExpr)
+			if !ok || ma.commentFilter.ShouldSkipCall(call) {
+				continue
+			}
+
+			sel, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok || common.GetVarName(sel.X) != varName {
+				continue
+			}
+
+			if containsMethod(lockMethods, sel.Sel.Name) {
+				currentDepth++
+				currentLockPos = call.Pos()
+				continue
+			}
+
+			if containsMethod(unlockMethods, sel.Sel.Name) && currentDepth > 0 {
+				currentDepth--
+			}
+		case *ast.IfStmt:
+			if pos, ok := ma.loopMayBreakHoldingMutex(s.Body.List, varName, lockMethods, unlockMethods, currentDepth, currentLockPos); ok {
+				return pos, true
+			}
+			if s.Else != nil {
+				switch elseNode := s.Else.(type) {
+				case *ast.BlockStmt:
+					if pos, ok := ma.loopMayBreakHoldingMutex(elseNode.List, varName, lockMethods, unlockMethods, currentDepth, currentLockPos); ok {
+						return pos, true
+					}
+				case *ast.IfStmt:
+					if pos, ok := ma.loopMayBreakHoldingMutex([]ast.Stmt{elseNode}, varName, lockMethods, unlockMethods, currentDepth, currentLockPos); ok {
+						return pos, true
+					}
+				}
+			}
+		case *ast.BlockStmt:
+			if pos, ok := ma.loopMayBreakHoldingMutex(s.List, varName, lockMethods, unlockMethods, currentDepth, currentLockPos); ok {
+				return pos, true
+			}
+		case *ast.LabeledStmt:
+			if pos, ok := ma.loopMayBreakHoldingMutex([]ast.Stmt{s.Stmt}, varName, lockMethods, unlockMethods, currentDepth, currentLockPos); ok {
+				return pos, true
+			}
+		case *ast.BranchStmt:
+			if s.Tok == token.BREAK && currentDepth > 0 {
+				return currentLockPos, true
+			}
+		}
+	}
+
+	return token.NoPos, false
 }
 
 // reportUnmatchedLocksInBranch reports unmatched locks in conditional branches
@@ -297,19 +388,35 @@ func (ma *Analyzer) reportUnmatchedMutexLocksWithContext(mutexName string, stats
 		rlockMessage = "rwmutex '" + mutexName + "' is rlocked but not runlocked in " + branchType
 	}
 
+	suppressFunctionLevelLock := branchType == "" && ma.functionReturnsLifecycleHandleFor(mutexName, []string{"Unlock"})
 	for _, pos := range ma.trailingPositions(stats.lockPos, ma.remainingLockCount(stats.lock, stats.deferUnlock)) {
+		if suppressFunctionLevelLock {
+			continue
+		}
 		ma.errorCollector.AddError(pos, lockMessage)
 	}
 
+	suppressFunctionLevelUnlock := branchType == "" && ma.functionIsLifecycleReleaseFor(mutexName, []string{"Lock", "TryLock"})
 	for _, pos := range stats.borrowedUnlockPos {
+		if suppressFunctionLevelUnlock {
+			continue
+		}
 		ma.errorCollector.AddError(pos, mutexType+" '"+mutexName+"' is unlocked but not locked")
 	}
 
 	if isRWMutex {
+		suppressFunctionLevelRLock := branchType == "" && ma.functionReturnsLifecycleHandleFor(mutexName, []string{"RUnlock"})
 		for _, pos := range ma.trailingPositions(stats.rlockPos, ma.remainingLockCount(stats.rlock, stats.deferRUnlock)) {
+			if suppressFunctionLevelRLock {
+				continue
+			}
 			ma.errorCollector.AddError(pos, rlockMessage)
 		}
+		suppressFunctionLevelRUnlock := branchType == "" && ma.functionIsLifecycleReleaseFor(mutexName, []string{"RLock", "TryRLock"})
 		for _, pos := range stats.borrowedRUnlockPos {
+			if suppressFunctionLevelRUnlock {
+				continue
+			}
 			ma.errorCollector.AddError(pos, "rwmutex '"+mutexName+"' is runlocked but not rlocked")
 		}
 	}

--- a/pkg/analyzer/testdata/src/mutex/mutex_extended_cases.go
+++ b/pkg/analyzer/testdata/src/mutex/mutex_extended_cases.go
@@ -305,6 +305,35 @@ type SafeMap struct {
 	data map[string]string
 }
 
+type InstrumentedMutex struct {
+	realLock    sync.Mutex
+	waitersLock sync.Mutex
+}
+
+type BrokenInstrumentedMutex struct {
+	realLock sync.Mutex
+}
+
+type BrokenUnlockInstrumentedMutex struct {
+	realLock sync.Mutex
+}
+
+type NamedWrapperMutex struct {
+	mu sync.RWMutex
+}
+
+type LoopExitLocker struct {
+	mu sync.Mutex
+}
+
+type iteratorLifecycleStore struct {
+	mu sync.Mutex
+}
+
+type iteratorLifecycleToken struct {
+	owner *iteratorLifecycleStore
+}
+
 // Good: struct field mutex properly locked and unlocked
 func GoodStructFieldMutex() {
 	var sm SafeMap
@@ -347,6 +376,76 @@ func (sm *SafeMap) GoodMethodMutex() {
 // Bad: method receiver with struct field mutex, locked but not unlocked
 func (sm *SafeMap) BadMethodMutex() {
 	sm.mu.Lock() // want "mutex 'sm.mu' is locked but not unlocked"
+}
+
+// Good: wrapper-style mutex methods can lock in Lock() and unlock in Unlock().
+func (im *InstrumentedMutex) Lock() {
+	im.waitersLock.Lock()
+	im.waitersLock.Unlock()
+	im.realLock.Lock()
+}
+
+func (im *InstrumentedMutex) Unlock() {
+	im.waitersLock.Lock()
+	im.waitersLock.Unlock()
+	im.realLock.Unlock()
+}
+
+// Bad: wrapper-style Lock() that acquires an underlying mutex with no sibling release.
+func (im *BrokenInstrumentedMutex) Lock() {
+	im.realLock.Lock() // want "mutex 'im.realLock' is locked but not unlocked"
+}
+
+func (im *BrokenInstrumentedMutex) Unlock() {}
+
+// Bad: wrapper-style Unlock() that releases an underlying mutex with no sibling acquire.
+func (im *BrokenUnlockInstrumentedMutex) Lock() {}
+
+func (im *BrokenUnlockInstrumentedMutex) Unlock() {
+	im.realLock.Unlock() // want "mutex 'im.realLock' is unlocked but not locked"
+}
+
+// Good: wrapper methods do not need to be literally named Lock/Unlock.
+func (nwm *NamedWrapperMutex) wLock() {
+	nwm.mu.Lock()
+}
+
+func (nwm *NamedWrapperMutex) wUnlock() {
+	nwm.mu.Unlock()
+}
+
+func (nwm *NamedWrapperMutex) rLock() {
+	nwm.mu.RLock()
+}
+
+func (nwm *NamedWrapperMutex) rUnlock() {
+	nwm.mu.RUnlock()
+}
+
+// Good: a loop can intentionally break while still holding the lock and release it afterwards.
+func (l *LoopExitLocker) GoodLoopBreakWithUnlockAfterLoop(stop bool) {
+	for {
+		l.mu.Lock()
+		if stop {
+			break
+		}
+		l.mu.Unlock()
+		stop = true
+	}
+	l.mu.Unlock()
+}
+
+// Good: a creator can return a token that owns the eventual unlock in Close.
+func (s *iteratorLifecycleStore) GoodIteratorReturnsLockedHandle() *iteratorLifecycleToken {
+	s.mu.Lock()
+	token := &iteratorLifecycleToken{
+		owner: s,
+	}
+	return token
+}
+
+func (t *iteratorLifecycleToken) Close() {
+	t.owner.mu.Unlock()
 }
 
 // ========== COMMENT FILTERING TESTS ==========

--- a/pkg/analyzer/testdata/src/packagelevel/usage.go
+++ b/pkg/analyzer/testdata/src/packagelevel/usage.go
@@ -1,10 +1,30 @@
 package packagelevel
 
+import "sync"
+
 func BadPackageLevelMutex() {
 	packageMu.Lock() // want "mutex 'packageMu' is locked but not unlocked"
 }
 
 func BadPackageLevelWaitGroup() {
 	packageWG.Add(1) // want "waitgroup 'packageWG' has Add without corresponding Done"
+	packageWG.Wait()
+}
+
+func GoodPackageLevelWaitGroupDoneInHelper() {
+	packageWG.Add(1)
+	go packageLevelWorker()
+	packageWG.Wait()
+}
+
+func packageLevelWorker() {
+	defer packageWG.Done()
+}
+
+func BadShadowedPackageLevelWaitGroup() {
+	var packageWG sync.WaitGroup
+
+	packageWG.Add(1) // want "waitgroup 'packageWG' has Add without corresponding Done"
+	go packageLevelWorker()
 	packageWG.Wait()
 }

--- a/pkg/analyzer/testdata/src/waitgroup/waitgroup_callbacks_cases.go
+++ b/pkg/analyzer/testdata/src/waitgroup/waitgroup_callbacks_cases.go
@@ -174,3 +174,78 @@ func GoodWaitGroupWaitOnlyGoroutine() {
 
 	<-done
 }
+
+type externalCallbackRegistrar interface {
+	Register(func())
+}
+
+type externalActivityRegistrar interface {
+	RegisterActivity(func() error)
+}
+
+type externalTaskSubmitter interface {
+	Submit(taskCarrier)
+}
+
+type taskCarrier struct {
+	*sync.WaitGroup
+}
+
+func (t taskCarrier) Ack() {
+	t.Done()
+}
+
+// A callback literal passed to an external registrar still means the WaitGroup lifecycle escaped.
+func GoodEscapingWaitGroupDoneCallback(reg externalCallbackRegistrar) {
+	var wg sync.WaitGroup
+	wg.Add(1)
+	reg.Register(func() {
+		wg.Done()
+	})
+	wg.Wait()
+}
+
+// A callback variable registered externally can own the WaitGroup Done lifecycle.
+func GoodEscapingWaitGroupDoneFuncVariable(reg externalActivityRegistrar) {
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	activity := func() error {
+		defer wg.Done()
+		return nil
+	}
+
+	reg.RegisterActivity(activity)
+	reg.RegisterActivity(activity)
+	wg.Wait()
+}
+
+// A task object carrying a WaitGroup can escape to another component that will Ack it later.
+func GoodEscapingWaitGroupInsideTaskObject(submitter externalTaskSubmitter) {
+	var wg sync.WaitGroup
+	wg.Add(1)
+	submitter.Submit(taskCarrier{WaitGroup: &wg})
+	wg.Wait()
+}
+
+// Branch-exclusive Done paths should not be counted as multiple excess Done calls.
+func GoodBranchExclusiveDonePaths(startWorker, enqueue bool) {
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	if !startWorker {
+		wg.Done()
+		return
+	}
+
+	if enqueue {
+		wg.Done()
+		return
+	}
+
+	go func() {
+		defer wg.Done()
+	}()
+
+	wg.Wait()
+}

--- a/pkg/analyzer/testdata/src/waitgroup/waitgroup_extended_cases.go
+++ b/pkg/analyzer/testdata/src/waitgroup/waitgroup_extended_cases.go
@@ -319,6 +319,14 @@ type WorkerPool struct {
 	wg sync.WaitGroup
 }
 
+type EmbeddedWorkerPool struct {
+	sync.WaitGroup
+}
+
+type HandlerLike struct {
+	startWG sync.WaitGroup
+}
+
 // Good: struct field waitgroup with proper Add and Done
 func GoodStructFieldWaitGroup() {
 	var wp WorkerPool
@@ -349,6 +357,58 @@ func (wp *WorkerPool) GoodMethodWaitGroup() {
 func (wp *WorkerPool) BadMethodWaitGroup() {
 	wp.wg.Add(1) // want "waitgroup 'wp.wg' has Add without corresponding Done"
 	wp.wg.Wait()
+}
+
+// Good: barrier-style waitgroup where goroutines wait and the main loop releases them with Done.
+func GoodBarrierWaitGroupMainLoopDone() {
+	const workers = 4
+
+	var startWG sync.WaitGroup
+	var endWG sync.WaitGroup
+
+	startWG.Add(workers)
+	endWG.Add(workers)
+
+	go func() {
+		startWG.Wait()
+	}()
+
+	for range workers {
+		go func() {
+			defer endWG.Done()
+			startWG.Wait()
+		}()
+		startWG.Done()
+	}
+
+	endWG.Wait()
+}
+
+// Good: embedded waitgroup field managed across sibling methods.
+func (wp *EmbeddedWorkerPool) GoodEmbeddedFieldSiblingMethod() {
+	wp.WaitGroup.Add(1)
+	go wp.run()
+	wp.WaitGroup.Wait()
+}
+
+func (wp *EmbeddedWorkerPool) run() {
+	defer wp.WaitGroup.Done()
+}
+
+// Good: constructor-style setup can Add in one function and Done in a lifecycle method.
+func GoodConstructorLifecycleWaitGroup() {
+	handler := NewHandlerLike()
+	handler.Start()
+}
+
+func NewHandlerLike() *HandlerLike {
+	handler := &HandlerLike{}
+	handler.startWG.Add(1)
+	return handler
+}
+
+func (h *HandlerLike) Start() {
+	h.startWG.Done()
 }
 
 // Good: a WaitGroup field whose lifecycle is balanced through returned closers.

--- a/pkg/analyzer/waitgroup/analyzer.go
+++ b/pkg/analyzer/waitgroup/analyzer.go
@@ -14,12 +14,14 @@ import (
 
 // Analyzer handles the analysis of WaitGroup usage
 type Analyzer struct {
-	waitGroupNames map[string]bool
-	errorCollector *report.ErrorCollector
-	function       *ast.FuncDecl
-	commentFilter  *commnetfilter.CommentFilter
-	typesInfo      *types.Info
-	functionDecls  map[token.Pos]*ast.FuncDecl
+	waitGroupNames             map[string]bool
+	localWaitGroupNames        map[string]bool
+	packageLevelWaitGroupNames map[string]bool
+	errorCollector             *report.ErrorCollector
+	function                   *ast.FuncDecl
+	commentFilter              *commnetfilter.CommentFilter
+	typesInfo                  *types.Info
+	functionDecls              map[token.Pos]*ast.FuncDecl
 }
 
 // addCall represents an Add() call with its position and value
@@ -40,13 +42,15 @@ type Stats struct {
 }
 
 // NewAnalyzer creates a new WaitGroup analyzer
-func NewAnalyzer(waitGroupNames map[string]bool, errorCollector *report.ErrorCollector, cf *commnetfilter.CommentFilter, pass *analysis.Pass) *Analyzer {
+func NewAnalyzer(waitGroupNames, localWaitGroupNames, packageLevelWaitGroupNames map[string]bool, errorCollector *report.ErrorCollector, cf *commnetfilter.CommentFilter, pass *analysis.Pass) *Analyzer {
 	return &Analyzer{
-		waitGroupNames: waitGroupNames,
-		errorCollector: errorCollector,
-		commentFilter:  cf,
-		typesInfo:      pass.TypesInfo,
-		functionDecls:  buildFunctionDeclMap(pass.Files),
+		waitGroupNames:             waitGroupNames,
+		localWaitGroupNames:        localWaitGroupNames,
+		packageLevelWaitGroupNames: packageLevelWaitGroupNames,
+		errorCollector:             errorCollector,
+		commentFilter:              cf,
+		typesInfo:                  pass.TypesInfo,
+		functionDecls:              buildFunctionDeclMap(pass.Files),
 	}
 }
 
@@ -251,8 +255,17 @@ func (wga *Analyzer) exprEscapesWaitGroup(expr ast.Expr, wgName string, callback
 		return true
 	}
 
+	if fnLit, ok := expr.(*ast.FuncLit); ok {
+		return wga.functionLiteralEscapesWaitGroup(fnLit, wgName, callbacks, seen)
+	}
+
 	found := false
 	ast.Inspect(expr, func(n ast.Node) bool {
+		if exprNode, ok := n.(ast.Expr); ok && wga.isWaitGroupArgument(exprNode, wgName) {
+			found = true
+			return false
+		}
+
 		if call, ok := n.(*ast.CallExpr); ok {
 			if fn, calleeWGName, related := wga.relatedWaitGroupForCall(call, wgName); related &&
 				fn != nil && wga.functionCouldManageWaitGroup(fn, calleeWGName, make(map[token.Pos]bool)) {
@@ -268,7 +281,7 @@ func (wga *Analyzer) exprEscapesWaitGroup(expr ast.Expr, wgName string, callback
 				return false
 			}
 		case *ast.FuncLit:
-			if wga.containsDoneCall(node.Body, wgName) {
+			if wga.functionLiteralEscapesWaitGroup(node, wgName, callbacks, seen) {
 				found = true
 				return false
 			}
@@ -291,6 +304,41 @@ func (wga *Analyzer) exprEscapesWaitGroup(expr ast.Expr, wgName string, callback
 		}
 		return !found
 	})
+	return found
+}
+
+func (wga *Analyzer) functionLiteralEscapesWaitGroup(fn *ast.FuncLit, wgName string, callbacks map[string]ast.Expr, seen map[string]bool) bool {
+	if fn == nil || fn.Body == nil {
+		return false
+	}
+
+	if wga.analyzeDoneCallsWithVisited(fn.Body, wgName, make(map[token.Pos]bool)).hasAnyDone {
+		return true
+	}
+
+	found := false
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		if found {
+			return false
+		}
+
+		if exprNode, ok := n.(ast.Expr); ok && wga.isWaitGroupArgument(exprNode, wgName) {
+			found = true
+			return false
+		}
+
+		if ident, ok := n.(*ast.Ident); ok {
+			if callbackExpr, ok := callbacks[ident.Name]; ok && !seen[ident.Name] {
+				seen[ident.Name] = true
+				found = wga.exprEscapesWaitGroup(callbackExpr, wgName, callbacks, seen)
+				delete(seen, ident.Name)
+				return !found
+			}
+		}
+
+		return true
+	})
+
 	return found
 }
 
@@ -367,6 +415,30 @@ func receiverName(fn *ast.FuncDecl) string {
 	return fn.Recv.List[0].Names[0].Name
 }
 
+func (wga *Analyzer) currentFunctionShadowsPackageLevelWaitGroup(wgName string) bool {
+	if wga.localWaitGroupNames[wgName] {
+		return true
+	}
+
+	if wga.function == nil || wga.function.Type == nil || wga.function.Type.Params == nil {
+		return false
+	}
+
+	for _, field := range wga.function.Type.Params.List {
+		typ := wga.typesInfo.TypeOf(field.Type)
+		if !common.IsWaitGroup(typ) {
+			continue
+		}
+		for _, name := range field.Names {
+			if name.Name == wgName {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
 func (wga *Analyzer) relatedWaitGroupForCall(call *ast.CallExpr, wgName string) (*ast.FuncDecl, string, bool) {
 	fn := wga.resolveCalledFunction(call)
 	if fn == nil || fn.Body == nil {
@@ -387,6 +459,11 @@ func (wga *Analyzer) relatedWaitGroupForCall(call *ast.CallExpr, wgName string) 
 	}
 
 	if fn.Type == nil || fn.Type.Params == nil {
+		if wga.packageLevelWaitGroupNames[wgName] &&
+			!wga.currentFunctionShadowsPackageLevelWaitGroup(wgName) &&
+			wga.functionCouldManageWaitGroup(fn, wgName, make(map[token.Pos]bool)) {
+			return fn, wgName, true
+		}
 		return nil, "", false
 	}
 
@@ -407,6 +484,12 @@ func (wga *Analyzer) relatedWaitGroupForCall(call *ast.CallExpr, wgName string) 
 			}
 			return nil, "", false
 		}
+	}
+
+	if wga.packageLevelWaitGroupNames[wgName] &&
+		!wga.currentFunctionShadowsPackageLevelWaitGroup(wgName) &&
+		wga.functionCouldManageWaitGroup(fn, wgName, make(map[token.Pos]bool)) {
+		return fn, wgName, true
 	}
 
 	return nil, "", false

--- a/pkg/analyzer/waitgroup/validation.go
+++ b/pkg/analyzer/waitgroup/validation.go
@@ -65,7 +65,7 @@ func (wga *Analyzer) checkWaitGroupBalance(stats map[string]*Stats) {
 			continue
 		}
 		if wga.isWaitGroupPassedToOtherFunctions(wgName) {
-			if st.doneCount == 0 && len(st.deferDoneCalls) == 0 && len(st.addCalls) > 0 {
+			if len(st.addCalls) > 0 {
 				continue
 			}
 		}
@@ -305,31 +305,32 @@ func (wga *Analyzer) reportUnmatchedAdds(wgName string, stats *Stats, totalExpec
 }
 
 // reportExcessDones reports Done calls that don't have corresponding Add calls
-func (wga *Analyzer) reportExcessDones(wgName string, stats *Stats, totalExpectedDone int, mainFlowDoneCount int) {
+func (wga *Analyzer) reportExcessDones(wgName string, stats *Stats, totalExpectedDone int, _ int) {
 	if totalExpectedDone <= stats.totalAdd {
 		return
 	}
 
 	// Only report excess for main flow Done calls (not goroutine Done calls)
-	if mainFlowDoneCount > stats.totalAdd {
-		// Sort done calls to report the last ones (most likely to be excess)
-		var mainFlowDoneCalls []token.Pos
-		for _, donePos := range stats.doneCalls {
-			if !wga.isInGoroutine(donePos) {
-				mainFlowDoneCalls = append(mainFlowDoneCalls, donePos)
-			}
+	var mainFlowDoneCalls []token.Pos
+	for _, donePos := range stats.doneCalls {
+		if !wga.isInGoroutine(donePos) && !wga.isInBranchingControlFlow(donePos) {
+			mainFlowDoneCalls = append(mainFlowDoneCalls, donePos)
 		}
+	}
 
-		sort.Slice(mainFlowDoneCalls, func(i, j int) bool {
-			return mainFlowDoneCalls[i] < mainFlowDoneCalls[j]
-		})
+	if len(mainFlowDoneCalls) <= stats.totalAdd {
+		return
+	}
 
-		excessCount := mainFlowDoneCount - stats.totalAdd
-		startIndex := len(mainFlowDoneCalls) - excessCount
+	sort.Slice(mainFlowDoneCalls, func(i, j int) bool {
+		return mainFlowDoneCalls[i] < mainFlowDoneCalls[j]
+	})
 
-		for i := startIndex; i < len(mainFlowDoneCalls) && i >= 0; i++ {
-			wga.errorCollector.AddError(mainFlowDoneCalls[i], "waitgroup '"+wgName+"' has Done without corresponding Add")
-		}
+	excessCount := len(mainFlowDoneCalls) - stats.totalAdd
+	startIndex := len(mainFlowDoneCalls) - excessCount
+
+	for i := startIndex; i < len(mainFlowDoneCalls) && i >= 0; i++ {
+		wga.errorCollector.AddError(mainFlowDoneCalls[i], "waitgroup '"+wgName+"' has Done without corresponding Add")
 	}
 }
 
@@ -580,6 +581,50 @@ func (wga *Analyzer) isInConditional(target ast.Node, scope ast.Node) bool {
 	})
 
 	return inConditional
+}
+
+func (wga *Analyzer) isInBranchingControlFlow(pos token.Pos) bool {
+	inBranch := false
+
+	ast.Inspect(wga.function.Body, func(n ast.Node) bool {
+		if inBranch || n == nil {
+			return false
+		}
+
+		switch node := n.(type) {
+		case *ast.IfStmt:
+			if nodeContainsPos(node.Body, pos) || nodeContainsPos(node.Else, pos) {
+				inBranch = true
+				return false
+			}
+		case *ast.SwitchStmt:
+			if nodeContainsPos(node.Body, pos) {
+				inBranch = true
+				return false
+			}
+		case *ast.TypeSwitchStmt:
+			if nodeContainsPos(node.Body, pos) {
+				inBranch = true
+				return false
+			}
+		case *ast.SelectStmt:
+			if nodeContainsPos(node.Body, pos) {
+				inBranch = true
+				return false
+			}
+		}
+
+		return true
+	})
+
+	return inBranch
+}
+
+func nodeContainsPos(n ast.Node, pos token.Pos) bool {
+	if n == nil {
+		return false
+	}
+	return n.Pos() <= pos && pos <= n.End()
 }
 
 // checkUnreachableDone checks for Done calls that are unreachable due to early returns


### PR DESCRIPTION
- mutex: detect wrapper methods (Lock/Unlock split across sibling methods on the same receiver) to avoid flagging intentional lifecycle APIs as unmatched locks

- mutex: track locks retained on loop exit via break statements

- waitgroup: skip Done calls inside branching control flow when reporting excess Dones to avoid false positives in conditional paths

- waitgroup: relax balance check when the WaitGroup is passed to other functions