### PR TITLE
feat: Add advanced concurrency checks and ignore directive support

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,13 +87,26 @@ Because the tool is a standard `go/analysis` single-checker, it accepts the usua
 | `lock-without-unlock` | `sync.Mutex`, `sync.RWMutex` | A `Lock()` / `RLock()` call has no matching `Unlock()` / `RUnlock()` on some execution path. |
 | `unlock-without-lock` | `sync.Mutex`, `sync.RWMutex` | An `Unlock()` / `RUnlock()` call is reached without a prior matching lock (including double-unlocks). |
 | `defer-unlock-without-lock` | `sync.Mutex`, `sync.RWMutex` | `defer mu.Unlock()` / `defer mu.RUnlock()` is scheduled before the corresponding lock is acquired. |
+| `unchecked-trylock` | `sync.Mutex`, `sync.RWMutex` | `TryLock()` / `TryRLock()` is called without checking the returned boolean. |
+| `defer-lock` | `sync.Mutex`, `sync.RWMutex` | `defer mu.Lock()` / `defer mu.RLock()` is used where an unlock was almost certainly intended. |
+| `mutex-in-loop` | `sync.Mutex`, `sync.RWMutex` | A mutex is declared inside a loop body, creating a fresh lock per iteration. |
+| `rwmutex-api-mismatch` | `sync.RWMutex` | `Unlock()` is used for a read lock, or `RUnlock()` is used for a write lock. |
+| `goroutine-lock-deadlock` | `sync.Mutex`, `sync.RWMutex` | A goroutine is started while a lock is held and tries to take the same lock before the parent can release it. |
+| `panic-before-unlock` | `sync.Mutex`, `sync.RWMutex` | An index with a statically known out-of-range value and collection length can panic between `Lock()` and a non-deferred unlock. |
 | `add-without-done` | `sync.WaitGroup` | `wg.Add(n)` has no matching number of `Done()` calls on all paths — the counter may never reach zero. |
 | `done-without-add` | `sync.WaitGroup` | `wg.Done()` is called more times than `wg.Add()` allows, which panics at runtime. |
 | `add-after-wait` | `sync.WaitGroup` | `wg.Add()` is called after `wg.Wait()` has returned with an empty counter — a classic reuse bug. |
 | `go-after-wait` | `sync.WaitGroup` | `wg.Go()` is called after `wg.Wait()` returned empty — same family as `add-after-wait`, specific to Go 1.25's `Go` method. |
+| `add-inside-goroutine` | `sync.WaitGroup` | `wg.Add()` is called from inside a worker goroutine, racing with `Wait()`. |
+| `done-not-deferred` | `sync.WaitGroup` | A worker calls `Done()` after potentially panicking work instead of deferring it; this is intentionally conservative for user-defined calls. |
+| `add-loop-count-mismatch` | `sync.WaitGroup` | A literal `Add(n)` count does not match a statically countable loop of worker goroutines. |
+| `add-zero` | `sync.WaitGroup` | `wg.Add(0)` is a no-op and usually means the intended count was lost. |
+| `wait-without-add` | `sync.WaitGroup` | A local `WaitGroup` is waited on without any `Add()` in the same lifecycle. |
+| `multiple-done-worker` | `sync.WaitGroup` | The same worker branch can call `Done()` more than once. |
+| `nested-waitgroup-deadlock` | `sync.WaitGroup` | A worker for one `WaitGroup` waits on another whose release is blocked behind the outer `Wait()`. |
 | `package-level-primitive` | all | Any of the above, applied to package-scoped primitives declared in a different file of the same package. |
 
-All checks are enabled by default and emitted as standard `go/analysis` diagnostics.
+All checks are enabled by default and emitted as standard `go/analysis` diagnostics. To silence an intentional one-line case, put `// goconcurrencylint:ignore` on the same line as the call; for example, `wg.Wait() // goconcurrencylint:ignore wait-without-add`. Any text after the directive is treated as a human-readable note; today the directive silences all checks reported on that line.
 
 ## Examples
 

--- a/pkg/analyzer/common/commentfilter/filter.go
+++ b/pkg/analyzer/common/commentfilter/filter.go
@@ -7,18 +7,28 @@ import (
 	"strings"
 )
 
+const ignoreDirective = "goconcurrencylint:ignore"
+
 // CommentFilter helps filter out code that is within comments
 type CommentFilter struct {
-	fileSet  *token.FileSet
-	comments []*ast.CommentGroup
+	fileSet              *token.FileSet
+	comments             []*ast.CommentGroup
+	ignoreDirectiveLines map[int]bool
 }
 
 // NewCommentFilter creates a new comment filter
 func NewCommentFilter(fset *token.FileSet, file *ast.File) *CommentFilter {
-	return &CommentFilter{
-		fileSet:  fset,
-		comments: file.Comments,
+	var comments []*ast.CommentGroup
+	if file != nil {
+		comments = file.Comments
 	}
+	cf := &CommentFilter{
+		fileSet:              fset,
+		comments:             comments,
+		ignoreDirectiveLines: make(map[int]bool),
+	}
+	cf.indexIgnoreDirectiveLines()
+	return cf
 }
 
 // IsInComment checks if a position is within a comment
@@ -43,12 +53,56 @@ func (cf *CommentFilter) IsInComment(pos token.Pos) bool {
 
 // ShouldSkipCall checks if a call expression should be skipped
 func (cf *CommentFilter) ShouldSkipCall(call *ast.CallExpr) bool {
-	return cf.IsInComment(call.Pos())
+	return cf.IsInComment(call.Pos()) || cf.HasIgnoreDirective(call.Pos())
 }
 
 // ShouldSkipStatement checks if an entire statement should be skipped
 func (cf *CommentFilter) ShouldSkipStatement(stmt ast.Stmt) bool {
-	return cf.IsInComment(stmt.Pos())
+	return cf.IsInComment(stmt.Pos()) || cf.HasIgnoreDirective(stmt.Pos())
+}
+
+// HasIgnoreDirective checks whether a goconcurrencylint ignore directive is on
+// the same line as the given position.
+func (cf *CommentFilter) HasIgnoreDirective(pos token.Pos) bool {
+	if pos == token.NoPos || cf.fileSet == nil {
+		return false
+	}
+
+	position := cf.fileSet.Position(pos)
+	return cf.ignoreDirectiveLines[position.Line]
+}
+
+func (cf *CommentFilter) indexIgnoreDirectiveLines() {
+	if cf.fileSet == nil {
+		return
+	}
+
+	for _, group := range cf.comments {
+		for _, comment := range group.List {
+			commentStart := cf.fileSet.Position(comment.Pos())
+			for lineOffset, textLine := range strings.Split(comment.Text, "\n") {
+				if hasIgnoreDirective(textLine) {
+					cf.ignoreDirectiveLines[commentStart.Line+lineOffset] = true
+				}
+			}
+		}
+	}
+}
+
+func hasIgnoreDirective(textLine string) bool {
+	start := 0
+	for {
+		idx := strings.Index(textLine[start:], ignoreDirective)
+		if idx < 0 {
+			return false
+		}
+
+		after := textLine[start+idx+len(ignoreDirective):]
+		if after == "" || after[0] == ' ' || after[0] == '\t' || strings.HasPrefix(after, "*/") {
+			return true
+		}
+		start += idx + len(ignoreDirective)
+	}
 }
 
 // positionInComment checks if a position is within a specific comment

--- a/pkg/analyzer/common/commentfilter/filter_test.go
+++ b/pkg/analyzer/common/commentfilter/filter_test.go
@@ -639,3 +639,69 @@ func main() {
 		return true
 	})
 }
+
+func TestCommentFilter_IgnoreDirectiveOnSameLine(t *testing.T) {
+	src := `package main
+
+func main() {
+	wg.Wait() // goconcurrencylint:ignore wait-without-add
+	wg.Wait()
+}
+`
+
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "test.go", src, parser.ParseComments)
+	require.NoError(t, err)
+
+	cf := NewCommentFilter(fset, file)
+	var skipped, reported int
+	ast.Inspect(file, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		if cf.ShouldSkipCall(call) {
+			skipped++
+			return true
+		}
+		reported++
+		return true
+	})
+
+	assert.Equal(t, 1, skipped)
+	assert.Equal(t, 1, reported)
+}
+
+func TestCommentFilter_IgnoreDirectiveRequiresBoundary(t *testing.T) {
+	src := `package main
+
+func main() {
+	wg.Wait() // see goconcurrencylint:ignore-rationale
+	wg.Wait() // goconcurrencylint:ignored-list
+	wg.Wait() // goconcurrencylint:ignore
+	wg.Wait()
+}
+`
+
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "test.go", src, parser.ParseComments)
+	require.NoError(t, err)
+
+	cf := NewCommentFilter(fset, file)
+	var skipped, reported int
+	ast.Inspect(file, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		if cf.ShouldSkipCall(call) {
+			skipped++
+			return true
+		}
+		reported++
+		return true
+	})
+
+	assert.Equal(t, 1, skipped)
+	assert.Equal(t, 3, reported)
+}

--- a/pkg/analyzer/mutex/analyzer.go
+++ b/pkg/analyzer/mutex/analyzer.go
@@ -13,19 +13,40 @@ import (
 
 // Analyzer handles the analysis of mutex and rwmutex usage
 type Analyzer struct {
-	mutexNames      map[string]bool
-	rwMutexNames    map[string]bool
-	errorCollector  *report.ErrorCollector
-	stats           map[string]*Stats
-	deferErrors     *deferErrorCollector
-	commentFilter   *commnetfilter.CommentFilter
-	function        *ast.FuncDecl
-	typesInfo       *types.Info
-	rawBodyEffects  bool
-	receiverMethods map[string]map[string]*ast.FuncDecl
-	functions       []*ast.FuncDecl
-	simulationStack map[methodSimulationKey]bool
-	localFuncStack  map[*ast.FuncLit]bool
+	mutexNames             map[string]bool
+	rwMutexNames           map[string]bool
+	errorCollector         *report.ErrorCollector
+	stats                  map[string]*Stats
+	deferErrors            *deferErrorCollector
+	commentFilter          *commnetfilter.CommentFilter
+	function               *ast.FuncDecl
+	typesInfo              *types.Info
+	rawBodyEffects         bool
+	receiverMethods        map[string]map[string]*ast.FuncDecl
+	functions              []*ast.FuncDecl
+	simulationStack        map[methodSimulationKey]bool
+	localFuncStack         map[*ast.FuncLit]bool
+	goroutineLockConflicts []goroutineLockConflict
+	tryLockResults         map[string]*tryLockResult
+	collectionLengths      map[string]int
+}
+
+// goroutineLockConflict records a goroutine that was launched while the parent
+// held a mutex that the goroutine also tries to acquire.
+type goroutineLockConflict struct {
+	varName        string
+	pos            token.Pos
+	isRWMutex      bool
+	parentReadLock bool
+	requestMethod  string
+}
+
+type tryLockResult struct {
+	varName   string
+	method    string
+	pos       token.Pos
+	checked   bool
+	isRWMutex bool
 }
 
 type methodSimulationKey struct {
@@ -70,9 +91,18 @@ func NewAnalyzer(mutexNames, rwMutexNames map[string]bool, errorCollector *repor
 // AnalyzeFunction analyzes mutex usage in a function
 func (ma *Analyzer) AnalyzeFunction(fn *ast.FuncDecl) {
 	ma.function = fn
+	ma.rawBodyEffects = false
+	ma.goroutineLockConflicts = nil
+	ma.tryLockResults = make(map[string]*tryLockResult)
+	ma.collectionLengths = make(map[string]int)
+	ma.deferErrors = &deferErrorCollector{
+		badDeferUnlock:  make(map[string]bool),
+		badDeferRUnlock: make(map[string]bool),
+	}
 	ma.initializeStats()
 	ma.checkLockOrderCycles(fn.Body)
 	finalStats := ma.analyzeBlock(fn.Body, ma.stats)
+	ma.reportUncheckedTryLockResults()
 	ma.reportUnmatchedLocks(finalStats)
 }
 

--- a/pkg/analyzer/mutex/behavior.go
+++ b/pkg/analyzer/mutex/behavior.go
@@ -3,6 +3,7 @@ package mutex
 import (
 	"go/ast"
 	"go/token"
+	"go/types"
 	"sort"
 
 	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/common"
@@ -414,4 +415,209 @@ func cloneIntMap(src map[string]int) map[string]int {
 		dst[k] = v
 	}
 	return dst
+}
+
+// goroutineBodyLockCallMethod returns the first direct lock method call found
+// for varName. Nested goroutines are not traversed so we only flag cases that
+// are directly reachable in this goroutine's frame.
+func (ma *Analyzer) goroutineBodyLockCallMethod(body *ast.BlockStmt, varName string, methodNames []string) (string, bool) {
+	var foundMethod string
+	ast.Inspect(body, func(n ast.Node) bool {
+		if foundMethod != "" {
+			return false
+		}
+		if _, ok := n.(*ast.GoStmt); ok {
+			return false // don't recurse into nested goroutines
+		}
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		if containsMethod(methodNames, sel.Sel.Name) && common.GetVarName(sel.X) == varName {
+			foundMethod = sel.Sel.Name
+			return false
+		}
+		return true
+	})
+	return foundMethod, foundMethod != ""
+}
+
+func (ma *Analyzer) rwMutexRequestDescription(methodName string) string {
+	switch methodName {
+	case "RLock", "TryRLock":
+		return "read lock"
+	default:
+		return "write lock"
+	}
+}
+
+func (ma *Analyzer) goroutineLockDeadlockMessage(varName string, isRWMutex bool, parentReadLock bool, requestMethod string, parentBlocks bool) string {
+	if !isRWMutex {
+		if parentBlocks {
+			return "mutex '" + varName + "' goroutine started while lock is held and also tries to acquire it before parent unlocks"
+		}
+		return "mutex '" + varName + "' goroutine started while lock is held and also tries to acquire it, will deadlock if parent never releases"
+	}
+
+	if parentReadLock {
+		if parentBlocks {
+			return "rwmutex '" + varName + "' goroutine started while read lock is held and also tries to acquire write lock before parent runlocks"
+		}
+		return "rwmutex '" + varName + "' goroutine started while read lock is held and also tries to acquire write lock, will deadlock if parent never runlocks"
+	}
+
+	requestDescription := ma.rwMutexRequestDescription(requestMethod)
+	if parentBlocks {
+		return "rwmutex '" + varName + "' goroutine started while write lock is held and also tries to acquire " + requestDescription + " before parent unlocks"
+	}
+	return "rwmutex '" + varName + "' goroutine started while write lock is held and also tries to acquire " + requestDescription + ", will deadlock if parent never releases"
+}
+
+func (ma *Analyzer) parentBlocksBeforeUnlock(goPos token.Pos, varName string, unlockMethods []string) bool {
+	if ma.function == nil || ma.function.Body == nil {
+		return false
+	}
+	return ma.blockBlocksBeforeUnlock(ma.function.Body.List, goPos, varName, unlockMethods)
+}
+
+func (ma *Analyzer) blockBlocksBeforeUnlock(stmts []ast.Stmt, goPos token.Pos, varName string, unlockMethods []string) bool {
+	for i, stmt := range stmts {
+		if stmt == nil {
+			continue
+		}
+		if stmt.Pos() == goPos {
+			return ma.followingStatementsBlockBeforeUnlock(stmts[i+1:], varName, unlockMethods)
+		}
+
+		switch s := stmt.(type) {
+		case *ast.BlockStmt:
+			if ma.blockBlocksBeforeUnlock(s.List, goPos, varName, unlockMethods) {
+				return true
+			}
+		case *ast.IfStmt:
+			if ma.blockBlocksBeforeUnlock(s.Body.List, goPos, varName, unlockMethods) {
+				return true
+			}
+			if ma.elseBlocksBeforeUnlock(s.Else, goPos, varName, unlockMethods) {
+				return true
+			}
+		case *ast.ForStmt:
+			if s.Body != nil && ma.blockBlocksBeforeUnlock(s.Body.List, goPos, varName, unlockMethods) {
+				return true
+			}
+		case *ast.RangeStmt:
+			if s.Body != nil && ma.blockBlocksBeforeUnlock(s.Body.List, goPos, varName, unlockMethods) {
+				return true
+			}
+		case *ast.SwitchStmt:
+			for _, clause := range s.Body.List {
+				if cc, ok := clause.(*ast.CaseClause); ok && ma.blockBlocksBeforeUnlock(cc.Body, goPos, varName, unlockMethods) {
+					return true
+				}
+			}
+		case *ast.TypeSwitchStmt:
+			for _, clause := range s.Body.List {
+				if cc, ok := clause.(*ast.CaseClause); ok && ma.blockBlocksBeforeUnlock(cc.Body, goPos, varName, unlockMethods) {
+					return true
+				}
+			}
+		case *ast.SelectStmt:
+			for _, clause := range s.Body.List {
+				if cc, ok := clause.(*ast.CommClause); ok && ma.blockBlocksBeforeUnlock(cc.Body, goPos, varName, unlockMethods) {
+					return true
+				}
+			}
+		case *ast.LabeledStmt:
+			if ma.blockBlocksBeforeUnlock([]ast.Stmt{s.Stmt}, goPos, varName, unlockMethods) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (ma *Analyzer) elseBlocksBeforeUnlock(stmt ast.Stmt, goPos token.Pos, varName string, unlockMethods []string) bool {
+	switch s := stmt.(type) {
+	case *ast.BlockStmt:
+		return ma.blockBlocksBeforeUnlock(s.List, goPos, varName, unlockMethods)
+	case *ast.IfStmt:
+		return ma.blockBlocksBeforeUnlock([]ast.Stmt{s}, goPos, varName, unlockMethods)
+	default:
+		return false
+	}
+}
+
+func (ma *Analyzer) followingStatementsBlockBeforeUnlock(stmts []ast.Stmt, varName string, unlockMethods []string) bool {
+	for _, stmt := range stmts {
+		if stmt == nil || ma.commentFilter.ShouldSkipStatement(stmt) {
+			continue
+		}
+		if ma.statementUnlocks(stmt, varName, unlockMethods) {
+			return false
+		}
+		if ma.statementMayBlock(stmt) {
+			return true
+		}
+	}
+	return false
+}
+
+func (ma *Analyzer) statementUnlocks(stmt ast.Stmt, varName string, unlockMethods []string) bool {
+	exprStmt, ok := stmt.(*ast.ExprStmt)
+	if !ok {
+		return false
+	}
+	call, ok := exprStmt.X.(*ast.CallExpr)
+	if !ok || ma.commentFilter.ShouldSkipCall(call) {
+		return false
+	}
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	return ok && common.GetVarName(sel.X) == varName && containsMethod(unlockMethods, sel.Sel.Name)
+}
+
+func (ma *Analyzer) statementMayBlock(stmt ast.Stmt) bool {
+	switch s := stmt.(type) {
+	case *ast.ExprStmt:
+		if unary, ok := s.X.(*ast.UnaryExpr); ok && unary.Op == token.ARROW {
+			return true
+		}
+		if call, ok := s.X.(*ast.CallExpr); ok {
+			return ma.callMayBlock(call)
+		}
+	case *ast.SelectStmt:
+		return true
+	}
+	return false
+}
+
+func (ma *Analyzer) callMayBlock(call *ast.CallExpr) bool {
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok || sel.Sel.Name != "Wait" || ma.typesInfo == nil {
+		return false
+	}
+
+	return isSyncWaitReceiver(ma.typesInfo.TypeOf(sel.X))
+}
+
+func isSyncWaitReceiver(typ types.Type) bool {
+	if typ == nil {
+		return false
+	}
+	if ptr, ok := types.Unalias(typ).(*types.Pointer); ok {
+		typ = ptr.Elem()
+	}
+	named, ok := types.Unalias(typ).(*types.Named)
+	if !ok || named.Obj() == nil || named.Obj().Pkg() == nil || named.Obj().Pkg().Path() != "sync" {
+		return false
+	}
+	switch named.Obj().Name() {
+	case "WaitGroup", "Cond":
+		return true
+	default:
+		return false
+	}
 }

--- a/pkg/analyzer/mutex/panic.go
+++ b/pkg/analyzer/mutex/panic.go
@@ -1,0 +1,176 @@
+package mutex
+
+import (
+	"go/ast"
+	"go/token"
+	"go/types"
+	"strconv"
+
+	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/common"
+)
+
+func (ma *Analyzer) reportPotentialPanicWhileLocked(stmt ast.Stmt, stats map[string]*Stats) {
+	if ma.rawBodyEffects || stmt == nil || !ma.hasUnprotectedHeldLock(stats) {
+		return
+	}
+
+	var panicPos token.Pos
+	ast.Inspect(stmt, func(n ast.Node) bool {
+		if panicPos != token.NoPos {
+			return false
+		}
+		if _, ok := n.(*ast.FuncLit); ok {
+			return false
+		}
+		index, ok := n.(*ast.IndexExpr)
+		if !ok {
+			return true
+		}
+		if ma.indexExprCanPanic(index) {
+			panicPos = index.Pos()
+			return false
+		}
+		return true
+	})
+	if panicPos == token.NoPos {
+		return
+	}
+
+	for name, st := range stats {
+		if st == nil {
+			continue
+		}
+		if ma.mutexNames[name] && ma.remainingLockCount(st.lock, st.deferUnlock) > 0 {
+			ma.errorCollector.AddError(panicPos, "mutex '"+name+"' may remain locked if index expression panics before unlock")
+		}
+		if ma.rwMutexNames[name] {
+			if ma.remainingLockCount(st.lock, st.deferUnlock) > 0 {
+				ma.errorCollector.AddError(panicPos, "rwmutex '"+name+"' may remain locked if index expression panics before unlock")
+			}
+			if ma.remainingLockCount(st.rlock, st.deferRUnlock) > 0 {
+				ma.errorCollector.AddError(panicPos, "rwmutex '"+name+"' may remain rlocked if index expression panics before runlock")
+			}
+		}
+	}
+}
+
+func (ma *Analyzer) hasUnprotectedHeldLock(stats map[string]*Stats) bool {
+	for name, st := range stats {
+		if st == nil {
+			continue
+		}
+		if ma.mutexNames[name] && ma.remainingLockCount(st.lock, st.deferUnlock) > 0 {
+			return true
+		}
+		if ma.rwMutexNames[name] &&
+			(ma.remainingLockCount(st.lock, st.deferUnlock) > 0 ||
+				ma.remainingLockCount(st.rlock, st.deferRUnlock) > 0) {
+			return true
+		}
+	}
+	return false
+}
+
+func (ma *Analyzer) indexExprCanPanic(index *ast.IndexExpr) bool {
+	if index == nil {
+		return false
+	}
+	indexValue, ok := common.ConstantIntValue(index.Index, ma.typesInfo)
+	if !ok {
+		return false
+	}
+	if indexValue < 0 {
+		return true
+	}
+	length, ok := ma.staticLength(index.X)
+	return ok && indexValue >= length
+}
+
+func (ma *Analyzer) staticLength(expr ast.Expr) (int, bool) {
+	switch e := expr.(type) {
+	case *ast.Ident:
+		length, ok := ma.collectionLengths[e.Name]
+		return length, ok
+	case *ast.BasicLit:
+		if e.Kind != token.STRING {
+			return 0, false
+		}
+		value, err := strconv.Unquote(e.Value)
+		if err != nil {
+			return 0, false
+		}
+		return len(value), true
+	case *ast.CompositeLit:
+		return len(e.Elts), true
+	case *ast.CallExpr:
+		return ma.staticMakeLength(e)
+	}
+
+	typ := ma.typesInfo.TypeOf(expr)
+	if array, ok := types.Unalias(typ).(*types.Array); ok {
+		return int(array.Len()), true
+	}
+	return 0, false
+}
+
+func (ma *Analyzer) staticMakeLength(call *ast.CallExpr) (int, bool) {
+	if call == nil || len(call.Args) < 2 {
+		return 0, false
+	}
+	ident, ok := call.Fun.(*ast.Ident)
+	if !ok || ident.Name != "make" {
+		return 0, false
+	}
+	return common.ConstantIntValue(call.Args[1], ma.typesInfo)
+}
+
+func (ma *Analyzer) recordCollectionLengthsFromDecl(stmt *ast.DeclStmt) {
+	if stmt == nil {
+		return
+	}
+	gen, ok := stmt.Decl.(*ast.GenDecl)
+	if !ok {
+		return
+	}
+	for _, spec := range gen.Specs {
+		vs, ok := spec.(*ast.ValueSpec)
+		if !ok {
+			continue
+		}
+		for i, name := range vs.Names {
+			if i >= len(vs.Values) {
+				delete(ma.collectionLengths, name.Name)
+				continue
+			}
+			ma.recordCollectionLength(name.Name, vs.Values[i])
+		}
+	}
+}
+
+func (ma *Analyzer) recordCollectionLengthsFromAssign(stmt *ast.AssignStmt) {
+	if stmt == nil || (stmt.Tok != token.ASSIGN && stmt.Tok != token.DEFINE) {
+		return
+	}
+	for i, lhs := range stmt.Lhs {
+		ident, ok := lhs.(*ast.Ident)
+		if !ok || ident.Name == "_" {
+			continue
+		}
+		if i >= len(stmt.Rhs) {
+			delete(ma.collectionLengths, ident.Name)
+			continue
+		}
+		ma.recordCollectionLength(ident.Name, stmt.Rhs[i])
+	}
+}
+
+func (ma *Analyzer) recordCollectionLength(name string, expr ast.Expr) {
+	if ma.collectionLengths == nil {
+		ma.collectionLengths = make(map[string]int)
+	}
+	if length, ok := ma.staticLength(expr); ok {
+		ma.collectionLengths[name] = length
+		return
+	}
+	delete(ma.collectionLengths, name)
+}

--- a/pkg/analyzer/mutex/stats.go
+++ b/pkg/analyzer/mutex/stats.go
@@ -26,10 +26,17 @@ func (ma *Analyzer) analyzeBlock(block *ast.BlockStmt, initial map[string]*Stats
 func (ma *Analyzer) analyzeStatement(stmt ast.Stmt, stats map[string]*Stats) {
 	switch s := stmt.(type) {
 	case *ast.ExprStmt:
+		ma.reportPotentialPanicWhileLocked(s, stats)
 		ma.analyzeExpressionStatement(s, stats)
+	case *ast.AssignStmt:
+		ma.analyzeAssignStatement(s, stats)
+	case *ast.DeclStmt:
+		ma.analyzeDeclStatement(s, stats)
 	case *ast.DeferStmt:
 		ma.analyzeDeferStatement(s, stats)
 	case *ast.ReturnStmt:
+		ma.markReturnedTryLockResultsChecked(s)
+		ma.reportPotentialPanicWhileLocked(s, stats)
 		ma.analyzeReturnStatement(s, stats)
 	case *ast.IfStmt:
 		ma.analyzeIfStatement(s, stats)
@@ -81,6 +88,26 @@ func (ma *Analyzer) analyzeExpressionStatement(stmt *ast.ExprStmt, stats map[str
 	}
 
 	varName := common.GetVarName(sel.X)
+
+	// When a TryLock/TryRLock return value is ignored, the caller has no way to
+	// know whether the lock was actually acquired, so any subsequent operation
+	// that assumes the lock is held is racy.
+	switch sel.Sel.Name {
+	case "TryLock":
+		if ma.mutexNames[varName] {
+			ma.errorCollector.AddError(call.Pos(), "mutex '"+varName+"' TryLock return value not checked, lock may not be held")
+			return
+		}
+		if ma.rwMutexNames[varName] {
+			ma.errorCollector.AddError(call.Pos(), "rwmutex '"+varName+"' TryLock return value not checked, lock may not be held")
+			return
+		}
+	case "TryRLock":
+		if ma.rwMutexNames[varName] {
+			ma.errorCollector.AddError(call.Pos(), "rwmutex '"+varName+"' TryRLock return value not checked, lock may not be held")
+			return
+		}
+	}
 
 	if ma.mutexNames[varName] {
 		ma.handleMutexCall(varName, sel.Sel.Name, call.Pos(), stats)
@@ -160,6 +187,14 @@ func (ma *Analyzer) handleRWMutexCall(varName, methodName string, pos token.Pos,
 		stats[varName].lock++
 		stats[varName].lockPos = append(stats[varName].lockPos, pos)
 	case "Unlock":
+		// Unlock called when only a read lock is held.
+		// Correct the state as if RUnlock was called to avoid cascading errors.
+		if stats[varName].rlock > 0 && stats[varName].lock == 0 {
+			ma.errorCollector.AddError(pos, "rwmutex '"+varName+"' Unlock called but only read lock is held, did you mean RUnlock?")
+			stats[varName].rlock--
+			ma.removeFirstRLockPos(stats[varName])
+			return
+		}
 		if stats[varName].lock == 0 {
 			if ma.isCarriedLoopUnlock(varName, pos, []string{"Lock", "TryLock"}, []string{"Unlock"}) {
 				return
@@ -179,6 +214,14 @@ func (ma *Analyzer) handleRWMutexCall(varName, methodName string, pos token.Pos,
 		stats[varName].rlock++
 		stats[varName].rlockPos = append(stats[varName].rlockPos, pos)
 	case "RUnlock":
+		// RUnlock called when only a write lock is held.
+		// Correct the state as if Unlock was called to avoid cascading errors.
+		if stats[varName].lock > 0 && stats[varName].rlock == 0 {
+			ma.errorCollector.AddError(pos, "rwmutex '"+varName+"' RUnlock called but only write lock is held, did you mean Unlock?")
+			stats[varName].lock--
+			ma.removeFirstLockPos(stats[varName])
+			return
+		}
 		if stats[varName].rlock == 0 {
 			if ma.isCarriedLoopUnlock(varName, pos, []string{"RLock", "TryRLock"}, []string{"RUnlock"}) {
 				return
@@ -232,6 +275,23 @@ func (ma *Analyzer) analyzeDeferStatement(stmt *ast.DeferStmt, stats map[string]
 // handleDeferCall processes direct defer calls
 func (ma *Analyzer) handleDeferCall(call *ast.SelectorExpr, pos token.Pos, stats map[string]*Stats) {
 	varName := common.GetVarName(call.X)
+
+	// defer Lock / defer RLock re-acquires the lock on
+	// function return instead of releasing it, guaranteed deadlock.
+	if ma.mutexNames[varName] && call.Sel.Name == "Lock" {
+		ma.errorCollector.AddError(pos, "mutex '"+varName+"' defer calls Lock instead of Unlock, will deadlock on return")
+		return
+	}
+	if ma.rwMutexNames[varName] {
+		switch call.Sel.Name {
+		case "Lock":
+			ma.errorCollector.AddError(pos, "rwmutex '"+varName+"' defer calls Lock instead of Unlock, will deadlock on return")
+			return
+		case "RLock":
+			ma.errorCollector.AddError(pos, "rwmutex '"+varName+"' defer calls RLock instead of RUnlock, will deadlock on return")
+			return
+		}
+	}
 
 	if ma.mutexNames[varName] && call.Sel.Name == "Unlock" {
 		ma.handleDeferUnlock(varName, pos, stats, false)

--- a/pkg/analyzer/mutex/trylock.go
+++ b/pkg/analyzer/mutex/trylock.go
@@ -1,0 +1,124 @@
+package mutex
+
+import (
+	"go/ast"
+
+	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/common"
+)
+
+func (ma *Analyzer) analyzeAssignStatement(stmt *ast.AssignStmt, stats map[string]*Stats) {
+	ma.recordCollectionLengthsFromAssign(stmt)
+	ma.reportPotentialPanicWhileLocked(stmt, stats)
+
+	for i, rhs := range stmt.Rhs {
+		call, ok := rhs.(*ast.CallExpr)
+		if !ok {
+			continue
+		}
+		result := ma.tryLockResultFromCall(call)
+		if result == nil {
+			continue
+		}
+		if i >= len(stmt.Lhs) {
+			ma.reportUncheckedTryLockResult(result)
+			continue
+		}
+		ident, ok := stmt.Lhs[i].(*ast.Ident)
+		if !ok || ident.Name == "_" {
+			ma.reportUncheckedTryLockResult(result)
+			continue
+		}
+		if ma.tryLockResults == nil {
+			ma.tryLockResults = make(map[string]*tryLockResult)
+		}
+		ma.tryLockResults[ident.Name] = result
+	}
+}
+
+func (ma *Analyzer) analyzeDeclStatement(stmt *ast.DeclStmt, stats map[string]*Stats) {
+	ma.recordCollectionLengthsFromDecl(stmt)
+	ma.reportPotentialPanicWhileLocked(stmt, stats)
+}
+
+func (ma *Analyzer) tryLockResultFromCall(call *ast.CallExpr) *tryLockResult {
+	if call == nil || ma.commentFilter.ShouldSkipCall(call) {
+		return nil
+	}
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return nil
+	}
+
+	varName := common.GetVarName(sel.X)
+	switch sel.Sel.Name {
+	case "TryLock":
+		if ma.mutexNames[varName] {
+			return &tryLockResult{varName: varName, method: "TryLock", pos: call.Pos()}
+		}
+		if ma.rwMutexNames[varName] {
+			return &tryLockResult{varName: varName, method: "TryLock", pos: call.Pos(), isRWMutex: true}
+		}
+	case "TryRLock":
+		if ma.rwMutexNames[varName] {
+			return &tryLockResult{varName: varName, method: "TryRLock", pos: call.Pos(), isRWMutex: true}
+		}
+	}
+	return nil
+}
+
+func (ma *Analyzer) markReturnedTryLockResultsChecked(stmt *ast.ReturnStmt) {
+	for _, result := range stmt.Results {
+		ident, ok := result.(*ast.Ident)
+		if !ok {
+			continue
+		}
+		if tryResult := ma.tryLockResults[ident.Name]; tryResult != nil {
+			tryResult.checked = true
+		}
+	}
+}
+
+func (ma *Analyzer) reportUncheckedTryLockResults() {
+	for _, result := range ma.tryLockResults {
+		if result != nil && !result.checked {
+			ma.reportUncheckedTryLockResult(result)
+		}
+	}
+}
+
+func (ma *Analyzer) reportUncheckedTryLockResult(result *tryLockResult) {
+	if result == nil {
+		return
+	}
+	mutexType := "mutex"
+	if result.isRWMutex {
+		mutexType = "rwmutex"
+	}
+	ma.errorCollector.AddError(result.pos, mutexType+" '"+result.varName+"' "+result.method+" return value not checked, lock may not be held")
+}
+
+func (ma *Analyzer) applyTryLockResultToBranch(cond ast.Expr, stats map[string]*Stats) bool {
+	ident, ok := cond.(*ast.Ident)
+	if !ok {
+		return false
+	}
+	result := ma.tryLockResults[ident.Name]
+	if result == nil {
+		return false
+	}
+
+	result.checked = true
+	st := stats[result.varName]
+	if st == nil {
+		return true
+	}
+	switch result.method {
+	case "TryLock":
+		st.lock++
+		st.lockPos = append(st.lockPos, result.pos)
+	case "TryRLock":
+		st.rlock++
+		st.rlockPos = append(st.rlockPos, result.pos)
+	}
+	return true
+}

--- a/pkg/analyzer/mutex/validation.go
+++ b/pkg/analyzer/mutex/validation.go
@@ -3,6 +3,7 @@ package mutex
 import (
 	"go/ast"
 	"go/token"
+	"go/types"
 	"maps"
 
 	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/common"
@@ -34,6 +35,7 @@ func (ma *Analyzer) handleDeferRUnlock(varName string, pos token.Pos, stats map[
 
 // analyzeRangeStatement handles range statements
 func (ma *Analyzer) analyzeRangeStatement(stmt *ast.RangeStmt, stats map[string]*Stats) {
+	ma.checkMutexDeclaredInLoop(stmt.Body)
 	ma.reportDeferredUnlocksInLoop(stmt.Body)
 	rangeStats := ma.analyzeBlock(stmt.Body, stats)
 	ma.replaceStats(stats, rangeStats)
@@ -89,6 +91,10 @@ func (ma *Analyzer) analyzeIfStatement(stmt *ast.IfStmt, stats map[string]*Stats
 		return
 	}
 
+	if stmt.Init != nil {
+		ma.analyzeStatement(stmt.Init, stats)
+	}
+
 	if condValue, ok := common.ConstantBoolValue(stmt.Cond, ma.typesInfo); ok {
 		if condValue {
 			thenStats := ma.analyzeBlock(stmt.Body, stats)
@@ -130,6 +136,10 @@ func (ma *Analyzer) branchInitialStatsForCondition(cond ast.Expr, stats map[stri
 	if unary, ok := cond.(*ast.UnaryExpr); ok && unary.Op == token.NOT {
 		negatedThen, negatedElse := ma.branchInitialStatsForCondition(unary.X, stats)
 		return negatedElse, negatedThen
+	}
+
+	if ma.applyTryLockResultToBranch(cond, thenStats) {
+		return thenStats, elseStats
 	}
 
 	call, ok := cond.(*ast.CallExpr)
@@ -209,6 +219,44 @@ func (ma *Analyzer) analyzeGoStatement(stmt *ast.GoStmt, stats map[string]*Stats
 	}
 
 	if fnLit, ok := stmt.Call.Fun.(*ast.FuncLit); ok {
+		// Record goroutines launched while a mutex is held that also try to
+		// acquire the same mutex. The conflict is reported at function exit if
+		// the parent still holds the lock.
+		for varName := range ma.mutexNames {
+			if stats[varName] != nil && stats[varName].lock > 0 {
+				if method, ok := ma.goroutineBodyLockCallMethod(fnLit.Body, varName, []string{"Lock"}); ok {
+					if ma.parentBlocksBeforeUnlock(stmt.Pos(), varName, []string{"Unlock"}) {
+						ma.errorCollector.AddError(stmt.Pos(),
+							ma.goroutineLockDeadlockMessage(varName, false, false, method, true))
+						continue
+					}
+					ma.goroutineLockConflicts = append(ma.goroutineLockConflicts, goroutineLockConflict{varName: varName, pos: stmt.Pos(), requestMethod: method})
+				}
+			}
+		}
+		for varName := range ma.rwMutexNames {
+			if stats[varName] != nil && stats[varName].lock > 0 {
+				if method, ok := ma.goroutineBodyLockCallMethod(fnLit.Body, varName, []string{"Lock", "RLock"}); ok {
+					if ma.parentBlocksBeforeUnlock(stmt.Pos(), varName, []string{"Unlock"}) {
+						ma.errorCollector.AddError(stmt.Pos(),
+							ma.goroutineLockDeadlockMessage(varName, true, false, method, true))
+						continue
+					}
+					ma.goroutineLockConflicts = append(ma.goroutineLockConflicts, goroutineLockConflict{varName: varName, pos: stmt.Pos(), isRWMutex: true, requestMethod: method})
+				}
+			}
+			if stats[varName] != nil && stats[varName].rlock > 0 {
+				if method, ok := ma.goroutineBodyLockCallMethod(fnLit.Body, varName, []string{"Lock"}); ok {
+					if ma.parentBlocksBeforeUnlock(stmt.Pos(), varName, []string{"RUnlock"}) {
+						ma.errorCollector.AddError(stmt.Pos(),
+							ma.goroutineLockDeadlockMessage(varName, true, true, method, true))
+						continue
+					}
+					ma.goroutineLockConflicts = append(ma.goroutineLockConflicts, goroutineLockConflict{varName: varName, pos: stmt.Pos(), isRWMutex: true, parentReadLock: true, requestMethod: method})
+				}
+			}
+		}
+
 		crossReleases := ma.reportCrossGoroutineReleases(fnLit.Body, stats)
 		goInitial := ma.emptyStatsLike(stats)
 		goStats := ma.analyzeBlock(fnLit.Body, goInitial)
@@ -227,6 +275,7 @@ func (ma *Analyzer) analyzeForStatement(stmt *ast.ForStmt, stats map[string]*Sta
 		return
 	}
 
+	ma.checkMutexDeclaredInLoop(stmt.Body)
 	ma.reportDeferredUnlocksInLoop(stmt.Body)
 	forStats := ma.analyzeBlock(stmt.Body, stats)
 	ma.applyLoopExitLocks(stmt, stats, forStats)
@@ -803,5 +852,101 @@ func (ma *Analyzer) reportUnmatchedLocks(stats map[string]*Stats) {
 			continue
 		}
 		ma.reportUnmatchedMutexLocks(rwMutexName, stats[rwMutexName], true)
+	}
+
+	// Report goroutine-parent deadlocks only when the parent exits while still
+	// holding the lock, so the goroutine can never acquire it.
+	for _, conflict := range ma.goroutineLockConflicts {
+		st := stats[conflict.varName]
+		if st == nil {
+			continue
+		}
+		if conflict.parentReadLock {
+			if ma.remainingLockCount(st.rlock, st.deferRUnlock) > 0 {
+				ma.errorCollector.AddError(conflict.pos,
+					ma.goroutineLockDeadlockMessage(conflict.varName, true, true, conflict.requestMethod, false))
+			}
+			continue
+		}
+
+		if ma.remainingLockCount(st.lock, st.deferUnlock) > 0 {
+			ma.errorCollector.AddError(conflict.pos,
+				ma.goroutineLockDeadlockMessage(conflict.varName, conflict.isRWMutex, false, conflict.requestMethod, false))
+		}
+	}
+}
+
+// checkMutexDeclaredInLoop reports sync.Mutex / sync.RWMutex variables that are
+// declared directly inside a loop body.  Each iteration creates a fresh mutex
+// that is invisible to other iterations and therefore cannot protect shared state.
+// Only the top-level statements of the loop body are examined; nested loops are
+// handled when they themselves are analysed as for/range statements.
+// Function literals inside the loop are skipped to avoid false positives for
+// patterns like `for { go func() { var mu sync.Mutex; … }() }`.
+func (ma *Analyzer) checkMutexDeclaredInLoop(loopBody *ast.BlockStmt) {
+	if loopBody == nil || ma.typesInfo == nil {
+		return
+	}
+	for _, stmt := range loopBody.List {
+		switch s := stmt.(type) {
+		case *ast.DeclStmt:
+			gen, ok := s.Decl.(*ast.GenDecl)
+			if !ok {
+				continue
+			}
+			for _, spec := range gen.Specs {
+				vs, ok := spec.(*ast.ValueSpec)
+				if !ok {
+					continue
+				}
+				ma.reportMutexInLoopValueSpec(vs)
+			}
+		case *ast.AssignStmt:
+			if s.Tok == token.DEFINE {
+				ma.reportMutexInLoopAssign(s)
+			}
+		}
+	}
+}
+
+func (ma *Analyzer) reportMutexInLoopValueSpec(vs *ast.ValueSpec) {
+	for _, name := range vs.Names {
+		obj := ma.typesInfo.Defs[name]
+		if obj == nil {
+			continue
+		}
+		typ := obj.Type()
+		switch {
+		case common.IsMutex(typ):
+			ma.errorCollector.AddError(name.Pos(),
+				"mutex '"+name.Name+"' declared inside loop, each iteration creates a new mutex that cannot protect shared state")
+		case common.IsRWMutex(typ):
+			ma.errorCollector.AddError(name.Pos(),
+				"rwmutex '"+name.Name+"' declared inside loop, each iteration creates a new mutex that cannot protect shared state")
+		}
+	}
+}
+
+func (ma *Analyzer) reportMutexInLoopAssign(s *ast.AssignStmt) {
+	for i, lhs := range s.Lhs {
+		ident, ok := lhs.(*ast.Ident)
+		if !ok || i >= len(s.Rhs) {
+			continue
+		}
+		typ := ma.typesInfo.TypeOf(s.Rhs[i])
+		if typ == nil {
+			continue
+		}
+		if ptr, ok := types.Unalias(typ).(*types.Pointer); ok {
+			typ = ptr.Elem()
+		}
+		switch {
+		case common.IsMutex(typ):
+			ma.errorCollector.AddError(ident.Pos(),
+				"mutex '"+ident.Name+"' declared inside loop, each iteration creates a new mutex that cannot protect shared state")
+		case common.IsRWMutex(typ):
+			ma.errorCollector.AddError(ident.Pos(),
+				"rwmutex '"+ident.Name+"' declared inside loop, each iteration creates a new mutex that cannot protect shared state")
+		}
 	}
 }

--- a/pkg/analyzer/testdata/src/mutex/mutex_basic_cases.go
+++ b/pkg/analyzer/testdata/src/mutex/mutex_basic_cases.go
@@ -146,6 +146,35 @@ func BadNegatedTryLockFalsePathUnlock() {
 	mu.Unlock()
 }
 
+// TryLock used as a plain statement ignores whether the lock was acquired.
+func BadTryLockIgnoredReturn() {
+	var mu sync.Mutex
+	mu.TryLock() // want "mutex 'mu' TryLock return value not checked, lock may not be held"
+	mu.Unlock()  // want "mutex 'mu' is unlocked but not locked"
+}
+
+// Assigning TryLock to blank is still an unchecked result.
+func BadTryLockAssignedToBlank() {
+	var mu sync.Mutex
+	_ = mu.TryLock() // want "mutex 'mu' TryLock return value not checked, lock may not be held"
+	mu.Unlock()      // want "mutex 'mu' is unlocked but not locked"
+}
+
+func BadTryLockStoredResultDiscarded() {
+	var mu sync.Mutex
+	ok := mu.TryLock() // want "mutex 'mu' TryLock return value not checked, lock may not be held"
+	_ = ok
+}
+
+// Storing and checking TryLock is fine.
+func GoodTryLockStoredResultChecked() {
+	var mu sync.Mutex
+	ok := mu.TryLock()
+	if ok {
+		mu.Unlock()
+	}
+}
+
 // Lock/unlock with panic recovery
 func GoodRecoverWithUnlock() {
 	var mu sync.Mutex
@@ -199,6 +228,18 @@ func BadDeferUnlockAfterPanic() {
 	mu.Lock()
 }
 
+// Defer Lock is almost always a typo for defer Unlock.
+func BadDeferLockInsteadOfUnlock() {
+	var mu sync.Mutex
+	mu.Lock()       // want "mutex 'mu' is locked but not unlocked"
+	defer mu.Lock() // want "mutex 'mu' defer calls Lock instead of Unlock, will deadlock on return"
+}
+
+func BadDeferLockWithoutPriorLock() {
+	var mu sync.Mutex
+	defer mu.Lock() // want "mutex 'mu' defer calls Lock instead of Unlock, will deadlock on return"
+}
+
 // ---------- Conditional Logic ----------
 
 // RLock + early-return-with-RUnlock in one branch + defer RUnlock in the other
@@ -236,6 +277,30 @@ func GoodRLockMutuallyExclusiveRUnlock(flush bool, p []byte) (int, error) {
 	}
 	mu.RUnlock()
 	return 0, nil
+}
+
+func BadConditionalUnlockAfterUnconditionalLock(cond bool) {
+	var mu sync.Mutex
+	mu.Lock() // want "mutex 'mu' is locked but not unlocked"
+	if cond {
+		mu.Unlock()
+	}
+}
+
+func BadIndexPanicBeforeUnlock() {
+	items := []int{1}
+	var mu sync.Mutex
+	mu.Lock()
+	_ = items[1] // want "mutex 'mu' may remain locked if index expression panics before unlock"
+	mu.Unlock()
+}
+
+func GoodIndexPanicProtectedByDeferUnlock() {
+	items := []int{1}
+	var mu sync.Mutex
+	mu.Lock()
+	defer mu.Unlock()
+	_ = items[1]
 }
 
 // Lock + early-return-Unlock + later Unlock (mutually exclusive, no defer)

--- a/pkg/analyzer/testdata/src/mutex/mutex_extended_cases.go
+++ b/pkg/analyzer/testdata/src/mutex/mutex_extended_cases.go
@@ -134,6 +134,48 @@ func GoodForLoopLockUnlock() {
 	}
 }
 
+func BadMutexDeclaredInForLoop() {
+	for i := 0; i < 10; i++ {
+		var mu sync.Mutex // want "mutex 'mu' declared inside loop, each iteration creates a new mutex that cannot protect shared state"
+		mu.Lock()
+		mu.Unlock()
+	}
+}
+
+func BadMutexDeclaredInRangeLoop() {
+	for range []int{1, 2, 3} {
+		mu := sync.Mutex{} // want "mutex 'mu' declared inside loop, each iteration creates a new mutex that cannot protect shared state"
+		mu.Lock()
+		mu.Unlock()
+	}
+}
+
+func BadMutexPointerInLoop() {
+	for i := 0; i < 10; i++ {
+		mu := &sync.Mutex{} // want "mutex 'mu' declared inside loop, each iteration creates a new mutex that cannot protect shared state"
+		mu.Lock()
+		mu.Unlock()
+	}
+}
+
+func GoodMutexOutsideLoop() {
+	var mu sync.Mutex
+	for i := 0; i < 10; i++ {
+		mu.Lock()
+		mu.Unlock()
+	}
+}
+
+func GoodMutexInFuncLiteralInsideLoop() {
+	for i := 0; i < 3; i++ {
+		func() {
+			var mu sync.Mutex
+			mu.Lock()
+			mu.Unlock()
+		}()
+	}
+}
+
 // Bad: Lock with defer Unlock in a loop stacks defers until the function returns.
 func BadForLoopDeferUnlock() {
 	var mu sync.Mutex
@@ -366,6 +408,14 @@ func GoodRWForLoopRLock() {
 	for i := 0; i < 10; i++ {
 		rwmu.RLock()
 		rwmu.RUnlock()
+	}
+}
+
+func BadRWMutexDeclaredInForLoop() {
+	for i := 0; i < 5; i++ {
+		var rw sync.RWMutex // want "rwmutex 'rw' declared inside loop, each iteration creates a new mutex that cannot protect shared state"
+		rw.Lock()
+		rw.Unlock()
 	}
 }
 
@@ -744,6 +794,23 @@ func BadStructContainingMutexAssignedByValue() {
 func BadGenericStructContainingMutexPassedByValue() {
 	sm := GenericSafeMap[int]{}
 	takesGenericSafeMapByValue(sm) // want "struct 'sm' containing mutex is copied by value"
+}
+
+type ValueReceiverCounterWithMutex struct {
+	mu sync.Mutex
+	n  int
+}
+
+func (c ValueReceiverCounterWithMutex) BadValueReceiverWithMutex() { // want "struct 'c' containing mutex is copied by value"
+	c.mu.Lock()
+	c.n++
+	c.mu.Unlock()
+}
+
+func (c *ValueReceiverCounterWithMutex) GoodPointerReceiverWithMutex() {
+	c.mu.Lock()
+	c.n++
+	c.mu.Unlock()
 }
 
 // Bad: struct field mutex locked but not unlocked

--- a/pkg/analyzer/testdata/src/mutex/mutex_goroutine_cases.go
+++ b/pkg/analyzer/testdata/src/mutex/mutex_goroutine_cases.go
@@ -23,6 +23,58 @@ func GoodGoroutineLocksAfterParentReleases() {
 	mu.Unlock()
 }
 
+func BadGoroutineDeadlockParentNeverUnlocks() {
+	var mu sync.Mutex
+	mu.Lock()   // want "mutex 'mu' is locked but not unlocked"
+	go func() { // want "mutex 'mu' goroutine started while lock is held and also tries to acquire it, will deadlock if parent never releases"
+		mu.Lock()
+		mu.Unlock()
+	}()
+}
+
+func BadGoroutineWaitsBeforeParentUnlocks() {
+	var mu sync.Mutex
+	done := make(chan struct{})
+	mu.Lock()
+	go func() { // want "mutex 'mu' goroutine started while lock is held and also tries to acquire it before parent unlocks"
+		mu.Lock()
+		mu.Unlock()
+		close(done)
+	}()
+	<-done
+	mu.Unlock()
+}
+
+func BadGoroutineWaitGroupWaitsBeforeParentUnlocks() {
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	wg.Add(1)
+	mu.Lock()
+	go func() { // want "mutex 'mu' goroutine started while lock is held and also tries to acquire it before parent unlocks"
+		defer wg.Done()
+		mu.Lock()
+		mu.Unlock()
+	}()
+	wg.Wait()
+	mu.Unlock()
+}
+
+type customWaiter struct{}
+
+func (customWaiter) Wait() {}
+
+func GoodGoroutineParentCallsCustomWaitBeforeUnlock() {
+	var mu sync.Mutex
+	var waiter customWaiter
+	mu.Lock()
+	go func() {
+		mu.Lock()
+		mu.Unlock()
+	}()
+	waiter.Wait()
+	mu.Unlock()
+}
+
 func GoodConsistentLockOrderAcrossGoroutines() {
 	var muA, muB sync.Mutex
 	go func() {

--- a/pkg/analyzer/testdata/src/mutex/rwmutex_cases.go
+++ b/pkg/analyzer/testdata/src/mutex/rwmutex_cases.go
@@ -92,6 +92,25 @@ func BadRWUnlockWithoutLock() {
 	mu.Unlock() // want "rwmutex 'mu' is unlocked but not locked"
 }
 
+func BadTryRLockIgnoredReturn() {
+	var mu sync.RWMutex
+	mu.TryRLock() // want "rwmutex 'mu' TryRLock return value not checked, lock may not be held"
+	mu.RUnlock()  // want "rwmutex 'mu' is runlocked but not rlocked"
+}
+
+func BadRWTryLockIgnoredReturn() {
+	var mu sync.RWMutex
+	mu.TryLock() // want "rwmutex 'mu' TryLock return value not checked, lock may not be held"
+	mu.Unlock()  // want "rwmutex 'mu' is unlocked but not locked"
+}
+
+func GoodTryRLockIfCondition() {
+	var mu sync.RWMutex
+	if mu.TryRLock() {
+		defer mu.RUnlock()
+	}
+}
+
 // ---------- RWMutex Defer Patterns ----------
 
 // Defer unlock after write lock
@@ -120,6 +139,18 @@ func BadRWDeferUnlockWithoutLock() {
 	var mu sync.RWMutex
 	defer mu.Unlock() // want "rwmutex 'mu' has defer unlock but no corresponding lock"
 	mu.Lock()
+}
+
+func BadRWDeferLockInsteadOfUnlock() {
+	var mu sync.RWMutex
+	mu.Lock()       // want "rwmutex 'mu' is locked but not unlocked"
+	defer mu.Lock() // want "rwmutex 'mu' defer calls Lock instead of Unlock, will deadlock on return"
+}
+
+func BadDeferRLockInsteadOfRUnlock() {
+	var mu sync.RWMutex
+	mu.RLock()       // want "rwmutex 'mu' is rlocked but not runlocked"
+	defer mu.RLock() // want "rwmutex 'mu' defer calls RLock instead of RUnlock, will deadlock on return"
 }
 
 // ---------- RWMutex Conditional Logic ----------
@@ -189,6 +220,47 @@ func BadRWGoroutineLockWithoutUnlock() {
 	}()
 }
 
+func BadRWGoroutineDeadlockParentNeverUnlocksWrite() {
+	var mu sync.RWMutex
+	mu.Lock()   // want "rwmutex 'mu' is locked but not unlocked"
+	go func() { // want "rwmutex 'mu' goroutine started while write lock is held and also tries to acquire read lock, will deadlock if parent never releases"
+		mu.RLock()
+		mu.RUnlock()
+	}()
+}
+
+func BadRWGoroutineDeadlockParentNeverRUnlocksRead() {
+	var mu sync.RWMutex
+	mu.RLock()  // want "rwmutex 'mu' is rlocked but not runlocked"
+	go func() { // want "rwmutex 'mu' goroutine started while read lock is held and also tries to acquire write lock, will deadlock if parent never runlocks"
+		mu.Lock()
+		mu.Unlock()
+	}()
+}
+
+func BadRWGoroutineWaitsBeforeParentRUnlocks() {
+	var mu sync.RWMutex
+	done := make(chan struct{})
+	mu.RLock()
+	go func() { // want "rwmutex 'mu' goroutine started while read lock is held and also tries to acquire write lock before parent runlocks"
+		mu.Lock()
+		mu.Unlock()
+		close(done)
+	}()
+	<-done
+	mu.RUnlock()
+}
+
+func GoodRWGoroutineLocksAfterParentRUnlocks() {
+	var mu sync.RWMutex
+	mu.RLock()
+	go func() {
+		mu.Lock()
+		mu.Unlock()
+	}()
+	mu.RUnlock()
+}
+
 // ---------- RWMutex Balance Issues ----------
 
 // Imbalanced: two rlocks, one runlock
@@ -204,6 +276,30 @@ func BadRWImbalancedMixed() {
 	var mu sync.RWMutex
 	mu.Lock()
 	mu.RLock() // want "rwmutex 'mu' is rlocked but not runlocked"
+	mu.Unlock()
+}
+
+func BadUnlockWhenReadLocked() {
+	var mu sync.RWMutex
+	mu.RLock()
+	mu.Unlock() // want "rwmutex 'mu' Unlock called but only read lock is held, did you mean RUnlock\\?"
+}
+
+func BadRUnlockWhenWriteLocked() {
+	var mu sync.RWMutex
+	mu.Lock()
+	mu.RUnlock() // want "rwmutex 'mu' RUnlock called but only write lock is held, did you mean Unlock\\?"
+}
+
+func GoodRWMutexCorrectReadAPI() {
+	var mu sync.RWMutex
+	mu.RLock()
+	mu.RUnlock()
+}
+
+func GoodRWMutexCorrectWriteAPI() {
+	var mu sync.RWMutex
+	mu.Lock()
 	mu.Unlock()
 }
 

--- a/pkg/analyzer/testdata/src/waitgroup/waitgroup_basic_cases.go
+++ b/pkg/analyzer/testdata/src/waitgroup/waitgroup_basic_cases.go
@@ -44,10 +44,10 @@ func GoodAddBeforeWait() {
 	wg.Wait()
 }
 
-// No Add, no Done (legal, Wait returns immediately)
-func GoodNoAddNoDone() {
+// Wait without Add is reported even though Wait returns immediately.
+func BadNoAddNoDone() {
 	var wg sync.WaitGroup
-	wg.Wait() // returns immediately
+	wg.Wait() // want "waitgroup 'wg' Wait called without any Add"
 }
 
 // Add without Done (counter never decremented)
@@ -102,6 +102,40 @@ func BadNegativeConstAdd() {
 	wg.Add(negativeAdd) // want "waitgroup 'wg' has negative Add"
 }
 
+func BadAddZero() {
+	var wg sync.WaitGroup
+	wg.Add(0) // want "waitgroup 'wg' Add\\(0\\) is a no-op"
+	wg.Wait()
+}
+
+func BadAddZeroAfterValidAdd() {
+	var wg sync.WaitGroup
+	wg.Add(1)
+	wg.Add(0) // want "waitgroup 'wg' Add\\(0\\) is a no-op"
+	go func() {
+		defer wg.Done()
+	}()
+	wg.Wait()
+}
+
+func GoodAddUnknownVariableNoAddZero(n int) {
+	var wg sync.WaitGroup
+	wg.Add(n)
+	go func() {
+		defer wg.Done()
+	}()
+	wg.Wait()
+}
+
+func GoodAddPositive() {
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+	}()
+	wg.Wait()
+}
+
 // ---------- Wait Ordering Patterns ----------
 
 // Add after Wait (illegal, Wait should be called after all Adds)
@@ -109,7 +143,7 @@ func BadAddAfterWait() {
 	var wg sync.WaitGroup
 	wg.Wait()
 	go func() {
-		wg.Add(1) // want "waitgroup 'wg' Add called after Wait"
+		wg.Add(1) // want "waitgroup 'wg' Add called after Wait" "waitgroup 'wg' Add called inside goroutine, may race with Wait"
 		wg.Done()
 	}()
 }
@@ -126,7 +160,12 @@ func EdgeCaseAddAfterWaitMainFlow() {
 // Edge case where Wait is called without any Adds
 func EdgeCaseNoAddNoDoneNoGoroutine() {
 	var wg sync.WaitGroup
-	wg.Wait() // legal, returns immediately
+	wg.Wait() // want "waitgroup 'wg' Wait called without any Add"
+}
+
+func GoodIgnoredWaitWithoutAdd() {
+	var wg sync.WaitGroup
+	wg.Wait() // goconcurrencylint:ignore wait-without-add
 }
 
 // Waiting in the same goroutine before any separate Done can run deadlocks.

--- a/pkg/analyzer/testdata/src/waitgroup/waitgroup_extended_cases.go
+++ b/pkg/analyzer/testdata/src/waitgroup/waitgroup_extended_cases.go
@@ -42,6 +42,30 @@ func GoodMixedWaitGroupUsage() {
 	wg2.Wait()
 }
 
+func BadNestedWaitGroupWaitInsideWorker() {
+	var wg1, wg2 sync.WaitGroup
+	wg1.Add(1)
+	wg2.Add(1)
+	go func() {
+		defer wg1.Done()
+		wg2.Wait() // want "waitgroup 'wg2' Wait inside worker for waitgroup 'wg1' can deadlock"
+	}()
+	wg1.Wait()
+	wg2.Done()
+}
+
+func GoodNestedWaitGroupReleasedBeforeOuterWait() {
+	var wg1, wg2 sync.WaitGroup
+	wg1.Add(1)
+	wg2.Add(1)
+	go func() {
+		defer wg1.Done()
+		wg2.Wait()
+	}()
+	wg2.Done()
+	wg1.Wait()
+}
+
 // ---------- Reuse Patterns ----------
 
 func GoodReuseWaitGroup() {
@@ -133,10 +157,10 @@ func EdgeCaseComplexButValid() {
 	wg.Wait()
 }
 
-// Add and Wait with a channel to signal completion
-func GoodWaitNoAddNoDone() {
+// Wait without Add on a local WaitGroup is reported.
+func BadWaitNoAddNoDone() {
 	var wg sync.WaitGroup
-	wg.Wait() // legal, returns immediately
+	wg.Wait() // want "waitgroup 'wg' Wait called without any Add"
 }
 
 // ---------- Switch/Select Edge Cases ----------

--- a/pkg/analyzer/testdata/src/waitgroup/waitgroup_goroutine_cases.go
+++ b/pkg/analyzer/testdata/src/waitgroup/waitgroup_goroutine_cases.go
@@ -16,6 +16,28 @@ func GoodLoopAddDone() {
 	wg.Wait()
 }
 
+func BadAddCountMismatchForLoopGoroutines() {
+	var wg sync.WaitGroup
+	wg.Add(1) // want "waitgroup 'wg' Add count 1 does not match 5 goroutines launched"
+	for i := 0; i < 5; i++ {
+		go func() {
+			defer wg.Done()
+		}()
+	}
+	wg.Wait()
+}
+
+func GoodAddCountMatchesForLoopGoroutines() {
+	var wg sync.WaitGroup
+	wg.Add(5)
+	for i := 0; i < 5; i++ {
+		go func() {
+			defer wg.Done()
+		}()
+	}
+	wg.Wait()
+}
+
 // Add inside a loop but Done may be missing in some paths
 func BadLoopAddMissingDone() {
 	var wg sync.WaitGroup
@@ -49,6 +71,37 @@ func GoodMultipleGoroutinesWithDeferDone() {
 
 	_ = errOrderConsumer
 	_ = errReturnConsumer
+}
+
+func BadAddInsideGoroutine() {
+	var wg sync.WaitGroup
+	go func() {
+		wg.Add(1) // want "waitgroup 'wg' Add called inside goroutine, may race with Wait"
+		defer wg.Done()
+	}()
+	wg.Wait()
+}
+
+func BadAddInsideGoroutineNoExternalAdd() {
+	var wg sync.WaitGroup
+	go func() {
+		wg.Add(1) // want "waitgroup 'wg' Add called inside goroutine, may race with Wait"
+		wg.Done()
+	}()
+	wg.Wait()
+}
+
+func BadAddInsideNestedGoroutine() {
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		go func() {
+			wg.Add(1) // want "waitgroup 'wg' Add called inside goroutine, may race with Wait"
+			wg.Done()
+		}()
+		wg.Done()
+	}()
+	wg.Wait()
 }
 
 func GoodSwitchWithDefault() {
@@ -122,7 +175,28 @@ func BadDoneAfterConditionalPanic() {
 		if shouldPanic {
 			panic("error")
 		}
-		wg.Done()
+		wg.Done() // want "waitgroup 'wg' Done not deferred in goroutine, panic will skip Done and deadlock Wait"
+	}()
+	wg.Wait()
+}
+
+func BadDoneNotDeferredInWorker() {
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		doSomething()
+		wg.Done() // want "waitgroup 'wg' Done not deferred in goroutine, panic will skip Done and deadlock Wait"
+	}()
+	wg.Wait()
+}
+
+func BadDoneNotDeferredMultipleCalls() {
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		doSomething()
+		doSomething()
+		wg.Done() // want "waitgroup 'wg' Done not deferred in goroutine, panic will skip Done and deadlock Wait"
 	}()
 	wg.Wait()
 }
@@ -136,6 +210,62 @@ func GoodDeferDoneBeforeConditionalPanic() {
 		defer wg.Done()
 		if shouldPanic {
 			panic("error")
+		}
+	}()
+	wg.Wait()
+}
+
+func GoodDoneOnlyStatement() {
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		wg.Done()
+	}()
+	wg.Wait()
+}
+
+func GoodDoneDeferredInsideFuncWrapper() {
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer func() {
+			wg.Done()
+		}()
+		doSomething()
+	}()
+	wg.Wait()
+}
+
+func BadMultipleDoneSameWorkerBranch() {
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		wg.Done() // want "waitgroup 'wg' Done called multiple times in the same worker branch"
+	}()
+	wg.Wait()
+}
+
+func BadMultipleDoneSameWorkerBranchAfterDone(cond bool) {
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		wg.Done()
+		if cond {
+			wg.Done() // want "waitgroup 'wg' Done called multiple times in the same worker branch"
+		}
+	}()
+	wg.Wait()
+}
+
+func GoodSingleDonePerWorkerBranch(cond bool) {
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		if cond {
+			wg.Done()
+		} else {
+			wg.Done()
 		}
 	}()
 	wg.Wait()

--- a/pkg/analyzer/waitgroup/analyzer.go
+++ b/pkg/analyzer/waitgroup/analyzer.go
@@ -116,13 +116,16 @@ func (wga *Analyzer) handleAddCall(call *ast.CallExpr, wgName string, stats map[
 	addValue := common.GetAddValue(call)
 	if len(call.Args) > 0 {
 		if constantValue, ok := common.ConstantIntValue(call.Args[0], wga.typesInfo); ok {
-			if constantValue < 0 {
-				addValue = constantValue
+			// Keep exact typed constants so balance and literal loop checks see
+			// wg.Add(workers) the same way they see wg.Add(4).
+			addValue = constantValue
+			if addValue < 0 {
+				wga.errorCollector.AddError(call.Pos(), "waitgroup '"+wgName+"' has negative Add("+strconv.Itoa(addValue)+")")
+			}
+			if addValue == 0 {
+				wga.errorCollector.AddError(call.Pos(), "waitgroup '"+wgName+"' Add(0) is a no-op")
 			}
 		}
-	}
-	if addValue < 0 {
-		wga.errorCollector.AddError(call.Pos(), "waitgroup '"+wgName+"' has negative Add("+strconv.Itoa(addValue)+")")
 	}
 	stats[wgName].addCalls = append(stats[wgName].addCalls, addCall{
 		pos:   call.Pos(),

--- a/pkg/analyzer/waitgroup/new_checks.go
+++ b/pkg/analyzer/waitgroup/new_checks.go
@@ -1,0 +1,457 @@
+package waitgroup
+
+import (
+	"go/ast"
+	"go/token"
+	"strconv"
+	"strings"
+
+	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/common"
+)
+
+func (wga *Analyzer) checkAddInsideGoroutine() {
+	ast.Inspect(wga.function.Body, func(n ast.Node) bool {
+		goStmt, ok := n.(*ast.GoStmt)
+		if !ok || wga.commentFilter.ShouldSkipStatement(goStmt) {
+			return true
+		}
+		fnLit, ok := goStmt.Call.Fun.(*ast.FuncLit)
+		if !ok || fnLit.Body == nil {
+			return true
+		}
+
+		ast.Inspect(fnLit.Body, func(inner ast.Node) bool {
+			call, ok := inner.(*ast.CallExpr)
+			if !ok || wga.commentFilter.ShouldSkipCall(call) {
+				return true
+			}
+			sel, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok || sel.Sel.Name != "Add" {
+				return true
+			}
+			wgName := common.GetVarName(sel.X)
+			if !wga.waitGroupNames[wgName] || wga.waitGroupIdentDefinedInside(fnLit.Body, sel.X) {
+				return true
+			}
+			wga.errorCollector.AddError(call.Pos(), "waitgroup '"+wgName+"' Add called inside goroutine, may race with Wait")
+			return true
+		})
+
+		return true
+	})
+}
+
+func (wga *Analyzer) waitGroupIdentDefinedInside(body *ast.BlockStmt, expr ast.Expr) bool {
+	ident, ok := expr.(*ast.Ident)
+	if !ok || body == nil || wga.typesInfo == nil {
+		return false
+	}
+	obj := wga.typesInfo.Uses[ident]
+	if obj == nil {
+		obj = wga.typesInfo.Defs[ident]
+	}
+	return obj != nil && body.Pos() <= obj.Pos() && obj.Pos() <= body.End()
+}
+
+func (wga *Analyzer) checkDoneNotDeferredInWorker() {
+	ast.Inspect(wga.function.Body, func(n ast.Node) bool {
+		goStmt, ok := n.(*ast.GoStmt)
+		if !ok || wga.commentFilter.ShouldSkipStatement(goStmt) {
+			return true
+		}
+		fnLit, ok := goStmt.Call.Fun.(*ast.FuncLit)
+		if !ok || fnLit.Body == nil {
+			return true
+		}
+		for wgName := range wga.waitGroupNames {
+			wga.checkDoneNotDeferredInBlock(fnLit.Body.List, wgName, false)
+		}
+		return true
+	})
+}
+
+func (wga *Analyzer) checkDoneNotDeferredInBlock(stmts []ast.Stmt, wgName string, riskyBefore bool) bool {
+	risky := riskyBefore
+	for _, stmt := range stmts {
+		if stmt == nil || wga.commentFilter.ShouldSkipStatement(stmt) {
+			continue
+		}
+		switch s := stmt.(type) {
+		case *ast.DeferStmt:
+			if wga.deferInvokesDone(s, wgName) {
+				continue
+			}
+			if wga.statementMayPanic(s, wgName) {
+				risky = true
+			}
+		case *ast.ExprStmt:
+			if call, ok := s.X.(*ast.CallExpr); ok && wga.callInvokesDone(call, wgName) {
+				if risky {
+					wga.errorCollector.AddError(call.Pos(), "waitgroup '"+wgName+"' Done not deferred in goroutine, panic will skip Done and deadlock Wait")
+				}
+				continue
+			}
+			if wga.statementMayPanic(s, wgName) {
+				risky = true
+			}
+		case *ast.IfStmt:
+			thenRisky := wga.checkDoneNotDeferredInBlock(s.Body.List, wgName, risky)
+			elseRisky := risky
+			if s.Else != nil {
+				elseRisky = wga.checkDoneNotDeferredInElse(s.Else, wgName, risky)
+			}
+			risky = thenRisky || elseRisky
+		case *ast.BlockStmt:
+			risky = wga.checkDoneNotDeferredInBlock(s.List, wgName, risky)
+		case *ast.LabeledStmt:
+			risky = wga.checkDoneNotDeferredInBlock([]ast.Stmt{s.Stmt}, wgName, risky)
+		default:
+			if wga.statementMayPanic(s, wgName) {
+				risky = true
+			}
+		}
+		if wga.isTerminatingStatement(stmt) {
+			return risky
+		}
+	}
+	return risky
+}
+
+func (wga *Analyzer) checkDoneNotDeferredInElse(stmt ast.Stmt, wgName string, risky bool) bool {
+	switch s := stmt.(type) {
+	case *ast.BlockStmt:
+		return wga.checkDoneNotDeferredInBlock(s.List, wgName, risky)
+	case *ast.IfStmt:
+		return wga.checkDoneNotDeferredInBlock([]ast.Stmt{s}, wgName, risky)
+	default:
+		return risky
+	}
+}
+
+func (wga *Analyzer) statementMayPanic(stmt ast.Stmt, wgName string) bool {
+	if _, ok := stmt.(*ast.GoStmt); ok {
+		return false
+	}
+	found := false
+	ast.Inspect(stmt, func(n ast.Node) bool {
+		if found {
+			return false
+		}
+		if _, ok := n.(*ast.FuncLit); ok {
+			return false
+		}
+		call, ok := n.(*ast.CallExpr)
+		if !ok || wga.commentFilter.ShouldSkipCall(call) {
+			return true
+		}
+		if wga.isWaitGroupHousekeepingCall(call, wgName) {
+			return true
+		}
+		found = true
+		return false
+	})
+	return found
+}
+
+func (wga *Analyzer) isWaitGroupHousekeepingCall(call *ast.CallExpr, wgName string) bool {
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok || common.GetVarName(sel.X) != wgName {
+		return false
+	}
+	switch sel.Sel.Name {
+	case "Add", "Done", "Wait", "Go":
+		return true
+	default:
+		return false
+	}
+}
+
+func (wga *Analyzer) checkLiteralAddLoopGoroutineMismatch(stats map[string]*Stats) {
+	for wgName, st := range stats {
+		var positiveAdds []addCall
+		for _, add := range st.addCalls {
+			if add.value > 0 && !wga.isInGoroutine(add.pos) {
+				positiveAdds = append(positiveAdds, add)
+			}
+		}
+		if len(positiveAdds) != 1 {
+			continue
+		}
+		launched := wga.countLoopWorkerGoroutinesAfter(positiveAdds[0].pos, wgName)
+		if launched <= 1 || launched == positiveAdds[0].value {
+			continue
+		}
+		wga.errorCollector.AddError(positiveAdds[0].pos,
+			"waitgroup '"+wgName+"' Add count "+strconv.Itoa(positiveAdds[0].value)+" does not match "+strconv.Itoa(launched)+" goroutines launched")
+	}
+}
+
+func (wga *Analyzer) countLoopWorkerGoroutinesAfter(after token.Pos, wgName string) int {
+	total := 0
+	ast.Inspect(wga.function.Body, func(n ast.Node) bool {
+		switch loop := n.(type) {
+		case *ast.ForStmt:
+			if loop.Pos() <= after {
+				return true
+			}
+			iterations := wga.estimateForIterations(loop)
+			if iterations <= 1 {
+				return true
+			}
+			total += iterations * wga.countWorkerGoroutines(loop.Body, wgName)
+		case *ast.RangeStmt:
+			if loop.Pos() <= after {
+				return true
+			}
+			iterations := wga.estimateRangeIterationsForMismatch(loop)
+			if iterations <= 1 {
+				return true
+			}
+			total += iterations * wga.countWorkerGoroutines(loop.Body, wgName)
+		}
+		return true
+	})
+	return total
+}
+
+func (wga *Analyzer) estimateRangeIterationsForMismatch(rangeStmt *ast.RangeStmt) int {
+	if rangeStmt == nil || rangeStmt.X == nil {
+		return 1
+	}
+	if lit, ok := rangeStmt.X.(*ast.CompositeLit); ok {
+		return len(lit.Elts)
+	}
+	return wga.estimateRangeIterations(rangeStmt)
+}
+
+func (wga *Analyzer) countWorkerGoroutines(body *ast.BlockStmt, wgName string) int {
+	if body == nil {
+		return 0
+	}
+	count := 0
+	ast.Inspect(body, func(n ast.Node) bool {
+		goStmt, ok := n.(*ast.GoStmt)
+		if !ok {
+			return true
+		}
+		doneInfo, related := wga.goroutineDoneInfo(goStmt, wgName)
+		if related && doneInfo.hasAnyDone {
+			count++
+		}
+		return true
+	})
+	return count
+}
+
+func (wga *Analyzer) checkWaitWithoutAdd(stats map[string]*Stats) {
+	for wgName, st := range stats {
+		if !wga.localWaitGroupNames[wgName] || strings.Contains(wgName, ".") ||
+			len(st.addCalls) > 0 || len(st.goCalls) > 0 || wga.waitGroupInitializedFromAnother(wgName) {
+			continue
+		}
+		for _, waitPos := range st.waitCalls {
+			wga.errorCollector.AddError(waitPos, "waitgroup '"+wgName+"' Wait called without any Add")
+		}
+	}
+}
+
+func (wga *Analyzer) waitGroupInitializedFromAnother(wgName string) bool {
+	found := false
+	ast.Inspect(wga.function.Body, func(n ast.Node) bool {
+		if found {
+			return false
+		}
+		switch node := n.(type) {
+		case *ast.AssignStmt:
+			for i, lhs := range node.Lhs {
+				ident, ok := lhs.(*ast.Ident)
+				if !ok || ident.Name != wgName || i >= len(node.Rhs) {
+					continue
+				}
+				if wga.isCopiedWaitGroupExpr(node.Rhs[i]) {
+					found = true
+					return false
+				}
+			}
+		case *ast.ValueSpec:
+			for i, name := range node.Names {
+				if name.Name != wgName || i >= len(node.Values) {
+					continue
+				}
+				if wga.isCopiedWaitGroupExpr(node.Values[i]) {
+					found = true
+					return false
+				}
+			}
+		}
+		return true
+	})
+	return found
+}
+
+func (wga *Analyzer) isCopiedWaitGroupExpr(expr ast.Expr) bool {
+	if expr == nil {
+		return false
+	}
+	switch e := expr.(type) {
+	case *ast.CompositeLit:
+		return false
+	case *ast.UnaryExpr:
+		return e.Op != token.AND && wga.isCopiedWaitGroupExpr(e.X)
+	}
+	return common.IsWaitGroup(wga.typesInfo.TypeOf(expr))
+}
+
+func (wga *Analyzer) checkMultipleDoneSameWorkerBranch() {
+	ast.Inspect(wga.function.Body, func(n ast.Node) bool {
+		goStmt, ok := n.(*ast.GoStmt)
+		if !ok || wga.commentFilter.ShouldSkipStatement(goStmt) {
+			return true
+		}
+		fnLit, ok := goStmt.Call.Fun.(*ast.FuncLit)
+		if !ok || fnLit.Body == nil {
+			return true
+		}
+		for wgName := range wga.waitGroupNames {
+			wga.checkMultipleDoneInBranch(fnLit.Body.List, wgName, 0)
+		}
+		return true
+	})
+}
+
+func (wga *Analyzer) checkMultipleDoneInBranch(stmts []ast.Stmt, wgName string, count int) int {
+	current := count
+	for _, stmt := range stmts {
+		if stmt == nil || wga.commentFilter.ShouldSkipStatement(stmt) {
+			continue
+		}
+		switch s := stmt.(type) {
+		case *ast.DeferStmt:
+			if wga.deferInvokesDone(s, wgName) {
+				current++
+				if current > 1 {
+					wga.errorCollector.AddError(s.Call.Pos(), "waitgroup '"+wgName+"' Done called multiple times in the same worker branch")
+				}
+			}
+		case *ast.ExprStmt:
+			if call, ok := s.X.(*ast.CallExpr); ok && wga.callInvokesDone(call, wgName) {
+				current++
+				if current > 1 {
+					wga.errorCollector.AddError(call.Pos(), "waitgroup '"+wgName+"' Done called multiple times in the same worker branch")
+				}
+			}
+		case *ast.IfStmt:
+			wga.checkMultipleDoneInBranch(s.Body.List, wgName, current)
+			if s.Else != nil {
+				wga.checkMultipleDoneInElse(s.Else, wgName, current)
+			}
+		case *ast.BlockStmt:
+			current = wga.checkMultipleDoneInBranch(s.List, wgName, current)
+		case *ast.LabeledStmt:
+			current = wga.checkMultipleDoneInBranch([]ast.Stmt{s.Stmt}, wgName, current)
+		}
+	}
+	return current
+}
+
+func (wga *Analyzer) checkMultipleDoneInElse(stmt ast.Stmt, wgName string, count int) {
+	switch s := stmt.(type) {
+	case *ast.BlockStmt:
+		wga.checkMultipleDoneInBranch(s.List, wgName, count)
+	case *ast.IfStmt:
+		wga.checkMultipleDoneInBranch([]ast.Stmt{s}, wgName, count)
+	}
+}
+
+func (wga *Analyzer) checkNestedWaitGroupDeadlock() {
+	ast.Inspect(wga.function.Body, func(n ast.Node) bool {
+		goStmt, ok := n.(*ast.GoStmt)
+		if !ok || wga.commentFilter.ShouldSkipStatement(goStmt) {
+			return true
+		}
+		fnLit, ok := goStmt.Call.Fun.(*ast.FuncLit)
+		if !ok || fnLit.Body == nil {
+			return true
+		}
+
+		outerGroups := wga.workerDoneWaitGroups(fnLit.Body)
+		if len(outerGroups) == 0 {
+			return true
+		}
+		wga.reportNestedWaitsForWorker(goStmt, fnLit.Body, outerGroups)
+		return true
+	})
+}
+
+func (wga *Analyzer) workerDoneWaitGroups(body *ast.BlockStmt) map[string]bool {
+	outerGroups := make(map[string]bool)
+	for wgName := range wga.waitGroupNames {
+		if wga.analyzeDoneCallsWithVisited(body, wgName, make(map[token.Pos]bool)).hasAnyDone {
+			outerGroups[wgName] = true
+		}
+	}
+	return outerGroups
+}
+
+func (wga *Analyzer) reportNestedWaitsForWorker(goStmt *ast.GoStmt, body *ast.BlockStmt, outerGroups map[string]bool) {
+	ast.Inspect(body, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok || wga.commentFilter.ShouldSkipCall(call) {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || sel.Sel.Name != "Wait" {
+			return true
+		}
+		innerWG := common.GetVarName(sel.X)
+		if !wga.waitGroupNames[innerWG] {
+			return true
+		}
+		for outerWG := range outerGroups {
+			if outerWG == innerWG {
+				continue
+			}
+			if wga.outerWaitBeforeInnerRelease(goStmt.Pos(), outerWG, innerWG) {
+				wga.errorCollector.AddError(call.Pos(),
+					"waitgroup '"+innerWG+"' Wait inside worker for waitgroup '"+outerWG+"' can deadlock")
+				return false
+			}
+		}
+		return true
+	})
+}
+
+func (wga *Analyzer) outerWaitBeforeInnerRelease(goPos token.Pos, outerWG, innerWG string) bool {
+	var outerWait token.Pos
+	var innerRelease token.Pos
+	hasInnerAdd := false
+
+	ast.Inspect(wga.function.Body, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok || wga.isInGoroutine(call.Pos()) {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		wgName := common.GetVarName(sel.X)
+		switch {
+		case wgName == innerWG && sel.Sel.Name == "Add" && call.Pos() < goPos:
+			if delta, ok := wga.addDelta(call, innerWG); ok && delta > 0 {
+				hasInnerAdd = true
+			}
+		case wgName == outerWG && sel.Sel.Name == "Wait" && call.Pos() > goPos && outerWait == token.NoPos:
+			outerWait = call.Pos()
+		case wgName == innerWG && sel.Sel.Name == "Done" && outerWait != token.NoPos && call.Pos() > outerWait && innerRelease == token.NoPos:
+			innerRelease = call.Pos()
+		case wgName == innerWG && sel.Sel.Name == "Add" && outerWait != token.NoPos && call.Pos() > outerWait && innerRelease == token.NoPos:
+			if delta, ok := wga.addDelta(call, innerWG); ok && delta < 0 {
+				innerRelease = call.Pos()
+			}
+		}
+		return true
+	})
+
+	return hasInnerAdd && outerWait != token.NoPos && innerRelease != token.NoPos
+}

--- a/pkg/analyzer/waitgroup/validation.go
+++ b/pkg/analyzer/waitgroup/validation.go
@@ -12,6 +12,12 @@ import (
 
 // validateUsage performs validation checks on collected statistics
 func (wga *Analyzer) validateUsage(stats map[string]*Stats) {
+	wga.checkAddInsideGoroutine()
+	wga.checkDoneNotDeferredInWorker()
+	wga.checkLiteralAddLoopGoroutineMismatch(stats)
+	wga.checkWaitWithoutAdd(stats)
+	wga.checkMultipleDoneSameWorkerBranch()
+	wga.checkNestedWaitGroupDeadlock()
 	wga.checkAddAfterWait(stats)
 	wga.checkWaitBeforeDoneSameGoroutine(stats)
 	wga.checkWaitAndDoneInSameGoroutine()
@@ -25,12 +31,7 @@ func (wga *Analyzer) validateUsage(stats map[string]*Stats) {
 // validateBalance performs the actual balance validation for a WaitGroup
 func (wga *Analyzer) validateBalance(wgName string, stats *Stats) {
 	// Count Done calls from main flow (not in goroutines)
-	mainFlowDoneCount := 0
-	for _, donePos := range stats.doneCalls {
-		if !wga.isInGoroutine(donePos) {
-			mainFlowDoneCount++
-		}
-	}
+	mainFlowDoneCount := wga.countMainFlowDoneCalls(wgName)
 
 	totalDone := mainFlowDoneCount
 
@@ -51,6 +52,74 @@ func (wga *Analyzer) validateBalance(wgName string, stats *Stats) {
 
 	if totalDone > stats.totalAdd {
 		wga.reportExcessDones(wgName, stats, totalDone, mainFlowDoneCount)
+	}
+}
+
+func (wga *Analyzer) countMainFlowDoneCalls(wgName string) int {
+	if wga.function == nil || wga.function.Body == nil {
+		return 0
+	}
+	return wga.countMainFlowDoneInStatements(wga.function.Body.List, wgName, 1)
+}
+
+func (wga *Analyzer) countMainFlowDoneInStatements(stmts []ast.Stmt, wgName string, multiplier int) int {
+	count := 0
+	for _, stmt := range stmts {
+		if stmt == nil || wga.commentFilter.ShouldSkipStatement(stmt) {
+			continue
+		}
+		switch s := stmt.(type) {
+		case *ast.ExprStmt:
+			call, ok := s.X.(*ast.CallExpr)
+			if ok && wga.callInvokesDone(call, wgName) {
+				count += multiplier
+			}
+		case *ast.GoStmt:
+			continue
+		case *ast.BlockStmt:
+			count += wga.countMainFlowDoneInStatements(s.List, wgName, multiplier)
+		case *ast.IfStmt:
+			count += wga.countMainFlowDoneInStatements(s.Body.List, wgName, multiplier)
+			if s.Else != nil {
+				count += wga.countMainFlowDoneInElse(s.Else, wgName, multiplier)
+			}
+		case *ast.ForStmt:
+			count += wga.countMainFlowDoneInStatements(s.Body.List, wgName, multiplier*wga.estimateForIterations(s))
+		case *ast.RangeStmt:
+			count += wga.countMainFlowDoneInStatements(s.Body.List, wgName, multiplier*wga.estimateRangeIterations(s))
+		case *ast.SwitchStmt:
+			for _, stmt := range s.Body.List {
+				if cc, ok := stmt.(*ast.CaseClause); ok {
+					count += wga.countMainFlowDoneInStatements(cc.Body, wgName, multiplier)
+				}
+			}
+		case *ast.TypeSwitchStmt:
+			for _, stmt := range s.Body.List {
+				if cc, ok := stmt.(*ast.CaseClause); ok {
+					count += wga.countMainFlowDoneInStatements(cc.Body, wgName, multiplier)
+				}
+			}
+		case *ast.SelectStmt:
+			for _, stmt := range s.Body.List {
+				if cc, ok := stmt.(*ast.CommClause); ok {
+					count += wga.countMainFlowDoneInStatements(cc.Body, wgName, multiplier)
+				}
+			}
+		case *ast.LabeledStmt:
+			count += wga.countMainFlowDoneInStatements([]ast.Stmt{s.Stmt}, wgName, multiplier)
+		}
+	}
+	return count
+}
+
+func (wga *Analyzer) countMainFlowDoneInElse(stmt ast.Stmt, wgName string, multiplier int) int {
+	switch s := stmt.(type) {
+	case *ast.BlockStmt:
+		return wga.countMainFlowDoneInStatements(s.List, wgName, multiplier)
+	case *ast.IfStmt:
+		return wga.countMainFlowDoneInStatements([]ast.Stmt{s}, wgName, multiplier)
+	default:
+		return 0
 	}
 }
 


### PR DESCRIPTION
- Add mutex checks: unchecked-trylock, defer-lock, mutex-in-loop, rwmutex-api-mismatch, goroutine-lock-deadlock, panic-before-unlock

- Add waitgroup checks: add-inside-goroutine, done-not-deferred, add-loop-count-mismatch, add-zero, wait-without-add, multiple-done-worker, nested-waitgroup-deadlock

- Support // goconcurrencylint:ignore line suppression

- Cache ignore directive lookup by source line

- Expand analyzer testdata for new bad/good cases