### PR TITLE
fix: use baseline tracking in applyFunctionExitDefers to prevent fals…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,5 @@ Thumbs.db
 # Local environment files
 .env
 .env.*
+
+scripts/

--- a/pkg/analyzer/mutex/analyzer.go
+++ b/pkg/analyzer/mutex/analyzer.go
@@ -871,6 +871,7 @@ func (ma *Analyzer) simulateMethodEffect(fn *ast.FuncDecl, varName string, isRWM
 
 	start := map[string]*Stats{varName: cloneStats(initial)}
 	final := simulated.analyzeBlock(fn.Body, start)
+	simulated.applyFunctionExitDefers(final, start)
 	return cloneStats(final[varName])
 }
 
@@ -915,8 +916,9 @@ func (ma *Analyzer) applyLocalFunctionLiteralLifecycleEffects(call *ast.CallExpr
 		},
 	}
 
-	final := simulated.analyzeBlock(fnlit.Body, stats)
-	simulated.applyFunctionExitDefers(final)
+	baseline := simulated.copyStats(stats)
+	final := simulated.analyzeBlock(fnlit.Body, baseline)
+	simulated.applyFunctionExitDefers(final, baseline)
 	ma.replaceStats(stats, final)
 	return true
 }
@@ -960,18 +962,27 @@ func (ma *Analyzer) localFunctionLiteralBefore(name string, before token.Pos) *a
 	return found
 }
 
-func (ma *Analyzer) applyFunctionExitDefers(stats map[string]*Stats) {
-	for _, st := range stats {
-		for st.deferUnlock > 0 && st.lock > 0 {
+func (ma *Analyzer) applyFunctionExitDefers(stats, baseline map[string]*Stats) {
+	for name, st := range stats {
+		baselineDeferUnlocks := 0
+		baselineDeferRUnlocks := 0
+		if baselineStats := baseline[name]; baselineStats != nil {
+			baselineDeferUnlocks = baselineStats.deferUnlock
+			baselineDeferRUnlocks = baselineStats.deferRUnlock
+		}
+
+		for st.deferUnlock > baselineDeferUnlocks && st.lock > 0 {
 			st.deferUnlock--
 			st.lock--
 			ma.removeFirstLockPos(st)
 		}
-		for st.deferRUnlock > 0 && st.rlock > 0 {
+		st.deferUnlock = baselineDeferUnlocks
+		for st.deferRUnlock > baselineDeferRUnlocks && st.rlock > 0 {
 			st.deferRUnlock--
 			st.rlock--
 			ma.removeFirstRLockPos(st)
 		}
+		st.deferRUnlock = baselineDeferRUnlocks
 	}
 }
 

--- a/pkg/analyzer/testdata/src/mutex/mutex_extended_cases.go
+++ b/pkg/analyzer/testdata/src/mutex/mutex_extended_cases.go
@@ -249,6 +249,83 @@ COPY:
 	_ = bufLen
 }
 
+type reportDeferredHelperCache struct {
+	mu    sync.Mutex
+	ready bool
+}
+
+func (c *reportDeferredHelperCache) reloadWithDefer() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.ready = true
+}
+
+// Good: a local helper's deferred unlock executes before the caller continues.
+// Regression for real-world helpers like kubelet UpdateAllocatedDevices and
+// go-ethereum accountCache.maybeReload.
+func (c *reportDeferredHelperCache) GoodCallHelperWithDeferThenLock() {
+	c.reloadWithDefer()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	_ = c.ready
+}
+
+type reportBufferedWriterLike struct {
+	mu      sync.Mutex
+	bufLen  int
+	bufSize int
+}
+
+func (w *reportBufferedWriterLike) flushWithDefer() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.bufLen = 0
+}
+
+// Good: the caller temporarily releases a lock, calls a helper that locks and
+// defers unlock, then relocks for its own deferred unlock. Regression for
+// consul's rexecWriter.Write -> Flush pattern.
+func (w *reportBufferedWriterLike) GoodTemporaryReleaseCallHelperAndRelock(buf []byte) {
+	if w.bufSize == 0 {
+		w.bufSize = 1
+	}
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+COPY:
+	remain := w.bufSize - w.bufLen
+	if remain > len(buf) {
+		w.bufLen += len(buf)
+	} else {
+		w.bufLen += remain
+		w.mu.Unlock()
+		w.flushWithDefer()
+		w.mu.Lock()
+		goto COPY
+	}
+}
+
+type reportRWDeferredHelperCache struct {
+	mu    sync.RWMutex
+	value int
+}
+
+func (c *reportRWDeferredHelperCache) readWithDefer() int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.value
+}
+
+// Good: a read-locking helper has released its deferred RUnlock before the
+// caller takes the write lock.
+func (c *reportRWDeferredHelperCache) GoodReadHelperThenWriteLock() {
+	_ = c.readWithDefer()
+	c.mu.Lock()
+	c.value++
+	c.mu.Unlock()
+}
+
 // ---------- Switch All Cases Edge Cases ----------
 
 // Good: switch where all cases + default properly lock/unlock


### PR DESCRIPTION
…e positives from helper defers

Deferred unlocks in helper methods (Lock + defer Unlock) were incorrectly left as pending when returning to the caller, causing subsequent locks in the caller to be flagged as double-locks.