### PR TITLE
feat: Add mutex and waitgroup analysis enhancements

### DIFF
--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -5,6 +5,7 @@ import (
 	"go/token"
 	"go/types"
 	"maps"
+	"strings"
 
 	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/common"
 	commnetfilter "github.com/sanbricio/goconcurrencylint/pkg/analyzer/common/commentfilter"
@@ -290,6 +291,9 @@ func reportCopyByValueParams(fn *ast.FuncDecl, pass *analysis.Pass, errorCollect
 		return
 	}
 
+	if fn.Recv != nil {
+		reportCopyByValueFieldList(fn.Recv, pass, errorCollector)
+	}
 	reportCopyByValueFieldList(fn.Type.Params, pass, errorCollector)
 }
 
@@ -322,7 +326,10 @@ func reportCopyByValueAssignments(assign *ast.AssignStmt, pass *analysis.Pass, e
 		return
 	}
 
-	for _, rhs := range assign.Rhs {
+	for i, rhs := range assign.Rhs {
+		if i < len(assign.Lhs) && isBlankIdentifier(assign.Lhs[i]) {
+			continue
+		}
 		if kind, name, ok := copiedSyncPrimitive(rhs, pass); ok {
 			errorCollector.AddError(rhs.Pos(), copyByValueMessage(kind, name))
 		}
@@ -358,6 +365,11 @@ func copiedSyncPrimitive(expr ast.Expr, pass *analysis.Pass) (string, string, bo
 	return kind, name, true
 }
 
+func isBlankIdentifier(expr ast.Expr) bool {
+	ident, ok := expr.(*ast.Ident)
+	return ok && ident.Name == "_"
+}
+
 func isTypeExpression(expr ast.Expr, info *types.Info) bool {
 	if expr == nil || info == nil {
 		return false
@@ -377,6 +389,16 @@ func isFreshSyncPrimitiveValue(expr ast.Expr) bool {
 }
 
 func syncPrimitiveValueKind(typ types.Type) string {
+	if kind := directSyncPrimitiveValueKind(typ); kind != "" {
+		return kind
+	}
+	if kind := containedSyncPrimitiveValueKind(typ, make(map[types.Type]bool)); kind != "" {
+		return "struct containing " + kind
+	}
+	return ""
+}
+
+func directSyncPrimitiveValueKind(typ types.Type) string {
 	if typ == nil {
 		return ""
 	}
@@ -398,5 +420,43 @@ func syncPrimitiveValueKind(typ types.Type) string {
 }
 
 func copyByValueMessage(kind, name string) string {
+	if contained, ok := strings.CutPrefix(kind, "struct containing "); ok {
+		return "struct '" + name + "' containing " + contained + " is copied by value"
+	}
 	return kind + " '" + name + "' is copied by value"
+}
+
+func containedSyncPrimitiveValueKind(typ types.Type, visited map[types.Type]bool) string {
+	if typ == nil {
+		return ""
+	}
+
+	typ = types.Unalias(typ)
+	if visited[typ] {
+		return ""
+	}
+	visited[typ] = true
+
+	switch t := typ.(type) {
+	case *types.Named:
+		if kind := directSyncPrimitiveValueKind(t); kind != "" {
+			return kind
+		}
+		return containedSyncPrimitiveValueKind(t.Underlying(), visited)
+	case *types.Struct:
+		for i := 0; i < t.NumFields(); i++ {
+			fieldType := types.Unalias(t.Field(i).Type())
+			if _, ok := fieldType.(*types.Pointer); ok {
+				continue
+			}
+			if kind := directSyncPrimitiveValueKind(fieldType); kind != "" {
+				return kind
+			}
+			if kind := containedSyncPrimitiveValueKind(fieldType, visited); kind != "" {
+				return kind
+			}
+		}
+	}
+
+	return ""
 }

--- a/pkg/analyzer/mutex/analyzer.go
+++ b/pkg/analyzer/mutex/analyzer.go
@@ -71,6 +71,7 @@ func NewAnalyzer(mutexNames, rwMutexNames map[string]bool, errorCollector *repor
 func (ma *Analyzer) AnalyzeFunction(fn *ast.FuncDecl) {
 	ma.function = fn
 	ma.initializeStats()
+	ma.checkLockOrderCycles(fn.Body)
 	finalStats := ma.analyzeBlock(fn.Body, ma.stats)
 	ma.reportUnmatchedLocks(finalStats)
 }

--- a/pkg/analyzer/mutex/analyzer.go
+++ b/pkg/analyzer/mutex/analyzer.go
@@ -660,10 +660,11 @@ func (ma *Analyzer) explicitTransferCallPositions(body *ast.BlockStmt) map[token
 	if body == nil {
 		return positions
 	}
-
-	var visitStmt func(ast.Stmt)
-	var visitStmtList func([]ast.Stmt)
-	var visitElse func(ast.Stmt)
+	var (
+		visitStmt     func(ast.Stmt)
+		visitStmtList func([]ast.Stmt)
+		visitElse     func(ast.Stmt)
+	)
 
 	recordCall := func(call *ast.CallExpr) {
 		if call != nil {

--- a/pkg/analyzer/mutex/behavior.go
+++ b/pkg/analyzer/mutex/behavior.go
@@ -1,0 +1,417 @@
+package mutex
+
+import (
+	"go/ast"
+	"go/token"
+	"sort"
+
+	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/common"
+)
+
+type lockOrderEdge struct {
+	from string
+	to   string
+}
+
+type crossGoroutineReleases struct {
+	unlocks  map[string][]token.Pos
+	runlocks map[string][]token.Pos
+}
+
+func (ma *Analyzer) checkLockOrderCycles(block *ast.BlockStmt) {
+	if block == nil {
+		return
+	}
+
+	edges := make(map[lockOrderEdge]token.Pos)
+	reported := make(map[lockOrderEdge]bool)
+	ma.scanLockOrderStatements(block.List, make(map[string]bool), edges, reported)
+}
+
+func (ma *Analyzer) scanLockOrderStatements(stmts []ast.Stmt, held map[string]bool, edges map[lockOrderEdge]token.Pos, reported map[lockOrderEdge]bool) {
+	for _, stmt := range stmts {
+		if stmt == nil || ma.commentFilter.ShouldSkipStatement(stmt) {
+			continue
+		}
+
+		switch s := stmt.(type) {
+		case *ast.ExprStmt:
+			if call, ok := s.X.(*ast.CallExpr); ok {
+				ma.scanLockOrderCall(call, held, edges, reported)
+			}
+		case *ast.DeferStmt:
+			ma.scanLockOrderDefer(s, held, edges, reported)
+		case *ast.GoStmt:
+			if fnLit, ok := s.Call.Fun.(*ast.FuncLit); ok && fnLit.Body != nil {
+				ma.scanLockOrderStatements(fnLit.Body.List, make(map[string]bool), edges, reported)
+			}
+		case *ast.IfStmt:
+			thenHeld := cloneBoolMap(held)
+			if varName, ok := ma.tryLockCallVar(s.Cond); ok {
+				ma.recordHeldLockOrderEdges(varName, s.Cond.Pos(), thenHeld, edges, reported)
+				thenHeld[varName] = true
+			}
+			ma.scanLockOrderStatements(s.Body.List, thenHeld, edges, reported)
+			if s.Else != nil {
+				ma.scanLockOrderElse(s.Else, cloneBoolMap(held), edges, reported)
+			}
+		case *ast.ForStmt:
+			if s.Body != nil {
+				ma.scanLockOrderStatements(s.Body.List, cloneBoolMap(held), edges, reported)
+			}
+		case *ast.RangeStmt:
+			if s.Body != nil {
+				ma.scanLockOrderStatements(s.Body.List, cloneBoolMap(held), edges, reported)
+			}
+		case *ast.BlockStmt:
+			ma.scanLockOrderStatements(s.List, held, edges, reported)
+		case *ast.LabeledStmt:
+			ma.scanLockOrderStatements([]ast.Stmt{s.Stmt}, held, edges, reported)
+		case *ast.SwitchStmt:
+			for _, clause := range s.Body.List {
+				if cc, ok := clause.(*ast.CaseClause); ok {
+					ma.scanLockOrderStatements(cc.Body, cloneBoolMap(held), edges, reported)
+				}
+			}
+		case *ast.TypeSwitchStmt:
+			for _, clause := range s.Body.List {
+				if cc, ok := clause.(*ast.CaseClause); ok {
+					ma.scanLockOrderStatements(cc.Body, cloneBoolMap(held), edges, reported)
+				}
+			}
+		case *ast.SelectStmt:
+			for _, clause := range s.Body.List {
+				if cc, ok := clause.(*ast.CommClause); ok {
+					ma.scanLockOrderStatements(cc.Body, cloneBoolMap(held), edges, reported)
+				}
+			}
+		}
+	}
+}
+
+func (ma *Analyzer) scanLockOrderCall(call *ast.CallExpr, held map[string]bool, edges map[lockOrderEdge]token.Pos, reported map[lockOrderEdge]bool) {
+	if call == nil || ma.commentFilter.ShouldSkipCall(call) {
+		return
+	}
+
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return
+	}
+
+	varName := common.GetVarName(sel.X)
+	switch {
+	case ma.isLockOrderAcquire(varName, sel.Sel.Name):
+		ma.recordHeldLockOrderEdges(varName, call.Pos(), held, edges, reported)
+		held[varName] = true
+	case ma.isLockOrderRelease(varName, sel.Sel.Name):
+		delete(held, varName)
+	}
+}
+
+func (ma *Analyzer) scanLockOrderDefer(stmt *ast.DeferStmt, held map[string]bool, edges map[lockOrderEdge]token.Pos, reported map[lockOrderEdge]bool) {
+	if stmt == nil || ma.commentFilter.ShouldSkipCall(stmt.Call) {
+		return
+	}
+	if call, ok := stmt.Call.Fun.(*ast.FuncLit); ok && call.Body != nil {
+		ma.scanLockOrderStatements(call.Body.List, cloneBoolMap(held), edges, reported)
+	}
+}
+
+func (ma *Analyzer) scanLockOrderElse(stmt ast.Stmt, held map[string]bool, edges map[lockOrderEdge]token.Pos, reported map[lockOrderEdge]bool) {
+	switch s := stmt.(type) {
+	case *ast.BlockStmt:
+		ma.scanLockOrderStatements(s.List, held, edges, reported)
+	case *ast.IfStmt:
+		ma.scanLockOrderStatements([]ast.Stmt{s}, held, edges, reported)
+	}
+}
+
+func (ma *Analyzer) tryLockCallVar(expr ast.Expr) (string, bool) {
+	call, ok := expr.(*ast.CallExpr)
+	if !ok {
+		return "", false
+	}
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return "", false
+	}
+	varName := common.GetVarName(sel.X)
+	switch sel.Sel.Name {
+	case "TryLock":
+		if ma.mutexNames[varName] || ma.rwMutexNames[varName] {
+			return varName, true
+		}
+	case "TryRLock":
+		if ma.rwMutexNames[varName] {
+			return varName, true
+		}
+	}
+	return "", false
+}
+
+func (ma *Analyzer) recordHeldLockOrderEdges(varName string, pos token.Pos, held map[string]bool, edges map[lockOrderEdge]token.Pos, reported map[lockOrderEdge]bool) {
+	for heldName := range held {
+		if heldName == varName {
+			continue
+		}
+
+		edge := lockOrderEdge{from: heldName, to: varName}
+		reverse := lockOrderEdge{from: varName, to: heldName}
+		if _, exists := edges[edge]; !exists {
+			edges[edge] = pos
+		}
+		if _, exists := edges[reverse]; !exists {
+			continue
+		}
+
+		reportKey := normalizedLockOrderEdge(heldName, varName)
+		if reported[reportKey] {
+			continue
+		}
+		reported[reportKey] = true
+		first, second := orderedLockNames(heldName, varName)
+		ma.errorCollector.AddError(pos, "mutex lock order cycle between '"+first+"' and '"+second+"'")
+	}
+}
+
+func normalizedLockOrderEdge(a, b string) lockOrderEdge {
+	first, second := orderedLockNames(a, b)
+	return lockOrderEdge{from: first, to: second}
+}
+
+func orderedLockNames(a, b string) (string, string) {
+	names := []string{a, b}
+	sort.Strings(names)
+	return names[0], names[1]
+}
+
+func (ma *Analyzer) isLockOrderAcquire(varName, methodName string) bool {
+	switch methodName {
+	case "Lock", "TryLock":
+		return ma.mutexNames[varName] || ma.rwMutexNames[varName]
+	case "RLock", "TryRLock":
+		return ma.rwMutexNames[varName]
+	default:
+		return false
+	}
+}
+
+func (ma *Analyzer) isLockOrderRelease(varName, methodName string) bool {
+	switch methodName {
+	case "Unlock":
+		return ma.mutexNames[varName] || ma.rwMutexNames[varName]
+	case "RUnlock":
+		return ma.rwMutexNames[varName]
+	default:
+		return false
+	}
+}
+
+func (ma *Analyzer) reportCrossGoroutineReleases(body *ast.BlockStmt, parentStats map[string]*Stats) crossGoroutineReleases {
+	releases := crossGoroutineReleases{
+		unlocks:  make(map[string][]token.Pos),
+		runlocks: make(map[string][]token.Pos),
+	}
+	if body == nil {
+		return releases
+	}
+
+	ma.scanCrossGoroutineReleaseStatements(body.List, parentStats, make(map[string]int), make(map[string]int), releases)
+	return releases
+}
+
+func (ma *Analyzer) scanCrossGoroutineReleaseStatements(stmts []ast.Stmt, parentStats map[string]*Stats, localLocks, localRLocks map[string]int, releases crossGoroutineReleases) {
+	for _, stmt := range stmts {
+		if stmt == nil || ma.commentFilter.ShouldSkipStatement(stmt) {
+			continue
+		}
+
+		switch s := stmt.(type) {
+		case *ast.ExprStmt:
+			if call, ok := s.X.(*ast.CallExpr); ok {
+				ma.scanCrossGoroutineReleaseCall(call, parentStats, localLocks, localRLocks, releases)
+			}
+		case *ast.DeferStmt:
+			ma.scanCrossGoroutineReleaseCall(s.Call, parentStats, localLocks, localRLocks, releases)
+		case *ast.IfStmt:
+			ma.scanCrossGoroutineReleaseStatements(s.Body.List, parentStats, cloneIntMap(localLocks), cloneIntMap(localRLocks), releases)
+			if s.Else != nil {
+				ma.scanCrossGoroutineReleaseElse(s.Else, parentStats, cloneIntMap(localLocks), cloneIntMap(localRLocks), releases)
+			}
+		case *ast.ForStmt:
+			if s.Body != nil {
+				ma.scanCrossGoroutineReleaseStatements(s.Body.List, parentStats, cloneIntMap(localLocks), cloneIntMap(localRLocks), releases)
+			}
+		case *ast.RangeStmt:
+			if s.Body != nil {
+				ma.scanCrossGoroutineReleaseStatements(s.Body.List, parentStats, cloneIntMap(localLocks), cloneIntMap(localRLocks), releases)
+			}
+		case *ast.BlockStmt:
+			ma.scanCrossGoroutineReleaseStatements(s.List, parentStats, localLocks, localRLocks, releases)
+		case *ast.LabeledStmt:
+			ma.scanCrossGoroutineReleaseStatements([]ast.Stmt{s.Stmt}, parentStats, localLocks, localRLocks, releases)
+		case *ast.SwitchStmt:
+			for _, clause := range s.Body.List {
+				if cc, ok := clause.(*ast.CaseClause); ok {
+					ma.scanCrossGoroutineReleaseStatements(cc.Body, parentStats, cloneIntMap(localLocks), cloneIntMap(localRLocks), releases)
+				}
+			}
+		case *ast.TypeSwitchStmt:
+			for _, clause := range s.Body.List {
+				if cc, ok := clause.(*ast.CaseClause); ok {
+					ma.scanCrossGoroutineReleaseStatements(cc.Body, parentStats, cloneIntMap(localLocks), cloneIntMap(localRLocks), releases)
+				}
+			}
+		case *ast.SelectStmt:
+			for _, clause := range s.Body.List {
+				if cc, ok := clause.(*ast.CommClause); ok {
+					ma.scanCrossGoroutineReleaseStatements(cc.Body, parentStats, cloneIntMap(localLocks), cloneIntMap(localRLocks), releases)
+				}
+			}
+		}
+	}
+}
+
+func (ma *Analyzer) scanCrossGoroutineReleaseElse(stmt ast.Stmt, parentStats map[string]*Stats, localLocks, localRLocks map[string]int, releases crossGoroutineReleases) {
+	switch s := stmt.(type) {
+	case *ast.BlockStmt:
+		ma.scanCrossGoroutineReleaseStatements(s.List, parentStats, localLocks, localRLocks, releases)
+	case *ast.IfStmt:
+		ma.scanCrossGoroutineReleaseStatements([]ast.Stmt{s}, parentStats, localLocks, localRLocks, releases)
+	}
+}
+
+func (ma *Analyzer) scanCrossGoroutineReleaseCall(call *ast.CallExpr, parentStats map[string]*Stats, localLocks, localRLocks map[string]int, releases crossGoroutineReleases) {
+	if call == nil || ma.commentFilter.ShouldSkipCall(call) {
+		return
+	}
+
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return
+	}
+
+	varName := common.GetVarName(sel.X)
+	switch sel.Sel.Name {
+	case "Lock", "TryLock":
+		if ma.mutexNames[varName] || ma.rwMutexNames[varName] {
+			localLocks[varName]++
+		}
+	case "Unlock":
+		if ma.mutexNames[varName] || ma.rwMutexNames[varName] {
+			if localLocks[varName] > 0 {
+				localLocks[varName]--
+				return
+			}
+			if ma.parentHoldsExclusiveLock(parentStats, varName) {
+				releases.unlocks[varName] = append(releases.unlocks[varName], call.Pos())
+				ma.errorCollector.AddError(call.Pos(), "mutex '"+varName+"' is unlocked in a different goroutine than it was locked")
+			}
+		}
+	case "RLock", "TryRLock":
+		if ma.rwMutexNames[varName] {
+			localRLocks[varName]++
+		}
+	case "RUnlock":
+		if ma.rwMutexNames[varName] {
+			if localRLocks[varName] > 0 {
+				localRLocks[varName]--
+				return
+			}
+			if ma.parentHoldsReadLock(parentStats, varName) {
+				releases.runlocks[varName] = append(releases.runlocks[varName], call.Pos())
+				ma.errorCollector.AddError(call.Pos(), "rwmutex '"+varName+"' is runlocked in a different goroutine than it was rlocked")
+			}
+		}
+	}
+}
+
+func (ma *Analyzer) parentHoldsExclusiveLock(stats map[string]*Stats, varName string) bool {
+	st := stats[varName]
+	if st == nil {
+		return false
+	}
+	return ma.remainingLockCount(st.lock, st.deferUnlock) > 0
+}
+
+func (ma *Analyzer) parentHoldsReadLock(stats map[string]*Stats, varName string) bool {
+	st := stats[varName]
+	if st == nil {
+		return false
+	}
+	return ma.remainingLockCount(st.rlock, st.deferRUnlock) > 0
+}
+
+func (ma *Analyzer) suppressCrossGoroutineBorrowedReleases(stats map[string]*Stats, releases crossGoroutineReleases) {
+	for varName, positions := range releases.unlocks {
+		st := stats[varName]
+		if st == nil {
+			continue
+		}
+		for _, pos := range positions {
+			if removePos(&st.borrowedUnlockPos, pos) && st.borrowedLock > 0 {
+				st.borrowedLock--
+			}
+		}
+	}
+
+	for varName, positions := range releases.runlocks {
+		st := stats[varName]
+		if st == nil {
+			continue
+		}
+		for _, pos := range positions {
+			if removePos(&st.borrowedRUnlockPos, pos) && st.borrowedRLock > 0 {
+				st.borrowedRLock--
+			}
+		}
+	}
+}
+
+func (ma *Analyzer) applyCrossGoroutineReleases(stats map[string]*Stats, releases crossGoroutineReleases) {
+	for varName, positions := range releases.unlocks {
+		st := stats[varName]
+		if st == nil {
+			continue
+		}
+		for range positions {
+			if st.lock > 0 {
+				st.lock--
+				ma.removeFirstLockPos(st)
+			}
+		}
+	}
+
+	for varName, positions := range releases.runlocks {
+		st := stats[varName]
+		if st == nil {
+			continue
+		}
+		for range positions {
+			if st.rlock > 0 {
+				st.rlock--
+				ma.removeFirstRLockPos(st)
+			}
+		}
+	}
+}
+
+func removePos(positions *[]token.Pos, pos token.Pos) bool {
+	for i, candidate := range *positions {
+		if candidate != pos {
+			continue
+		}
+		*positions = append((*positions)[:i], (*positions)[i+1:]...)
+		return true
+	}
+	return false
+}
+
+func cloneIntMap(src map[string]int) map[string]int {
+	dst := make(map[string]int, len(src))
+	for k, v := range src {
+		dst[k] = v
+	}
+	return dst
+}

--- a/pkg/analyzer/mutex/validation.go
+++ b/pkg/analyzer/mutex/validation.go
@@ -209,9 +209,12 @@ func (ma *Analyzer) analyzeGoStatement(stmt *ast.GoStmt, stats map[string]*Stats
 	}
 
 	if fnLit, ok := stmt.Call.Fun.(*ast.FuncLit); ok {
+		crossReleases := ma.reportCrossGoroutineReleases(fnLit.Body, stats)
 		goInitial := ma.emptyStatsLike(stats)
 		goStats := ma.analyzeBlock(fnLit.Body, goInitial)
+		ma.suppressCrossGoroutineBorrowedReleases(goStats, crossReleases)
 		ma.reportUnmatchedLocksInBranch(goInitial, goStats, "goroutine")
+		ma.applyCrossGoroutineReleases(stats, crossReleases)
 		return
 	}
 

--- a/pkg/analyzer/testdata/src/mutex/mutex_extended_cases.go
+++ b/pkg/analyzer/testdata/src/mutex/mutex_extended_cases.go
@@ -605,6 +605,11 @@ type SafeMap struct {
 	data map[string]string
 }
 
+type GenericSafeMap[T any] struct {
+	mu    sync.Mutex
+	value T
+}
+
 type InstrumentedMutex struct {
 	realLock    sync.Mutex
 	waitersLock sync.Mutex
@@ -712,6 +717,33 @@ func GoodStructFieldMutexDefer() {
 	var sm SafeMap
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
+}
+
+func takesSafeMapByValue(sm SafeMap) { // want "struct 'sm' containing mutex is copied by value"
+	sm.mu.Lock()
+	sm.mu.Unlock()
+}
+
+func takesGenericSafeMapByValue[T any](sm GenericSafeMap[T]) { // want "struct 'sm' containing mutex is copied by value"
+	sm.mu.Lock()
+	sm.mu.Unlock()
+}
+
+func BadStructContainingMutexPassedByValue() {
+	var sm SafeMap
+	takesSafeMapByValue(sm) // want "struct 'sm' containing mutex is copied by value"
+}
+
+func BadStructContainingMutexAssignedByValue() {
+	var sm SafeMap
+	copied := sm // want "struct 'sm' containing mutex is copied by value"
+	copied.mu.Lock()
+	copied.mu.Unlock()
+}
+
+func BadGenericStructContainingMutexPassedByValue() {
+	sm := GenericSafeMap[int]{}
+	takesGenericSafeMapByValue(sm) // want "struct 'sm' containing mutex is copied by value"
 }
 
 // Bad: struct field mutex locked but not unlocked

--- a/pkg/analyzer/testdata/src/mutex/mutex_goroutine_cases.go
+++ b/pkg/analyzer/testdata/src/mutex/mutex_goroutine_cases.go
@@ -23,6 +23,22 @@ func GoodGoroutineLocksAfterParentReleases() {
 	mu.Unlock()
 }
 
+func GoodConsistentLockOrderAcrossGoroutines() {
+	var muA, muB sync.Mutex
+	go func() {
+		muA.Lock()
+		muB.Lock()
+		muB.Unlock()
+		muA.Unlock()
+	}()
+	go func() {
+		muA.Lock()
+		muB.Lock()
+		muB.Unlock()
+		muA.Unlock()
+	}()
+}
+
 type borrowedLockManager struct {
 	mu sync.Mutex
 }
@@ -94,6 +110,57 @@ func BadGoroutineLockWithoutUnlockAfterParentReleases() {
 		mu.Lock() // want "mutex 'mu' is locked but not unlocked in goroutine"
 	}()
 	mu.Unlock()
+}
+
+func BadCrossGoroutineUnlock() {
+	var mu sync.Mutex
+	mu.Lock()
+	go func() {
+		mu.Unlock() // want "mutex 'mu' is unlocked in a different goroutine than it was locked"
+	}()
+}
+
+func BadCrossGoroutineUnlockThenParentUnlock() {
+	var mu sync.Mutex
+	mu.Lock()
+	go func() {
+		mu.Unlock() // want "mutex 'mu' is unlocked in a different goroutine than it was locked"
+	}()
+	mu.Unlock() // want "mutex 'mu' is unlocked but not locked"
+}
+
+func BadGoroutineLockOrderCycle() {
+	var muA, muB sync.Mutex
+	go func() {
+		muA.Lock()
+		muB.Lock()
+		muB.Unlock()
+		muA.Unlock()
+	}()
+	go func() {
+		muB.Lock()
+		muA.Lock() // want "mutex lock order cycle between 'muA' and 'muB'"
+		muA.Unlock()
+		muB.Unlock()
+	}()
+}
+
+func BadTryRLockOrderCycle() {
+	var mu sync.Mutex
+	var rw sync.RWMutex
+	go func() {
+		if rw.TryRLock() {
+			mu.Lock()
+			mu.Unlock()
+			rw.RUnlock()
+		}
+	}()
+	go func() {
+		mu.Lock()
+		rw.Lock() // want "mutex lock order cycle between 'mu' and 'rw'"
+		rw.Unlock()
+		mu.Unlock()
+	}()
 }
 
 // Goroutine defer unlock without lock

--- a/pkg/analyzer/testdata/src/waitgroup/waitgroup_basic_cases.go
+++ b/pkg/analyzer/testdata/src/waitgroup/waitgroup_basic_cases.go
@@ -173,3 +173,42 @@ func BadWaitGroupGoAfterWait() {
 		doSomething()
 	})
 }
+
+func GoodWaitGroupGoRecoveredPanic() {
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		defer func() {
+			_ = recover()
+		}()
+		panic("handled")
+	})
+	wg.Wait()
+}
+
+func BadWaitGroupGoPanic() {
+	var wg sync.WaitGroup
+	wg.Go(func() { // want "waitgroup 'wg' Go function may panic"
+		panic("boom")
+	})
+	wg.Wait()
+}
+
+func BadWaitGroupGoRecoverOutsideDefer() {
+	var wg sync.WaitGroup
+	wg.Go(func() { // want "waitgroup 'wg' Go function may panic"
+		_ = recover()
+		panic("boom")
+	})
+	wg.Wait()
+}
+
+func BadWaitGroupGoRecoverInNestedFunction() {
+	var wg sync.WaitGroup
+	wg.Go(func() { // want "waitgroup 'wg' Go function may panic"
+		go func() {
+			_ = recover()
+		}()
+		panic("boom")
+	})
+	wg.Wait()
+}

--- a/pkg/analyzer/testdata/src/waitgroup/waitgroup_extended_cases.go
+++ b/pkg/analyzer/testdata/src/waitgroup/waitgroup_extended_cases.go
@@ -319,6 +319,11 @@ type WorkerPool struct {
 	wg sync.WaitGroup
 }
 
+type GenericWorkerPool[T any] struct {
+	wg    sync.WaitGroup
+	value T
+}
+
 type EmbeddedWorkerPool struct {
 	sync.WaitGroup
 }
@@ -357,6 +362,53 @@ func (wp *WorkerPool) GoodMethodWaitGroup() {
 func (wp *WorkerPool) BadMethodWaitGroup() {
 	wp.wg.Add(1) // want "waitgroup 'wp.wg' has Add without corresponding Done"
 	wp.wg.Wait()
+}
+
+func takesWorkerPoolByValue(wp WorkerPool) { // want "struct 'wp' containing waitgroup is copied by value"
+	wp.wg.Add(1)
+	wp.wg.Done()
+	wp.wg.Wait()
+}
+
+func takesGenericWorkerPoolByValue[T any](wp GenericWorkerPool[T]) { // want "struct 'wp' containing waitgroup is copied by value"
+	wp.wg.Add(1)
+	wp.wg.Done()
+	wp.wg.Wait()
+}
+
+func BadStructContainingWaitGroupPassedByValue() {
+	var wp WorkerPool
+	takesWorkerPoolByValue(wp) // want "struct 'wp' containing waitgroup is copied by value"
+}
+
+func BadStructContainingWaitGroupAssignedByValue() {
+	var wp WorkerPool
+	copied := wp // want "struct 'wp' containing waitgroup is copied by value"
+	copied.wg.Wait()
+}
+
+func BadGenericStructContainingWaitGroupPassedByValue() {
+	wp := GenericWorkerPool[int]{}
+	takesGenericWorkerPoolByValue(wp) // want "struct 'wp' containing waitgroup is copied by value"
+}
+
+func BadWaitAndDoneInSameGoroutine() {
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		wg.Wait() // want "waitgroup 'wg' Wait will deadlock: same goroutine has pending Done"
+	}()
+}
+
+func BadParentDoneForWorkerGoroutine() {
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		doSomething()
+	}()
+	wg.Done() // want "waitgroup 'wg' Done called outside worker goroutine"
+	wg.Wait()
 }
 
 // Good: barrier-style waitgroup where goroutines wait and the main loop releases them with Done.

--- a/pkg/analyzer/waitgroup/behavior.go
+++ b/pkg/analyzer/waitgroup/behavior.go
@@ -214,8 +214,10 @@ func (wga *Analyzer) checkDoneOutsideWorkerForWaitGroup(wgName string) {
 	recentPositiveAdd := false
 	workerGoroutinesWithoutDone := 0
 
-	var visitStmt func(ast.Stmt)
-	var visitStmts func([]ast.Stmt)
+	var (
+		visitStmt  func(ast.Stmt)
+		visitStmts func([]ast.Stmt)
+	)
 
 	visitStmts = func(stmts []ast.Stmt) {
 		for _, stmt := range stmts {

--- a/pkg/analyzer/waitgroup/behavior.go
+++ b/pkg/analyzer/waitgroup/behavior.go
@@ -1,0 +1,469 @@
+package waitgroup
+
+import (
+	"go/ast"
+	"go/token"
+
+	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/common"
+)
+
+type waitDonePositions struct {
+	waits      []token.Pos
+	dones      []token.Pos
+	deferDones []token.Pos
+}
+
+func (wga *Analyzer) checkWaitAndDoneInSameGoroutine() {
+	ast.Inspect(wga.function.Body, func(n ast.Node) bool {
+		goStmt, ok := n.(*ast.GoStmt)
+		if !ok {
+			return true
+		}
+
+		fnLit, ok := goStmt.Call.Fun.(*ast.FuncLit)
+		if !ok || fnLit.Body == nil {
+			return true
+		}
+
+		for wgName := range wga.waitGroupNames {
+			positions := wga.collectWaitDonePositions(fnLit.Body, wgName)
+			for _, waitPos := range positions.waits {
+				if wga.waitDependsOnDoneInSameGoroutine(waitPos, positions) {
+					wga.errorCollector.AddError(waitPos, "waitgroup '"+wgName+"' Wait will deadlock: same goroutine has pending Done")
+				}
+			}
+		}
+
+		return true
+	})
+}
+
+func (wga *Analyzer) waitDependsOnDoneInSameGoroutine(waitPos token.Pos, positions waitDonePositions) bool {
+	for _, donePos := range positions.dones {
+		if donePos > waitPos {
+			return true
+		}
+	}
+	for range positions.deferDones {
+		return true
+	}
+	return false
+}
+
+func (wga *Analyzer) collectWaitDonePositions(block *ast.BlockStmt, wgName string) waitDonePositions {
+	positions := waitDonePositions{}
+
+	var visitStmt func(ast.Stmt)
+	var visitStmts func([]ast.Stmt)
+	var visitExpr func(ast.Expr)
+
+	visitStmts = func(stmts []ast.Stmt) {
+		for _, stmt := range stmts {
+			visitStmt(stmt)
+		}
+	}
+
+	visitExpr = func(expr ast.Expr) {
+		switch e := expr.(type) {
+		case *ast.CallExpr:
+			if wga.commentFilter.ShouldSkipCall(e) {
+				return
+			}
+			wga.recordWaitDoneCall(e, wgName, &positions)
+			if fnLit, ok := e.Fun.(*ast.FuncLit); ok && fnLit.Body != nil {
+				visitStmts(fnLit.Body.List)
+			}
+		case *ast.UnaryExpr:
+			visitExpr(e.X)
+		case *ast.BinaryExpr:
+			visitExpr(e.X)
+			visitExpr(e.Y)
+		case *ast.ParenExpr:
+			visitExpr(e.X)
+		}
+	}
+
+	visitStmt = func(stmt ast.Stmt) {
+		if stmt == nil || wga.commentFilter.ShouldSkipStatement(stmt) {
+			return
+		}
+
+		switch s := stmt.(type) {
+		case *ast.ExprStmt:
+			visitExpr(s.X)
+		case *ast.DeferStmt:
+			if wga.commentFilter.ShouldSkipCall(s.Call) {
+				return
+			}
+			if wga.deferInvokesDone(s, wgName) {
+				positions.deferDones = append(positions.deferDones, s.Call.Pos())
+			}
+		case *ast.AssignStmt:
+			for _, expr := range s.Rhs {
+				visitExpr(expr)
+			}
+		case *ast.DeclStmt:
+			if gen, ok := s.Decl.(*ast.GenDecl); ok {
+				for _, spec := range gen.Specs {
+					if vs, ok := spec.(*ast.ValueSpec); ok {
+						for _, expr := range vs.Values {
+							visitExpr(expr)
+						}
+					}
+				}
+			}
+		case *ast.ReturnStmt:
+			for _, expr := range s.Results {
+				visitExpr(expr)
+			}
+		case *ast.IfStmt:
+			visitStmt(s.Init)
+			visitExpr(s.Cond)
+			visitStmts(s.Body.List)
+			wga.visitWaitDoneElse(s.Else, visitStmt, visitStmts)
+		case *ast.ForStmt:
+			visitStmt(s.Init)
+			visitExpr(s.Cond)
+			visitStmt(s.Post)
+			visitStmts(s.Body.List)
+		case *ast.RangeStmt:
+			visitExpr(s.X)
+			visitStmts(s.Body.List)
+		case *ast.BlockStmt:
+			visitStmts(s.List)
+		case *ast.LabeledStmt:
+			visitStmt(s.Stmt)
+		case *ast.SwitchStmt:
+			visitStmt(s.Init)
+			visitExpr(s.Tag)
+			for _, stmt := range s.Body.List {
+				if cc, ok := stmt.(*ast.CaseClause); ok {
+					for _, expr := range cc.List {
+						visitExpr(expr)
+					}
+					visitStmts(cc.Body)
+				}
+			}
+		case *ast.TypeSwitchStmt:
+			visitStmt(s.Init)
+			visitStmt(s.Assign)
+			for _, stmt := range s.Body.List {
+				if cc, ok := stmt.(*ast.CaseClause); ok {
+					visitStmts(cc.Body)
+				}
+			}
+		case *ast.SelectStmt:
+			for _, stmt := range s.Body.List {
+				if cc, ok := stmt.(*ast.CommClause); ok {
+					visitStmt(cc.Comm)
+					visitStmts(cc.Body)
+				}
+			}
+		}
+	}
+
+	if block != nil {
+		visitStmts(block.List)
+	}
+	return positions
+}
+
+func (wga *Analyzer) visitWaitDoneElse(stmt ast.Stmt, visitStmt func(ast.Stmt), visitStmts func([]ast.Stmt)) {
+	switch s := stmt.(type) {
+	case *ast.BlockStmt:
+		visitStmts(s.List)
+	case *ast.IfStmt:
+		visitStmt(s)
+	}
+}
+
+func (wga *Analyzer) recordWaitDoneCall(call *ast.CallExpr, wgName string, positions *waitDonePositions) {
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok || common.GetVarName(sel.X) != wgName {
+		return
+	}
+
+	switch sel.Sel.Name {
+	case "Wait":
+		positions.waits = append(positions.waits, call.Pos())
+	case "Done":
+		positions.dones = append(positions.dones, call.Pos())
+	}
+}
+
+func (wga *Analyzer) deferInvokesDone(deferStmt *ast.DeferStmt, wgName string) bool {
+	if wga.isSimpleDeferDone(deferStmt, wgName) || wga.isCallbackDeferDone(deferStmt, wgName) {
+		return true
+	}
+	if fnLit, ok := deferStmt.Call.Fun.(*ast.FuncLit); ok && fnLit.Body != nil {
+		return wga.containsDoneCall(fnLit.Body, wgName)
+	}
+	return false
+}
+
+func (wga *Analyzer) checkDoneOutsideWorkerGoroutine() {
+	for wgName := range wga.waitGroupNames {
+		wga.checkDoneOutsideWorkerForWaitGroup(wgName)
+	}
+}
+
+func (wga *Analyzer) checkDoneOutsideWorkerForWaitGroup(wgName string) {
+	pendingAdds := 0
+	// Keep this intentionally narrow: only an Add immediately followed by a
+	// worker goroutine is treated as an ownership handoff.
+	recentPositiveAdd := false
+	workerGoroutinesWithoutDone := 0
+
+	var visitStmt func(ast.Stmt)
+	var visitStmts func([]ast.Stmt)
+
+	visitStmts = func(stmts []ast.Stmt) {
+		for _, stmt := range stmts {
+			visitStmt(stmt)
+		}
+	}
+
+	visitStmt = func(stmt ast.Stmt) {
+		if stmt == nil || wga.commentFilter.ShouldSkipStatement(stmt) {
+			return
+		}
+
+		switch s := stmt.(type) {
+		case *ast.ExprStmt:
+			call, ok := s.X.(*ast.CallExpr)
+			if !ok || wga.commentFilter.ShouldSkipCall(call) {
+				return
+			}
+			if delta, ok := wga.addDelta(call, wgName); ok {
+				if delta > 0 {
+					pendingAdds += delta
+					recentPositiveAdd = true
+				}
+				return
+			}
+			if wga.callInvokesDone(call, wgName) {
+				recentPositiveAdd = false
+				if workerGoroutinesWithoutDone > 0 {
+					wga.errorCollector.AddError(call.Pos(), "waitgroup '"+wgName+"' Done called outside worker goroutine")
+					workerGoroutinesWithoutDone--
+				}
+				if pendingAdds > 0 {
+					pendingAdds--
+				}
+			}
+		case *ast.DeferStmt:
+			recentPositiveAdd = false
+			if wga.deferInvokesDone(s, wgName) {
+				if workerGoroutinesWithoutDone > 0 {
+					wga.errorCollector.AddError(s.Call.Pos(), "waitgroup '"+wgName+"' Done called outside worker goroutine")
+					workerGoroutinesWithoutDone--
+				}
+				if pendingAdds > 0 {
+					pendingAdds--
+				}
+			}
+		case *ast.GoStmt:
+			if pendingAdds <= 0 || !recentPositiveAdd {
+				recentPositiveAdd = false
+				return
+			}
+			recentPositiveAdd = false
+			doneInfo, related := wga.goroutineDoneInfo(s, wgName)
+			if related && doneInfo.hasAnyDone {
+				return
+			}
+			if wga.goroutineOnlyWaitsOnWaitGroup(s, wgName) {
+				return
+			}
+			workerGoroutinesWithoutDone++
+		case *ast.AssignStmt, *ast.DeclStmt, *ast.ReturnStmt:
+			recentPositiveAdd = false
+		case *ast.IfStmt:
+			visitStmt(s.Init)
+			visitStmts(s.Body.List)
+			wga.visitMainFlowElse(s.Else, visitStmt, visitStmts)
+			recentPositiveAdd = false
+		case *ast.ForStmt:
+			visitStmt(s.Init)
+			visitStmts(s.Body.List)
+			visitStmt(s.Post)
+			recentPositiveAdd = false
+		case *ast.RangeStmt:
+			visitStmts(s.Body.List)
+			recentPositiveAdd = false
+		case *ast.BlockStmt:
+			visitStmts(s.List)
+		case *ast.LabeledStmt:
+			visitStmt(s.Stmt)
+		case *ast.SwitchStmt:
+			visitStmt(s.Init)
+			for _, stmt := range s.Body.List {
+				if cc, ok := stmt.(*ast.CaseClause); ok {
+					visitStmts(cc.Body)
+				}
+			}
+			recentPositiveAdd = false
+		case *ast.TypeSwitchStmt:
+			visitStmt(s.Init)
+			visitStmt(s.Assign)
+			for _, stmt := range s.Body.List {
+				if cc, ok := stmt.(*ast.CaseClause); ok {
+					visitStmts(cc.Body)
+				}
+			}
+			recentPositiveAdd = false
+		case *ast.SelectStmt:
+			for _, stmt := range s.Body.List {
+				if cc, ok := stmt.(*ast.CommClause); ok {
+					visitStmt(cc.Comm)
+					visitStmts(cc.Body)
+				}
+			}
+			recentPositiveAdd = false
+		}
+	}
+
+	if wga.function.Body != nil {
+		visitStmts(wga.function.Body.List)
+	}
+}
+
+func (wga *Analyzer) visitMainFlowElse(stmt ast.Stmt, visitStmt func(ast.Stmt), visitStmts func([]ast.Stmt)) {
+	switch s := stmt.(type) {
+	case *ast.BlockStmt:
+		visitStmts(s.List)
+	case *ast.IfStmt:
+		visitStmt(s)
+	}
+}
+
+func (wga *Analyzer) addDelta(call *ast.CallExpr, wgName string) (int, bool) {
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok || sel.Sel.Name != "Add" || common.GetVarName(sel.X) != wgName {
+		return 0, false
+	}
+
+	addValue := common.GetAddValue(call)
+	if len(call.Args) > 0 {
+		if constantValue, ok := common.ConstantIntValue(call.Args[0], wga.typesInfo); ok {
+			addValue = constantValue
+		}
+	}
+	return addValue, true
+}
+
+func (wga *Analyzer) checkWaitGroupGoPanic() {
+	ast.Inspect(wga.function.Body, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok || wga.commentFilter.ShouldSkipCall(call) {
+			return true
+		}
+
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || sel.Sel.Name != "Go" {
+			return true
+		}
+		wgName := common.GetVarName(sel.X)
+		if !wga.waitGroupNames[wgName] || len(call.Args) == 0 {
+			return true
+		}
+
+		fnLit, ok := call.Args[0].(*ast.FuncLit)
+		if !ok || fnLit.Body == nil {
+			return true
+		}
+		if wga.functionLiteralMayPanic(fnLit) {
+			wga.errorCollector.AddError(call.Pos(), "waitgroup '"+wgName+"' Go function may panic")
+		}
+		return true
+	})
+}
+
+func (wga *Analyzer) functionLiteralMayPanic(fnLit *ast.FuncLit) bool {
+	if fnLit == nil || fnLit.Body == nil || wga.functionLiteralRecovers(fnLit) {
+		return false
+	}
+
+	found := false
+	ast.Inspect(fnLit.Body, func(n ast.Node) bool {
+		if found {
+			return false
+		}
+		if nested, ok := n.(*ast.FuncLit); ok && nested != fnLit {
+			return false
+		}
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		ident, ok := call.Fun.(*ast.Ident)
+		if ok && ident.Name == "panic" {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
+}
+
+func (wga *Analyzer) functionLiteralRecovers(fnLit *ast.FuncLit) bool {
+	if fnLit == nil || fnLit.Body == nil {
+		return false
+	}
+
+	found := false
+	ast.Inspect(fnLit.Body, func(n ast.Node) bool {
+		if found {
+			return false
+		}
+		if nested, ok := n.(*ast.FuncLit); ok && nested != fnLit {
+			return false
+		}
+		deferStmt, ok := n.(*ast.DeferStmt)
+		if !ok {
+			return true
+		}
+		if wga.deferCallRecovers(deferStmt.Call) {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
+}
+
+func (wga *Analyzer) deferCallRecovers(call *ast.CallExpr) bool {
+	if call == nil {
+		return false
+	}
+
+	if ident, ok := call.Fun.(*ast.Ident); ok && ident.Name == "recover" {
+		return true
+	}
+
+	fnLit, ok := call.Fun.(*ast.FuncLit)
+	if !ok || fnLit.Body == nil {
+		return false
+	}
+
+	found := false
+	ast.Inspect(fnLit.Body, func(n ast.Node) bool {
+		if found {
+			return false
+		}
+		if nested, ok := n.(*ast.FuncLit); ok && nested != fnLit {
+			return false
+		}
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		ident, ok := call.Fun.(*ast.Ident)
+		if ok && ident.Name == "recover" {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
+}

--- a/pkg/analyzer/waitgroup/validation.go
+++ b/pkg/analyzer/waitgroup/validation.go
@@ -14,6 +14,9 @@ import (
 func (wga *Analyzer) validateUsage(stats map[string]*Stats) {
 	wga.checkAddAfterWait(stats)
 	wga.checkWaitBeforeDoneSameGoroutine(stats)
+	wga.checkWaitAndDoneInSameGoroutine()
+	wga.checkDoneOutsideWorkerGoroutine()
+	wga.checkWaitGroupGoPanic()
 	wga.checkLoopAddDoneBalance()
 	wga.checkUnreachableDone()
 	wga.checkWaitGroupBalance(stats)


### PR DESCRIPTION
- Implemented lock order cycle detection in mutex analysis.
- Added checks for cross-goroutine unlocks and lock order cycles.
- Enhanced waitgroup analysis with checks for Wait and Done calls in the same goroutine.
- Introduced support for generic types in mutex and waitgroup structures.
- Added test cases for various mutex and waitgroup scenarios, including generic types and edge cases.