### PR TITLE
fix: reduce false positives in mutex and waitgroup analyzers

### DIFF
--- a/pkg/analyzer/mutex/panic.go
+++ b/pkg/analyzer/mutex/panic.go
@@ -75,6 +75,11 @@ func (ma *Analyzer) indexExprCanPanic(index *ast.IndexExpr) bool {
 	if index == nil {
 		return false
 	}
+	// Map indexing never panics: missing keys return the zero value, and
+	// negative or out-of-range keys are valid for any comparable key type.
+	if ma.isMapIndex(index) {
+		return false
+	}
 	indexValue, ok := common.ConstantIntValue(index.Index, ma.typesInfo)
 	if !ok {
 		return false
@@ -84,6 +89,18 @@ func (ma *Analyzer) indexExprCanPanic(index *ast.IndexExpr) bool {
 	}
 	length, ok := ma.staticLength(index.X)
 	return ok && indexValue >= length
+}
+
+func (ma *Analyzer) isMapIndex(index *ast.IndexExpr) bool {
+	if index == nil || ma.typesInfo == nil {
+		return false
+	}
+	typ := ma.typesInfo.TypeOf(index.X)
+	if typ == nil {
+		return false
+	}
+	_, ok := typ.Underlying().(*types.Map)
+	return ok
 }
 
 func (ma *Analyzer) staticLength(expr ast.Expr) (int, bool) {

--- a/pkg/analyzer/testdata/src/mutex/mutex_basic_cases.go
+++ b/pkg/analyzer/testdata/src/mutex/mutex_basic_cases.go
@@ -303,6 +303,17 @@ func GoodIndexPanicProtectedByDeferUnlock() {
 	_ = items[1]
 }
 
+// Map indexing never panics on missing or out-of-range keys, so a constant
+// index that would be out of range for a slice must not be flagged for maps.
+func GoodMapIndexWithOutOfRangeConstant() {
+	const missingKey = -1
+	m := map[int]string{0: "zero"}
+	var mu sync.Mutex
+	mu.Lock()
+	_ = m[missingKey]
+	mu.Unlock()
+}
+
 // Lock + early-return-Unlock + later Unlock (mutually exclusive, no defer)
 func GoodLockMutuallyExclusiveUnlock(cur, size int) error {
 	var mu sync.Mutex

--- a/pkg/analyzer/testdata/src/waitgroup/helpers.go
+++ b/pkg/analyzer/testdata/src/waitgroup/helpers.go
@@ -78,6 +78,16 @@ func handleExternalWork(wg *sync.WaitGroup) {
 	// external work
 }
 
+// trySpawnHelper increments the WaitGroup, then runs fn in a goroutine that
+// always calls Done. The caller does not need to call Add itself.
+func trySpawnHelper(wg *sync.WaitGroup, fn func()) {
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		fn()
+	}()
+}
+
 func (o *callbackOwner) markDone() {
 	o.wg.Done()
 }

--- a/pkg/analyzer/testdata/src/waitgroup/waitgroup_callbacks_cases.go
+++ b/pkg/analyzer/testdata/src/waitgroup/waitgroup_callbacks_cases.go
@@ -307,3 +307,48 @@ func GoodBranchExclusiveDonePaths(startWorker, enqueue bool) {
 
 	wg.Wait()
 }
+
+// A helper that takes &wg performs Add internally. Wait should not be flagged
+// as "Wait without Add" because the helper supplies the missing Add.
+func GoodWaitWithAddInHelper() {
+	var wg sync.WaitGroup
+	trySpawnHelper(&wg, func() {})
+	trySpawnHelper(&wg, func() {})
+	wg.Wait()
+}
+
+// Add lives inside a closure assigned to a local variable. The closure is
+// invoked an arbitrary number of times after assignment, supplying Add and
+// scheduling the matching Done. Wait must not be flagged as missing Add.
+func GoodWaitWithAddInLocalClosure() {
+	var wg sync.WaitGroup
+	addAndRun := func() {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+		}()
+	}
+	addAndRun()
+	addAndRun()
+	wg.Wait()
+}
+
+// A shadowed WaitGroup inside a callback must not make the outer WaitGroup look
+// initialized. The outer wg still has no Add.
+func BadWaitWithoutAddDespiteShadowedCallbackAdd() {
+	var wg sync.WaitGroup
+	registerCallback(func() {
+		var wg sync.WaitGroup
+		wg.Add(1)
+	})
+	wg.Wait() // want "waitgroup 'wg' Wait called without any Add"
+}
+
+// Helper invocations that appear after Wait cannot supply its missing Add, so
+// the warning must still fire even though the WaitGroup is later passed to a
+// helper that calls Add.
+func BadWaitWithHelperAddAfterWait() {
+	var wg sync.WaitGroup
+	wg.Wait() // want "waitgroup 'wg' Wait called without any Add"
+	trySpawnHelper(&wg, func() {})
+}

--- a/pkg/analyzer/testdata/src/waitgroup/waitgroup_goroutine_cases.go
+++ b/pkg/analyzer/testdata/src/waitgroup/waitgroup_goroutine_cases.go
@@ -175,7 +175,7 @@ func BadDoneAfterConditionalPanic() {
 		if shouldPanic {
 			panic("error")
 		}
-		wg.Done() // want "waitgroup 'wg' Done not deferred in goroutine, panic will skip Done and deadlock Wait"
+		wg.Done() // want "waitgroup 'wg' Done should be deferred so it runs on panic or runtime.Goexit"
 	}()
 	wg.Wait()
 }
@@ -185,7 +185,7 @@ func BadDoneNotDeferredInWorker() {
 	wg.Add(1)
 	go func() {
 		doSomething()
-		wg.Done() // want "waitgroup 'wg' Done not deferred in goroutine, panic will skip Done and deadlock Wait"
+		wg.Done() // want "waitgroup 'wg' Done should be deferred so it runs on panic or runtime.Goexit"
 	}()
 	wg.Wait()
 }
@@ -196,7 +196,7 @@ func BadDoneNotDeferredMultipleCalls() {
 	go func() {
 		doSomething()
 		doSomething()
-		wg.Done() // want "waitgroup 'wg' Done not deferred in goroutine, panic will skip Done and deadlock Wait"
+		wg.Done() // want "waitgroup 'wg' Done should be deferred so it runs on panic or runtime.Goexit"
 	}()
 	wg.Wait()
 }
@@ -220,6 +220,20 @@ func GoodDoneOnlyStatement() {
 	wg.Add(1)
 	go func() {
 		wg.Done()
+	}()
+	wg.Wait()
+}
+
+// A defer registers the call for execution at function exit; the deferred
+// call itself does not run inline, so it cannot panic before Done.
+func GoodDoneAfterDeferRegistration() {
+	var wg sync.WaitGroup
+	wg.Add(1)
+	ch := make(chan struct{})
+	go func() {
+		defer close(ch)
+		wg.Done()
+		<-ch
 	}()
 	wg.Wait()
 }

--- a/pkg/analyzer/waitgroup/panic.go
+++ b/pkg/analyzer/waitgroup/panic.go
@@ -34,13 +34,17 @@ func (wga *Analyzer) checkDoneNotDeferredInBlock(stmts []ast.Stmt, wgName string
 			if wga.deferInvokesDone(s, wgName) {
 				continue
 			}
-			if wga.statementMayPanic(s, wgName) {
+			// A defer registers the call for execution at function exit; the
+			// deferred call itself does not run inline. Only the argument
+			// expressions are evaluated synchronously, so only those can mark
+			// subsequent code as risky.
+			if wga.deferArgsMayPanic(s, wgName) {
 				risky = true
 			}
 		case *ast.ExprStmt:
 			if call, ok := s.X.(*ast.CallExpr); ok && wga.callInvokesDone(call, wgName) {
 				if risky {
-					wga.errorCollector.AddError(call.Pos(), "waitgroup '"+wgName+"' Done not deferred in goroutine, panic will skip Done and deadlock Wait")
+					wga.errorCollector.AddError(call.Pos(), "waitgroup '"+wgName+"' Done should be deferred so it runs on panic or runtime.Goexit")
 				}
 				continue
 			}
@@ -79,6 +83,47 @@ func (wga *Analyzer) checkDoneNotDeferredInElse(stmt ast.Stmt, wgName string, ri
 	default:
 		return risky
 	}
+}
+
+// deferArgsMayPanic reports whether evaluating the arguments of a deferred
+// call may panic. The deferred call itself runs at function exit, so its body
+// cannot interrupt the ongoing flow; only the argument expressions evaluated
+// at the defer point can.
+func (wga *Analyzer) deferArgsMayPanic(stmt *ast.DeferStmt, wgName string) bool {
+	if stmt == nil || stmt.Call == nil {
+		return false
+	}
+	for _, arg := range stmt.Call.Args {
+		if wga.exprMayPanic(arg, wgName) {
+			return true
+		}
+	}
+	return false
+}
+
+func (wga *Analyzer) exprMayPanic(expr ast.Expr, wgName string) bool {
+	if expr == nil {
+		return false
+	}
+	found := false
+	ast.Inspect(expr, func(n ast.Node) bool {
+		if found {
+			return false
+		}
+		if _, ok := n.(*ast.FuncLit); ok {
+			return false
+		}
+		call, ok := n.(*ast.CallExpr)
+		if !ok || wga.commentFilter.ShouldSkipCall(call) {
+			return true
+		}
+		if wga.isWaitGroupHousekeepingCall(call, wgName) {
+			return true
+		}
+		found = true
+		return false
+	})
+	return found
 }
 
 func (wga *Analyzer) statementMayPanic(stmt ast.Stmt, wgName string) bool {

--- a/pkg/analyzer/waitgroup/validation.go
+++ b/pkg/analyzer/waitgroup/validation.go
@@ -4,11 +4,13 @@ import (
 	"go/ast"
 	"go/constant"
 	"go/token"
+	"go/types"
 	"sort"
 	"strconv"
 	"strings"
 
 	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/common"
+	"golang.org/x/tools/go/ast/astutil"
 )
 
 // validateUsage performs validation checks on collected statistics
@@ -882,9 +884,183 @@ func (wga *Analyzer) checkWaitWithoutAdd(stats map[string]*Stats) {
 			continue
 		}
 		for _, waitPos := range st.waitCalls {
+			targetObj := wga.waitGroupReceiverObjectAt(wgName, "Wait", waitPos)
+			// The Add may live in a helper function the WaitGroup is passed to,
+			// or in a closure assigned to a local variable that is invoked later.
+			// Both checks must consider only references that appear before the
+			// Wait, since later code cannot supply the missing Add.
+			if targetObj != nil &&
+				(wga.isWaitGroupPassedToOtherFunctionsForWait(targetObj, waitPos) ||
+					wga.hasAddInLocalClosure(targetObj, waitPos)) {
+				continue
+			}
 			wga.errorCollector.AddError(waitPos, "waitgroup '"+wgName+"' Wait called without any Add")
 		}
 	}
+}
+
+// hasAddInLocalClosure reports whether a WaitGroup has Add called inside a
+// function literal assigned to a local variable. This is intentionally
+// permissive: it does not prove the closure is invoked. Only closures whose
+// definition appears before waitPos are considered, since a closure defined
+// later cannot have run before the Wait.
+func (wga *Analyzer) hasAddInLocalClosure(target types.Object, waitPos token.Pos) bool {
+	if wga.function == nil || wga.function.Body == nil || target == nil {
+		return false
+	}
+
+	found := false
+	funcLitDepth := 0
+	astutil.Apply(wga.function.Body, func(c *astutil.Cursor) bool {
+		if found {
+			return false
+		}
+		node := c.Node()
+		if node == nil {
+			return true
+		}
+		if fnLit, ok := node.(*ast.FuncLit); ok {
+			if fnLit.Pos() >= waitPos {
+				return false
+			}
+			funcLitDepth++
+			return true
+		}
+		call, ok := node.(*ast.CallExpr)
+		if !ok || funcLitDepth == 0 {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || sel.Sel.Name != "Add" {
+			return true
+		}
+		if wga.exprReferencesObject(sel.X, target) {
+			found = true
+			return false
+		}
+		return true
+	}, func(c *astutil.Cursor) bool {
+		if _, ok := c.Node().(*ast.FuncLit); ok {
+			funcLitDepth--
+		}
+		return true
+	})
+	return found
+}
+
+// isWaitGroupPassedToOtherFunctionsForWait reports whether the WaitGroup
+// referred to by target is referenced (passed, assigned, returned, etc.)
+// somewhere in the enclosing function before waitPos. References after the
+// Wait cannot supply its missing Add.
+func (wga *Analyzer) isWaitGroupPassedToOtherFunctionsForWait(target types.Object, waitPos token.Pos) bool {
+	if wga.function == nil || wga.function.Body == nil || target == nil {
+		return false
+	}
+
+	found := false
+	ast.Inspect(wga.function.Body, func(n ast.Node) bool {
+		if found || n == nil || n.Pos() >= waitPos {
+			return false
+		}
+		switch node := n.(type) {
+		case *ast.CallExpr:
+			for _, arg := range node.Args {
+				if wga.exprReferencesObject(arg, target) {
+					found = true
+					return false
+				}
+			}
+		case *ast.AssignStmt:
+			for _, rhs := range node.Rhs {
+				if wga.exprReferencesObject(rhs, target) {
+					found = true
+					return false
+				}
+			}
+		case *ast.ValueSpec:
+			for _, value := range node.Values {
+				if wga.exprReferencesObject(value, target) {
+					found = true
+					return false
+				}
+			}
+		case *ast.ReturnStmt:
+			for _, result := range node.Results {
+				if wga.exprReferencesObject(result, target) {
+					found = true
+					return false
+				}
+			}
+		}
+		return true
+	})
+	return found
+}
+
+func (wga *Analyzer) waitGroupReceiverObjectAt(wgName, method string, pos token.Pos) types.Object {
+	if wga.function == nil || wga.function.Body == nil {
+		return nil
+	}
+	var obj types.Object
+	ast.Inspect(wga.function.Body, func(n ast.Node) bool {
+		if obj != nil {
+			return false
+		}
+		call, ok := n.(*ast.CallExpr)
+		if !ok || call.Pos() != pos {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || sel.Sel.Name != method || common.GetVarName(sel.X) != wgName {
+			return true
+		}
+		obj = wga.receiverObject(sel.X)
+		return false
+	})
+	return obj
+}
+
+func (wga *Analyzer) exprReferencesObject(expr ast.Expr, target types.Object) bool {
+	if expr == nil || target == nil {
+		return false
+	}
+	if obj := wga.receiverObject(expr); obj != nil {
+		return obj == target
+	}
+
+	found := false
+	ast.Inspect(expr, func(n ast.Node) bool {
+		if found {
+			return false
+		}
+		exprNode, ok := n.(ast.Expr)
+		if !ok {
+			return true
+		}
+		if obj := wga.receiverObject(exprNode); obj != nil && obj == target {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
+}
+
+func (wga *Analyzer) receiverObject(expr ast.Expr) types.Object {
+	switch e := expr.(type) {
+	case *ast.Ident:
+		if wga.typesInfo == nil {
+			return nil
+		}
+		return wga.typesInfo.ObjectOf(e)
+	case *ast.ParenExpr:
+		return wga.receiverObject(e.X)
+	case *ast.UnaryExpr:
+		if e.Op == token.AND || e.Op == token.MUL {
+			return wga.receiverObject(e.X)
+		}
+	}
+	return nil
 }
 
 func (wga *Analyzer) waitGroupInitializedFromAnother(wgName string) bool {


### PR DESCRIPTION
- mutex: skip map indexing in panic detection (maps never panic on missing or out-of-range keys)

- waitgroup: a deferred call body does not run inline; only its arguments can mark subsequent code as risky for Done-not-deferred

- waitgroup: do not flag "Wait without Add" when the WaitGroup is passed to another function or its Add lives in a local closure defined before the Wait, using types.Object identity to avoid name-shadowing false negatives

- reword Done-not-deferred message to mention runtime.Goexit