### PR TITLE
feat(mutex): propagate lock state through method calls and detect cal…

### DIFF
--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -1,10 +1,10 @@
 package analyzer
 
 import (
-	"maps"
 	"go/ast"
 	"go/token"
 	"go/types"
+	"maps"
 
 	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/common"
 	commnetfilter "github.com/sanbricio/goconcurrencylint/pkg/analyzer/common/commentfilter"
@@ -246,7 +246,7 @@ func hasWaitGroups(primitives *syncPrimitive) bool {
 
 // analyzeMutexUsage handles mutex and rwmutex analysis
 func analyzeMutexUsage(fn *ast.FuncDecl, primitives *syncPrimitive, errorCollector *report.ErrorCollector, cf *commnetfilter.CommentFilter, pass *analysis.Pass) {
-	analyzer := mutex.NewAnalyzer(primitives.mutexes, primitives.rwMutexes, errorCollector, cf, pass.Files)
+	analyzer := mutex.NewAnalyzer(primitives.mutexes, primitives.rwMutexes, errorCollector, cf, pass.TypesInfo, pass.Files)
 	analyzer.AnalyzeFunction(fn)
 }
 

--- a/pkg/analyzer/common/common.go
+++ b/pkg/analyzer/common/common.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"go/ast"
+	"go/constant"
 	"go/token"
 	"go/types"
 	"strconv"
@@ -69,4 +70,19 @@ func GetAddValue(call *ast.CallExpr) int {
 	}
 	// If the argument is not a literal integer, default to 1.
 	return 1
+}
+
+// ConstantBoolValue returns the constant boolean value of expr when one is
+// available in the type information.
+func ConstantBoolValue(expr ast.Expr, info *types.Info) (bool, bool) {
+	if expr == nil || info == nil {
+		return false, false
+	}
+
+	tv, ok := info.Types[expr]
+	if !ok || tv.Value == nil || tv.Value.Kind() != constant.Bool {
+		return false, false
+	}
+
+	return constant.BoolVal(tv.Value), true
 }

--- a/pkg/analyzer/common/common_test.go
+++ b/pkg/analyzer/common/common_test.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"go/ast"
+	"go/constant"
 	"go/token"
 	"go/types"
 	"testing"
@@ -85,11 +86,49 @@ func TestGetAddValue(t *testing.T) {
 	}
 	assert.Equal(t, 1, GetAddValue(callWrongLit))
 
-
 	callBadLit := &ast.CallExpr{
 		Args: []ast.Expr{&ast.BasicLit{Kind: token.INT, Value: "xxx"}},
 	}
 	assert.Equal(t, 1, GetAddValue(callBadLit))
+}
+
+func TestConstantBoolValue(t *testing.T) {
+	trueExpr := &ast.Ident{Name: "always"}
+	falseExpr := &ast.Ident{Name: "never"}
+	unknownExpr := &ast.Ident{Name: "maybe"}
+
+	info := &types.Info{
+		Types: map[ast.Expr]types.TypeAndValue{
+			trueExpr: {
+				Type:  types.Typ[types.Bool],
+				Value: constant.MakeBool(true),
+			},
+			falseExpr: {
+				Type:  types.Typ[types.Bool],
+				Value: constant.MakeBool(false),
+			},
+			unknownExpr: {
+				Type: types.Typ[types.Bool],
+			},
+		},
+	}
+
+	value, ok := ConstantBoolValue(trueExpr, info)
+	assert.True(t, ok)
+	assert.True(t, value)
+
+	value, ok = ConstantBoolValue(falseExpr, info)
+	assert.True(t, ok)
+	assert.False(t, value)
+
+	_, ok = ConstantBoolValue(unknownExpr, info)
+	assert.False(t, ok)
+
+	_, ok = ConstantBoolValue(nil, info)
+	assert.False(t, ok)
+
+	_, ok = ConstantBoolValue(trueExpr, nil)
+	assert.False(t, ok)
 }
 
 func makeNamedType(pkgPath, name string, isPtr bool) types.Type {

--- a/pkg/analyzer/common/report/report.go
+++ b/pkg/analyzer/common/report/report.go
@@ -16,13 +16,23 @@ type ErrorReport struct {
 // ErrorCollector collects all errors and allows sorting them by position
 type ErrorCollector struct {
 	errors []ErrorReport
+	seen   map[ErrorReport]struct{}
 }
 
 func (ec *ErrorCollector) AddError(pos token.Pos, message string) {
-	ec.errors = append(ec.errors, ErrorReport{
+	report := ErrorReport{
 		Pos:     pos,
 		Message: message,
-	})
+	}
+
+	if ec.seen == nil {
+		ec.seen = make(map[ErrorReport]struct{})
+	}
+	if _, exists := ec.seen[report]; exists {
+		return
+	}
+	ec.seen[report] = struct{}{}
+	ec.errors = append(ec.errors, report)
 }
 
 func (ec *ErrorCollector) ReportAll(pass *analysis.Pass) {

--- a/pkg/analyzer/mutex/analyzer.go
+++ b/pkg/analyzer/mutex/analyzer.go
@@ -3,6 +3,7 @@ package mutex
 import (
 	"go/ast"
 	"go/token"
+	"go/types"
 	"strings"
 
 	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/common"
@@ -19,6 +20,8 @@ type Analyzer struct {
 	deferErrors     *deferErrorCollector
 	commentFilter   *commnetfilter.CommentFilter
 	function        *ast.FuncDecl
+	typesInfo       *types.Info
+	rawBodyEffects  bool
 	receiverMethods map[string]map[string]*ast.FuncDecl
 	functions       []*ast.FuncDecl
 }
@@ -40,12 +43,13 @@ type deferErrorCollector struct {
 }
 
 // NewAnalyzer creates a new mutex analyzer
-func NewAnalyzer(mutexNames, rwMutexNames map[string]bool, errorCollector *report.ErrorCollector, cf *commnetfilter.CommentFilter, files []*ast.File) *Analyzer {
+func NewAnalyzer(mutexNames, rwMutexNames map[string]bool, errorCollector *report.ErrorCollector, cf *commnetfilter.CommentFilter, typesInfo *types.Info, files []*ast.File) *Analyzer {
 	return &Analyzer{
 		mutexNames:      mutexNames,
 		rwMutexNames:    rwMutexNames,
 		errorCollector:  errorCollector,
 		commentFilter:   cf,
+		typesInfo:       typesInfo,
 		receiverMethods: buildReceiverMethodMap(files),
 		functions:       collectFunctionDecls(files),
 		deferErrors: &deferErrorCollector{
@@ -139,7 +143,28 @@ func baseTypeName(expr ast.Expr) string {
 	}
 }
 
+func baseTypeNameFromType(typ types.Type) string {
+	if typ == nil {
+		return ""
+	}
+
+	switch t := types.Unalias(typ).(type) {
+	case *types.Pointer:
+		return baseTypeNameFromType(t.Elem())
+	case *types.Named:
+		if obj := t.Obj(); obj != nil {
+			return obj.Name()
+		}
+	}
+
+	return ""
+}
+
 func (ma *Analyzer) isBorrowedWrapperCall(varName, methodName string) bool {
+	if ma.rawBodyEffects {
+		return false
+	}
+
 	if ma.function == nil || ma.function.Name == nil {
 		return false
 	}
@@ -315,6 +340,42 @@ func containsMethod(methodNames []string, methodName string) bool {
 		}
 	}
 	return false
+}
+
+func relativeMutexPath(varName, prefix string) (string, bool) {
+	relative, ok := strings.CutPrefix(varName, prefix+".")
+	if !ok || relative == "" {
+		return "", false
+	}
+	return relative, true
+}
+
+func functionBodyContainsFieldCallBefore(body *ast.BlockStmt, varName string, methodNames []string, before token.Pos) bool {
+	if body == nil {
+		return false
+	}
+
+	found := false
+	ast.Inspect(body, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok || call.Pos() >= before {
+			return true
+		}
+
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+
+		if containsMethod(methodNames, sel.Sel.Name) && common.GetVarName(sel.X) == varName {
+			found = true
+			return false
+		}
+
+		return true
+	})
+
+	return found
 }
 
 func splitBaseAndSuffix(varName string) (string, string, bool) {
@@ -525,6 +586,285 @@ func (ma *Analyzer) functionIsLifecycleReleaseFor(mutexName string, methodNames 
 	}
 
 	return false
+}
+
+func (ma *Analyzer) callTargetsCurrentMethod(call *ast.CallExpr, receiverType string) (string, bool) {
+	if ma.function == nil || ma.function.Name == nil {
+		return "", false
+	}
+
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok || sel.Sel.Name != ma.function.Name.Name {
+		return "", false
+	}
+
+	if baseTypeNameFromType(ma.typesInfo.TypeOf(sel.X)) != receiverType {
+		return "", false
+	}
+
+	baseVar := common.GetVarName(sel.X)
+	if baseVar == "?" {
+		return "", false
+	}
+
+	return baseVar, true
+}
+
+func (ma *Analyzer) explicitTransferCallPositions(body *ast.BlockStmt) map[token.Pos]struct{} {
+	positions := make(map[token.Pos]struct{})
+	if body == nil {
+		return positions
+	}
+
+	var visitStmt func(ast.Stmt)
+	var visitStmtList func([]ast.Stmt)
+	var visitElse func(ast.Stmt)
+
+	recordCall := func(call *ast.CallExpr) {
+		if call != nil {
+			positions[call.Pos()] = struct{}{}
+		}
+	}
+
+	visitStmtList = func(stmts []ast.Stmt) {
+		for _, stmt := range stmts {
+			visitStmt(stmt)
+		}
+	}
+
+	visitElse = func(stmt ast.Stmt) {
+		switch e := stmt.(type) {
+		case *ast.BlockStmt:
+			visitStmtList(e.List)
+		case *ast.IfStmt:
+			visitStmt(e)
+		}
+	}
+
+	visitStmt = func(stmt ast.Stmt) {
+		switch s := stmt.(type) {
+		case *ast.BlockStmt:
+			visitStmtList(s.List)
+		case *ast.LabeledStmt:
+			visitStmt(s.Stmt)
+		case *ast.ExprStmt:
+			if call, ok := s.X.(*ast.CallExpr); ok {
+				recordCall(call)
+			}
+		case *ast.ReturnStmt:
+			for _, result := range s.Results {
+				if call, ok := result.(*ast.CallExpr); ok {
+					recordCall(call)
+				}
+			}
+		case *ast.GoStmt:
+			recordCall(s.Call)
+		case *ast.IfStmt:
+			visitStmtList(s.Body.List)
+			if s.Else != nil {
+				visitElse(s.Else)
+			}
+		case *ast.ForStmt:
+			visitStmtList(s.Body.List)
+		case *ast.RangeStmt:
+			visitStmtList(s.Body.List)
+		case *ast.SwitchStmt:
+			for _, clause := range s.Body.List {
+				if cc, ok := clause.(*ast.CaseClause); ok {
+					visitStmtList(cc.Body)
+				}
+			}
+		case *ast.TypeSwitchStmt:
+			for _, clause := range s.Body.List {
+				if cc, ok := clause.(*ast.CaseClause); ok {
+					visitStmtList(cc.Body)
+				}
+			}
+		case *ast.SelectStmt:
+			for _, clause := range s.Body.List {
+				if cc, ok := clause.(*ast.CommClause); ok {
+					visitStmtList(cc.Body)
+				}
+			}
+		}
+	}
+
+	visitStmtList(body.List)
+	return positions
+}
+
+func (ma *Analyzer) functionIsCallerManagedReleaseFor(mutexName string, methodNames []string) bool {
+	if ma.function == nil || ma.function.Name == nil {
+		return false
+	}
+
+	currentReceiver := receiverName(ma.function)
+	currentType := receiverTypeName(ma.function)
+	if currentReceiver == "" || currentType == "" {
+		return false
+	}
+
+	relativePath, ok := relativeMutexPath(mutexName, currentReceiver)
+	if !ok {
+		return false
+	}
+
+	totalCallSites := 0
+
+	for _, fn := range ma.functions {
+		if fn == nil || fn.Body == nil || fn == ma.function {
+			continue
+		}
+
+		explicitTransferPositions := ma.explicitTransferCallPositions(fn.Body)
+		ast.Inspect(fn.Body, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+
+			baseVar, ok := ma.callTargetsCurrentMethod(call, currentType)
+			if !ok {
+				return true
+			}
+
+			totalCallSites++
+			if _, ok := explicitTransferPositions[call.Pos()]; !ok {
+				totalCallSites = -1
+				return false
+			}
+			if !functionBodyContainsFieldCallBefore(fn.Body, baseVar+"."+relativePath, methodNames, call.Pos()) {
+				totalCallSites = -1
+				return false
+			}
+			return true
+		})
+		if totalCallSites < 0 {
+			return false
+		}
+	}
+
+	return totalCallSites > 0
+}
+
+func cloneStats(stats *Stats) *Stats {
+	if stats == nil {
+		return &Stats{}
+	}
+
+	return &Stats{
+		lock:               stats.lock,
+		rlock:              stats.rlock,
+		borrowedLock:       stats.borrowedLock,
+		borrowedRLock:      stats.borrowedRLock,
+		deferUnlock:        stats.deferUnlock,
+		deferRUnlock:       stats.deferRUnlock,
+		lockPos:            append([]token.Pos{}, stats.lockPos...),
+		rlockPos:           append([]token.Pos{}, stats.rlockPos...),
+		borrowedUnlockPos:  append([]token.Pos{}, stats.borrowedUnlockPos...),
+		borrowedRUnlockPos: append([]token.Pos{}, stats.borrowedRUnlockPos...),
+	}
+}
+
+func (ma *Analyzer) clearStats(stats map[string]*Stats) {
+	for name := range stats {
+		stats[name] = &Stats{}
+	}
+}
+
+func (ma *Analyzer) simulateMethodEffect(fn *ast.FuncDecl, varName string, isRWMutex bool, initial *Stats) *Stats {
+	if fn == nil || fn.Body == nil {
+		return nil
+	}
+
+	mutexNames := map[string]bool{}
+	rwMutexNames := map[string]bool{}
+	if isRWMutex {
+		rwMutexNames[varName] = true
+	} else {
+		mutexNames[varName] = true
+	}
+
+	simulated := &Analyzer{
+		mutexNames:      mutexNames,
+		rwMutexNames:    rwMutexNames,
+		errorCollector:  &report.ErrorCollector{},
+		commentFilter:   ma.commentFilter,
+		function:        fn,
+		typesInfo:       ma.typesInfo,
+		rawBodyEffects:  true,
+		receiverMethods: ma.receiverMethods,
+		functions:       ma.functions,
+		deferErrors: &deferErrorCollector{
+			badDeferUnlock:  make(map[string]bool),
+			badDeferRUnlock: make(map[string]bool),
+		},
+	}
+
+	start := map[string]*Stats{varName: cloneStats(initial)}
+	final := simulated.analyzeBlock(fn.Body, start)
+	return cloneStats(final[varName])
+}
+
+func (ma *Analyzer) applyLocalMethodLifecycleEffects(call *ast.CallExpr, stats map[string]*Stats) bool {
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+
+	baseVar := common.GetVarName(sel.X)
+	if baseVar == "?" {
+		return false
+	}
+
+	receiverType := baseTypeNameFromType(ma.typesInfo.TypeOf(sel.X))
+	if receiverType == "" {
+		return false
+	}
+
+	callee := ma.receiverMethods[receiverType][sel.Sel.Name]
+	if callee == nil || callee.Body == nil || callee == ma.function {
+		return false
+	}
+
+	calleeReceiver := receiverName(callee)
+	if calleeReceiver == "" {
+		return false
+	}
+
+	changed := false
+
+	for mutexName := range ma.mutexNames {
+		relativePath, ok := relativeMutexPath(mutexName, baseVar)
+		if !ok {
+			continue
+		}
+
+		simulated := ma.simulateMethodEffect(callee, calleeReceiver+"."+relativePath, false, stats[mutexName])
+		if simulated == nil {
+			continue
+		}
+
+		stats[mutexName] = simulated
+		changed = true
+	}
+
+	for rwMutexName := range ma.rwMutexNames {
+		relativePath, ok := relativeMutexPath(rwMutexName, baseVar)
+		if !ok {
+			continue
+		}
+
+		simulated := ma.simulateMethodEffect(callee, calleeReceiver+"."+relativePath, true, stats[rwMutexName])
+		if simulated == nil {
+			continue
+		}
+
+		stats[rwMutexName] = simulated
+		changed = true
+	}
+
+	return changed
 }
 
 // initializeStats initializes the stats map for all known mutexes

--- a/pkg/analyzer/mutex/stats.go
+++ b/pkg/analyzer/mutex/stats.go
@@ -34,7 +34,7 @@ func (ma *Analyzer) analyzeStatement(stmt ast.Stmt, stats map[string]*Stats) {
 	case *ast.IfStmt:
 		ma.analyzeIfStatement(s, stats)
 	case *ast.GoStmt:
-		ma.analyzeGoStatement(s)
+		ma.analyzeGoStatement(s, stats)
 	case *ast.ForStmt:
 		ma.analyzeForStatement(s, stats)
 	case *ast.RangeStmt:
@@ -85,6 +85,8 @@ func (ma *Analyzer) analyzeExpressionStatement(stmt *ast.ExprStmt, stats map[str
 	if ma.rwMutexNames[varName] {
 		ma.handleRWMutexCall(varName, sel.Sel.Name, call.Pos(), stats)
 	}
+
+	ma.applyLocalMethodLifecycleEffects(call, stats)
 }
 
 // handleMutexCall processes mutex method calls
@@ -157,12 +159,19 @@ func (ma *Analyzer) handleRWMutexCall(varName, methodName string, pos token.Pos,
 
 func (ma *Analyzer) analyzeReturnStatement(stmt *ast.ReturnStmt, stats map[string]*Stats) {
 	for _, result := range stmt.Results {
+		call, ok := result.(*ast.CallExpr)
+		if ok && !ma.commentFilter.ShouldSkipCall(call) {
+			ma.applyLocalMethodLifecycleEffects(call, stats)
+		}
+
 		fnlit, ok := result.(*ast.FuncLit)
 		if !ok {
 			continue
 		}
 		ma.handleDeferFunctionLiteral(fnlit, stmt.Pos(), stats)
 	}
+
+	ma.reportUnmatchedLocks(stats)
 }
 
 // analyzeDeferStatement handles defer statements

--- a/pkg/analyzer/mutex/validation.go
+++ b/pkg/analyzer/mutex/validation.go
@@ -87,6 +87,20 @@ func (ma *Analyzer) analyzeIfStatement(stmt *ast.IfStmt, stats map[string]*Stats
 		return
 	}
 
+	if condValue, ok := common.ConstantBoolValue(stmt.Cond, ma.typesInfo); ok {
+		if condValue {
+			thenStats := ma.analyzeBlock(stmt.Body, stats)
+			ma.replaceStats(stats, thenStats)
+			return
+		}
+
+		if stmt.Else != nil {
+			elseStats := ma.analyzeElseBranch(stmt.Else, stats)
+			ma.replaceStats(stats, elseStats)
+		}
+		return
+	}
+
 	thenBase, elseBase := ma.branchInitialStatsForCondition(stmt.Cond, stats)
 	thenStats := ma.analyzeBlock(stmt.Body, thenBase)
 
@@ -179,15 +193,18 @@ func (ma *Analyzer) sameBranchState(a, b *Stats) bool {
 }
 
 // analyzeGoStatement handles goroutine statements
-func (ma *Analyzer) analyzeGoStatement(stmt *ast.GoStmt) {
+func (ma *Analyzer) analyzeGoStatement(stmt *ast.GoStmt, stats map[string]*Stats) {
 	if ma.commentFilter.ShouldSkipStatement(stmt) {
 		return
 	}
 
 	if fnLit, ok := stmt.Call.Fun.(*ast.FuncLit); ok {
-		goStats := ma.analyzeBlock(fnLit.Body, ma.stats)
-		ma.reportUnmatchedLocksInBranch(ma.stats, goStats, "goroutine")
+		goStats := ma.analyzeBlock(fnLit.Body, stats)
+		ma.reportUnmatchedLocksInBranch(stats, goStats, "goroutine")
+		return
 	}
+
+	ma.applyLocalMethodLifecycleEffects(stmt.Call, stats)
 }
 
 // analyzeForStatement handles for loop statements
@@ -198,7 +215,36 @@ func (ma *Analyzer) analyzeForStatement(stmt *ast.ForStmt, stats map[string]*Sta
 
 	forStats := ma.analyzeBlock(stmt.Body, stats)
 	ma.applyLoopExitLocks(stmt, stats, forStats)
+	if stmt.Cond == nil && ma.blockContainsReturn(stmt.Body) && !ma.blockContainsBreak(stmt.Body) {
+		ma.clearStats(stats)
+		return
+	}
 	ma.replaceStats(stats, forStats)
+}
+
+func (ma *Analyzer) blockContainsReturn(block *ast.BlockStmt) bool {
+	found := false
+	ast.Inspect(block, func(n ast.Node) bool {
+		if _, ok := n.(*ast.ReturnStmt); ok {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
+}
+
+func (ma *Analyzer) blockContainsBreak(block *ast.BlockStmt) bool {
+	found := false
+	ast.Inspect(block, func(n ast.Node) bool {
+		branch, ok := n.(*ast.BranchStmt)
+		if ok && branch.Tok == token.BREAK {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
 }
 
 func (ma *Analyzer) applyLoopExitLocks(stmt *ast.ForStmt, initial, final map[string]*Stats) {
@@ -324,8 +370,10 @@ func (ma *Analyzer) reportBranchDelta(mutexName string, initial, final *Stats, i
 		}
 	}
 
+	suppressBorrowedUnlock := ma.functionIsLifecycleReleaseFor(mutexName, []string{"Lock", "TryLock"}) ||
+		ma.functionIsCallerManagedReleaseFor(mutexName, []string{"Lock", "TryLock"})
 	unlockMessage := mutexType + " '" + mutexName + "' is unlocked but not locked"
-	if delta := final.borrowedLock - initial.borrowedLock; delta > 0 {
+	if delta := final.borrowedLock - initial.borrowedLock; delta > 0 && !suppressBorrowedUnlock {
 		for _, pos := range ma.trailingPositions(final.borrowedUnlockPos, delta) {
 			ma.errorCollector.AddError(pos, unlockMessage)
 		}
@@ -339,8 +387,10 @@ func (ma *Analyzer) reportBranchDelta(mutexName string, initial, final *Stats, i
 			}
 		}
 
+		suppressBorrowedRUnlock := ma.functionIsLifecycleReleaseFor(mutexName, []string{"RLock", "TryRLock"}) ||
+			ma.functionIsCallerManagedReleaseFor(mutexName, []string{"RLock", "TryRLock"})
 		runlockMessage := "rwmutex '" + mutexName + "' is runlocked but not rlocked"
-		if delta := final.borrowedRLock - initial.borrowedRLock; delta > 0 {
+		if delta := final.borrowedRLock - initial.borrowedRLock; delta > 0 && !suppressBorrowedRUnlock {
 			for _, pos := range ma.trailingPositions(final.borrowedRUnlockPos, delta) {
 				ma.errorCollector.AddError(pos, runlockMessage)
 			}
@@ -396,7 +446,9 @@ func (ma *Analyzer) reportUnmatchedMutexLocksWithContext(mutexName string, stats
 		ma.errorCollector.AddError(pos, lockMessage)
 	}
 
-	suppressFunctionLevelUnlock := branchType == "" && ma.functionIsLifecycleReleaseFor(mutexName, []string{"Lock", "TryLock"})
+	suppressFunctionLevelUnlock := branchType == "" &&
+		(ma.functionIsLifecycleReleaseFor(mutexName, []string{"Lock", "TryLock"}) ||
+			ma.functionIsCallerManagedReleaseFor(mutexName, []string{"Lock", "TryLock"}))
 	for _, pos := range stats.borrowedUnlockPos {
 		if suppressFunctionLevelUnlock {
 			continue
@@ -412,7 +464,9 @@ func (ma *Analyzer) reportUnmatchedMutexLocksWithContext(mutexName string, stats
 			}
 			ma.errorCollector.AddError(pos, rlockMessage)
 		}
-		suppressFunctionLevelRUnlock := branchType == "" && ma.functionIsLifecycleReleaseFor(mutexName, []string{"RLock", "TryRLock"})
+		suppressFunctionLevelRUnlock := branchType == "" &&
+			(ma.functionIsLifecycleReleaseFor(mutexName, []string{"RLock", "TryRLock"}) ||
+				ma.functionIsCallerManagedReleaseFor(mutexName, []string{"RLock", "TryRLock"}))
 		for _, pos := range stats.borrowedRUnlockPos {
 			if suppressFunctionLevelRUnlock {
 				continue

--- a/pkg/analyzer/testdata/src/mutex/mutex_extended_cases.go
+++ b/pkg/analyzer/testdata/src/mutex/mutex_extended_cases.go
@@ -1,6 +1,10 @@
 package mutex
 
-import "sync"
+import (
+	"errors"
+	"runtime"
+	"sync"
+)
 
 // ========== MIXED SCENARIOS ==========
 
@@ -240,6 +244,32 @@ RETRY:
 	}
 }
 
+// Good: repeated platform guards should behave like straight-line code on the
+// active target, not like unrelated conditional branches.
+func GoodPlatformGuardedLockingFlow(pending bool, err error) error {
+	var mu sync.Mutex
+
+	if runtime.GOOS == "linux" {
+		mu.Lock()
+		if pending {
+			mu.Unlock()
+			return nil
+		}
+	}
+
+	if err != nil {
+		if runtime.GOOS == "linux" {
+			mu.Unlock()
+		}
+		return err
+	}
+
+	if runtime.GOOS == "linux" {
+		mu.Unlock()
+	}
+	return nil
+}
+
 // ========== FUNCTION PARAMETER TESTS ==========
 
 // Good: function receives mutex parameter, properly locks and unlocks
@@ -323,6 +353,47 @@ type NamedWrapperMutex struct {
 }
 
 type LoopExitLocker struct {
+	mu sync.Mutex
+}
+
+type HelperUnlockedState struct {
+	mu sync.Mutex
+}
+
+type ResolverLikeClient struct {
+	mu sync.RWMutex
+}
+
+type NestedResolverWrapper struct {
+	cc *ResolverLikeClient
+}
+
+type BranchingUnlockClient struct {
+	mu    sync.RWMutex
+	conns map[int]struct{}
+}
+
+type RetryLoopStream struct {
+	mu        sync.Mutex
+	committed bool
+}
+
+type RetryContinueStream struct {
+	mu        sync.Mutex
+	committed bool
+	attempt   *int
+}
+
+type RetryLikeAttempt struct{}
+
+type RetryLikeStream struct {
+	mu          sync.Mutex
+	committed   bool
+	replayReady bool
+	attempt     *RetryLikeAttempt
+}
+
+type MixedCallerManagedRelease struct {
 	mu sync.Mutex
 }
 
@@ -433,6 +504,182 @@ func (l *LoopExitLocker) GoodLoopBreakWithUnlockAfterLoop(stop bool) {
 		stop = true
 	}
 	l.mu.Unlock()
+}
+
+func (h *HelperUnlockedState) releaseHelper() {
+	h.mu.Unlock()
+}
+
+func (h *HelperUnlockedState) GoodHelperReleasesCallerLock(async bool) {
+	h.mu.Lock()
+	if async {
+		go h.releaseHelper()
+		return
+	}
+	h.releaseHelper()
+}
+
+func (cc *ResolverLikeClient) updateAndUnlock() {
+	cc.mu.Unlock()
+}
+
+func (w *NestedResolverWrapper) GoodNestedHelperUnlock() {
+	w.cc.mu.Lock()
+	w.cc.updateAndUnlock()
+}
+
+func (cc *ResolverLikeClient) updateAndUnlockWithError(err error) error {
+	cc.mu.Unlock()
+	return err
+}
+
+func (w *NestedResolverWrapper) GoodNestedReturnHelperUnlock(err error) error {
+	w.cc.mu.Lock()
+	return w.cc.updateAndUnlockWithError(err)
+}
+
+func (cc *BranchingUnlockClient) updateStateAndUnlock(err error) error {
+	if cc.conns == nil {
+		cc.mu.Unlock()
+		return nil
+	}
+	if err != nil {
+		cc.mu.Unlock()
+		return err
+	}
+	cc.mu.Unlock()
+	return nil
+}
+
+func (cc *BranchingUnlockClient) GoodBranchingHelperUnlock(err error) error {
+	cc.mu.Lock()
+	if err != nil {
+		cc.updateStateAndUnlock(err)
+		return errors.New("wrapped")
+	}
+	cc.mu.Unlock()
+	return nil
+}
+
+func (cc *BranchingUnlockClient) GoodExitIdleModeLike(startErr error) error {
+	cc.mu.Lock()
+	if cc.conns == nil {
+		cc.mu.Unlock()
+		return errors.New("closed")
+	}
+	cc.mu.Unlock()
+
+	if startErr != nil {
+		cc.mu.Lock()
+		cc.updateStateAndUnlock(startErr)
+		return errors.New("failed to start")
+	}
+	return nil
+}
+
+func (s *RetryLoopStream) GoodRetryLoopLockCarry() error {
+	s.mu.Lock()
+	for {
+		if s.committed {
+			s.mu.Unlock()
+			return nil
+		}
+		s.mu.Unlock()
+		s.mu.Lock()
+		if s.committed {
+			s.mu.Unlock()
+			return nil
+		}
+	}
+}
+
+func (s *RetryContinueStream) retryLocked() error {
+	return nil
+}
+
+func (s *RetryContinueStream) GoodRetryLoopWithContinue(switched, fail bool) error {
+	s.mu.Lock()
+	for {
+		if s.committed {
+			s.mu.Unlock()
+			return nil
+		}
+		s.mu.Unlock()
+		a := s.attempt
+		_ = a
+		s.mu.Lock()
+		if switched {
+			continue
+		}
+		if fail {
+			s.mu.Unlock()
+			return errors.New("failed")
+		}
+		if err := s.retryLocked(); err != nil {
+			s.mu.Unlock()
+			return err
+		}
+	}
+}
+
+func (s *RetryLikeStream) newAttemptLocked() (*RetryLikeAttempt, error) {
+	return &RetryLikeAttempt{}, nil
+}
+
+func (s *RetryLikeStream) retryLocked(_ *RetryLikeAttempt, _ error) error {
+	return nil
+}
+
+func (s *RetryLikeStream) commitAttemptLocked() {}
+
+func (s *RetryLikeStream) GoodWithRetryLike(switched bool, opErr error, onSuccess func()) error {
+	s.mu.Lock()
+	for {
+		if s.committed {
+			s.mu.Unlock()
+			return opErr
+		}
+		if !s.replayReady {
+			var err error
+			if s.attempt, err = s.newAttemptLocked(); err != nil {
+				s.mu.Unlock()
+				return err
+			}
+		}
+		a := s.attempt
+		s.mu.Unlock()
+		err := opErr
+		s.mu.Lock()
+		if a != s.attempt {
+			continue
+		}
+		if err == nil {
+			if onSuccess != nil {
+				onSuccess()
+			} else {
+				s.commitAttemptLocked()
+			}
+			s.mu.Unlock()
+			return nil
+		}
+		if err := s.retryLocked(a, err); err != nil {
+			s.mu.Unlock()
+			return err
+		}
+	}
+}
+
+func (m *MixedCallerManagedRelease) releaseHelper() {
+	m.mu.Unlock() // want "mutex 'm.mu' is unlocked but not locked"
+}
+
+func (m *MixedCallerManagedRelease) GoodCallerManagedRelease() {
+	m.mu.Lock()
+	m.releaseHelper()
+}
+
+func (m *MixedCallerManagedRelease) BadCallerManagedRelease() {
+	m.releaseHelper()
 }
 
 // Good: a creator can return a token that owns the eventual unlock in Close.


### PR DESCRIPTION
…ler-managed release

- propagate Lock/Unlock effects when calling sibling methods on the same receiver, so wrappers don't cause spurious unmatched-lock reports

- detect caller-managed release patterns where a function returns holding a lock that another call site is expected to release

- use pass.TypesInfo to resolve receiver types for cross-method lifecycle analysis

- deduplicate identical errors in ErrorCollector to prevent repeated reports at the same position

- trigger unmatched-lock reporting on return statements to catch locks leaked via return paths