### PR TITLE
feat: error reporting to use diagnostic categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,9 +104,33 @@ Because the tool is a standard `go/analysis` single-checker, it accepts the usua
 | `wait-without-add` | `sync.WaitGroup` | A local `WaitGroup` is waited on without any `Add()` in the same lifecycle. |
 | `multiple-done-worker` | `sync.WaitGroup` | The same worker branch can call `Done()` more than once. |
 | `nested-waitgroup-deadlock` | `sync.WaitGroup` | A worker for one `WaitGroup` waits on another whose release is blocked behind the outer `Wait()`. |
-| `package-level-primitive` | all | Any of the above, applied to package-scoped primitives declared in a different file of the same package. |
+| `done-outside-goroutine` | `sync.WaitGroup` | `Done()` runs on the parent goroutine instead of the worker, so a panic in the parent skips it. |
+| `wait-deadlock` | `sync.WaitGroup` | `Wait()` is reached while the same goroutine still owes a `Done()`. |
+| `add-negative` | `sync.WaitGroup` | `wg.Add(n)` is called with a negative literal — panics at runtime. |
+| `go-panic` | `sync.WaitGroup` | A function passed to `wg.Go()` may panic and bring the program down. |
+| `defer-unlock-in-loop` | `sync.Mutex`, `sync.RWMutex` | `defer mu.Unlock()` lives inside a loop body, so the unlock only runs at function return. |
+| `double-lock` | `sync.Mutex`, `sync.RWMutex` | A second `Lock()` is taken while the first is still held (or a write `Lock()` while a read lock is held). |
+| `cross-goroutine-unlock` | `sync.Mutex`, `sync.RWMutex` | `Unlock()` / `RUnlock()` runs in a different goroutine than the matching lock. |
+| `lock-order-cycle` | `sync.Mutex`, `sync.RWMutex` | Two functions acquire the same pair of mutexes in opposite orders — classic deadlock pattern. |
+| `sync-primitive-copy` | all | A `sync.Mutex`, `sync.RWMutex` or `sync.WaitGroup` (or a struct embedding one) is copied by value. |
 
-All checks are enabled by default and emitted as standard `go/analysis` diagnostics. To silence an intentional one-line case, put `// goconcurrencylint:ignore` on the same line as the call; for example, `wg.Wait() // goconcurrencylint:ignore wait-without-add`. Any text after the directive is treated as a human-readable note; today the directive silences all checks reported on that line.
+All checks above also fire on package-scoped primitives declared in any file of the same package — there is no separate ID for that case; the diagnostic carries the same category as the in-function variant.
+
+Each diagnostic is emitted with a stable [`analysis.Diagnostic.Category`](https://pkg.go.dev/golang.org/x/tools/go/analysis#Diagnostic) equal to the ID in the table above, so `golangci-lint` and IDE integrations can filter or label by check.
+
+### Suppressing diagnostics
+
+Place `// goconcurrencylint:ignore` on the same line as the offending call:
+
+```go
+wg.Wait() // goconcurrencylint:ignore wait-without-add
+mu.Lock() // goconcurrencylint:ignore lock-without-unlock, defer-lock
+mu.Lock() // goconcurrencylint:ignore  legacy code, see issue #42
+```
+
+- A list of one or more category IDs (separated by spaces, commas or semicolons) silences only those checks on the line.
+- A bare `// goconcurrencylint:ignore`, or a directive followed only by free text, silences every check on the line.
+- Tokens after the first one that does not match a known category are treated as a human-readable note, so `// goconcurrencylint:ignore lock-without-unlock because foo` only silences `lock-without-unlock`.
 
 ## Examples
 

--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/common"
+	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/common/category"
 	commnetfilter "github.com/sanbricio/goconcurrencylint/pkg/analyzer/common/commentfilter"
 	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/common/report"
 	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/mutex"
@@ -16,12 +17,13 @@ import (
 )
 
 // Analyzer is the main entry point for the goconcurrencylint linter.
-// It detects common mistakes in the use of sync.Mutex and sync.WaitGroup:
-// - Locks without unlocks
-// - Add without Done
+// It performs control-flow-sensitive analysis to detect structural misuse
+// of sync.Mutex, sync.RWMutex, and sync.WaitGroup, plus copy-by-value of
+// these primitives. Each diagnostic is emitted with a stable Category
+// identifier so downstream tooling can filter by check.
 var Analyzer = &analysis.Analyzer{
 	Name:     "goconcurrencylint",
-	Doc:      "Detects common mistakes in the use of sync.Mutex and sync.WaitGroup: locks without unlock and Add without Done.",
+	Doc:      "Detects misuse of sync.Mutex, sync.RWMutex and sync.WaitGroup, plus copy-by-value of sync primitives.",
 	Run:      run,
 	Requires: []*analysis.Analyzer{},
 }
@@ -37,19 +39,40 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	errorCollector := &report.ErrorCollector{}
 	pkgPrimitives := collectPackageLevelPrimitives(pass)
 
-	detectCopyByValue(pass, errorCollector)
+	filtersByFile := make(map[string]*commnetfilter.CommentFilter, len(pass.Files))
 	for _, file := range pass.Files {
-		analyzeFunctions(file, pass, errorCollector, pkgPrimitives)
+		cf := commnetfilter.NewCommentFilter(pass.Fset, file)
+		if name := cf.FileName(); name != "" {
+			filtersByFile[name] = cf
+		}
+		analyzeFunctionsWithFilter(file, cf, pass, errorCollector, pkgPrimitives)
 	}
+	detectCopyByValue(pass, errorCollector)
 
-	errorCollector.ReportAll(pass)
+	errorCollector.ReportAll(pass, ignoreFromFilters(filtersByFile))
 	return nil, nil
 }
 
-// analyzeFunctions processes all function declarations in a file
-func analyzeFunctions(file *ast.File, pass *analysis.Pass, errorCollector *report.ErrorCollector, pkgPrimitives *syncPrimitive) {
-	commentFilter := commnetfilter.NewCommentFilter(pass.Fset, file)
+// ignoreFromFilters returns an IgnoreFunc that consults the per-file
+// CommentFilter for inline directives. A nil map is treated as "no
+// directives present anywhere".
+func ignoreFromFilters(filters map[string]*commnetfilter.CommentFilter) report.IgnoreFunc {
+	if len(filters) == 0 {
+		return nil
+	}
+	return func(filename string, line int, cat string) bool {
+		cf, ok := filters[filename]
+		if !ok {
+			return false
+		}
+		return cf.IsCategoryIgnored(line, cat)
+	}
+}
 
+// analyzeFunctionsWithFilter processes all function declarations in a file
+// using a pre-built CommentFilter, so the same instance is reused for
+// per-file ignore-directive lookups at report time.
+func analyzeFunctionsWithFilter(file *ast.File, commentFilter *commnetfilter.CommentFilter, pass *analysis.Pass, errorCollector *report.ErrorCollector, pkgPrimitives *syncPrimitive) {
 	for _, decl := range file.Decls {
 		fn, ok := decl.(*ast.FuncDecl)
 		if !ok || fn.Body == nil {
@@ -304,7 +327,7 @@ func reportCopyByValueFieldList(fields *ast.FieldList, pass *analysis.Pass, erro
 			continue
 		}
 		for _, name := range field.Names {
-			errorCollector.AddError(name.Pos(), copyByValueMessage(kind, name.Name))
+			errorCollector.AddError(name.Pos(), category.SyncPrimitiveCopy, copyByValueMessage(kind, name.Name))
 		}
 	}
 }
@@ -316,7 +339,7 @@ func reportCopyByValueValueSpec(vs *ast.ValueSpec, pass *analysis.Pass, errorCol
 
 	for _, value := range vs.Values {
 		if kind, name, ok := copiedSyncPrimitive(value, pass); ok {
-			errorCollector.AddError(value.Pos(), copyByValueMessage(kind, name))
+			errorCollector.AddError(value.Pos(), category.SyncPrimitiveCopy, copyByValueMessage(kind, name))
 		}
 	}
 }
@@ -331,7 +354,7 @@ func reportCopyByValueAssignments(assign *ast.AssignStmt, pass *analysis.Pass, e
 			continue
 		}
 		if kind, name, ok := copiedSyncPrimitive(rhs, pass); ok {
-			errorCollector.AddError(rhs.Pos(), copyByValueMessage(kind, name))
+			errorCollector.AddError(rhs.Pos(), category.SyncPrimitiveCopy, copyByValueMessage(kind, name))
 		}
 	}
 }
@@ -343,7 +366,7 @@ func reportCopyByValueArgs(call *ast.CallExpr, pass *analysis.Pass, errorCollect
 
 	for _, arg := range call.Args {
 		if kind, name, ok := copiedSyncPrimitive(arg, pass); ok {
-			errorCollector.AddError(arg.Pos(), copyByValueMessage(kind, name))
+			errorCollector.AddError(arg.Pos(), category.SyncPrimitiveCopy, copyByValueMessage(kind, name))
 		}
 	}
 }

--- a/pkg/analyzer/analyzer_integration_test.go
+++ b/pkg/analyzer/analyzer_integration_test.go
@@ -13,6 +13,7 @@ func TestAnalyzerFixtures(t *testing.T) {
 		{name: "mutex", packages: []string{"mutex"}},
 		{name: "waitgroup", packages: []string{"waitgroup"}},
 		{name: "packagelevel", packages: []string{"packagelevel"}},
+		{name: "ignoredirective", packages: []string{"ignoredirective"}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			analysistest.Run(t, analysistest.TestData(), Analyzer, tc.packages...)

--- a/pkg/analyzer/category_propagation_test.go
+++ b/pkg/analyzer/category_propagation_test.go
@@ -1,0 +1,46 @@
+package analyzer
+
+import (
+	"testing"
+
+	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/common/category"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/tools/go/analysis/analysistest"
+)
+
+// TestDiagnosticCategoryPropagation runs the analyzer over the full set of
+// fixtures and verifies every emitted diagnostic carries a Category that
+// belongs to the public catalogue. This catches regressions where a new
+// AddError call site forgets to pass a category, or where a refactor breaks
+// the wire-up between ErrorCollector and pass.Report.
+func TestDiagnosticCategoryPropagation(t *testing.T) {
+	known := make(map[string]struct{}, len(category.All()))
+	for _, id := range category.All() {
+		known[id] = struct{}{}
+	}
+
+	results := analysistest.Run(t, analysistest.TestData(), Analyzer,
+		"mutex", "waitgroup", "packagelevel", "ignoredirective")
+
+	totalDiagnostics := 0
+	for _, res := range results {
+		require.NotNil(t, res.Pass, "analysistest must return a non-nil Pass")
+		for _, diag := range res.Diagnostics {
+			totalDiagnostics++
+			pos := res.Pass.Fset.Position(diag.Pos)
+			assert.NotEmpty(t, diag.Category,
+				"diagnostic at %s missing Category: %q", pos, diag.Message)
+			if diag.Category == "" {
+				continue
+			}
+			_, ok := known[diag.Category]
+			assert.True(t, ok,
+				"diagnostic at %s carries unknown Category %q (message: %q)",
+				pos, diag.Category, diag.Message)
+		}
+	}
+
+	assert.Greater(t, totalDiagnostics, 0,
+		"expected the fixtures to produce at least one diagnostic")
+}

--- a/pkg/analyzer/common/category/category.go
+++ b/pkg/analyzer/common/category/category.go
@@ -1,0 +1,90 @@
+// Package category defines stable check identifiers used as
+// analysis.Diagnostic.Category values. Tools like golangci-lint and IDE
+// integrations filter diagnostics by these IDs, and the inline directive
+// `// goconcurrencylint:ignore <id>...` matches against them.
+//
+// IDs are kept lowercase-kebab-case and must remain stable: changing one is
+// a breaking change for downstream consumers and ignore directives.
+package category
+
+const (
+	// Mutex / RWMutex checks.
+	LockWithoutUnlock      = "lock-without-unlock"
+	UnlockWithoutLock      = "unlock-without-lock"
+	DeferUnlockWithoutLock = "defer-unlock-without-lock"
+	UncheckedTryLock       = "unchecked-trylock"
+	DeferLock              = "defer-lock"
+	MutexInLoop            = "mutex-in-loop"
+	DeferUnlockInLoop      = "defer-unlock-in-loop"
+	RWMutexAPIMismatch     = "rwmutex-api-mismatch"
+	GoroutineLockDeadlock  = "goroutine-lock-deadlock"
+	PanicBeforeUnlock      = "panic-before-unlock"
+	DoubleLock             = "double-lock"
+	CrossGoroutineUnlock   = "cross-goroutine-unlock"
+	LockOrderCycle         = "lock-order-cycle"
+
+	// WaitGroup checks.
+	AddWithoutDone          = "add-without-done"
+	DoneWithoutAdd          = "done-without-add"
+	AddAfterWait            = "add-after-wait"
+	GoAfterWait             = "go-after-wait"
+	AddInsideGoroutine      = "add-inside-goroutine"
+	DoneNotDeferred         = "done-not-deferred"
+	AddLoopCountMismatch    = "add-loop-count-mismatch"
+	AddZero                 = "add-zero"
+	AddNegative             = "add-negative"
+	WaitWithoutAdd          = "wait-without-add"
+	WaitDeadlock            = "wait-deadlock"
+	MultipleDoneWorker      = "multiple-done-worker"
+	NestedWaitGroupDeadlock = "nested-waitgroup-deadlock"
+	DoneOutsideGoroutine    = "done-outside-goroutine"
+	GoPanic                 = "go-panic"
+
+	// Cross-primitive.
+	SyncPrimitiveCopy = "sync-primitive-copy"
+)
+
+// All returns every known check category. Order is not significant.
+func All() []string {
+	return []string{
+		LockWithoutUnlock,
+		UnlockWithoutLock,
+		DeferUnlockWithoutLock,
+		UncheckedTryLock,
+		DeferLock,
+		MutexInLoop,
+		DeferUnlockInLoop,
+		RWMutexAPIMismatch,
+		GoroutineLockDeadlock,
+		PanicBeforeUnlock,
+		DoubleLock,
+		CrossGoroutineUnlock,
+		LockOrderCycle,
+		AddWithoutDone,
+		DoneWithoutAdd,
+		AddAfterWait,
+		GoAfterWait,
+		AddInsideGoroutine,
+		DoneNotDeferred,
+		AddLoopCountMismatch,
+		AddZero,
+		AddNegative,
+		WaitWithoutAdd,
+		WaitDeadlock,
+		MultipleDoneWorker,
+		NestedWaitGroupDeadlock,
+		DoneOutsideGoroutine,
+		GoPanic,
+		SyncPrimitiveCopy,
+	}
+}
+
+// IsKnown reports whether id is a recognised check category.
+func IsKnown(id string) bool {
+	for _, c := range All() {
+		if c == id {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/analyzer/common/commentfilter/filter.go
+++ b/pkg/analyzer/common/commentfilter/filter.go
@@ -5,33 +5,62 @@ import (
 	"go/ast"
 	"go/token"
 	"strings"
+
+	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/common/category"
 )
 
 const ignoreDirective = "goconcurrencylint:ignore"
 
-// CommentFilter helps filter out code that is within comments
+// CommentFilter helps filter out code that is within comments and tracks
+// per-line `goconcurrencylint:ignore` directives. The directive can be
+// either bare (silences every category on the line) or carry a list of
+// category IDs separated by spaces or commas, e.g.:
+//
+//	wg.Wait() // goconcurrencylint:ignore wait-without-add
+//	mu.Lock() // goconcurrencylint:ignore lock-without-unlock,defer-lock
+//	mu.Lock() // goconcurrencylint:ignore     <- silences every check
 type CommentFilter struct {
-	fileSet              *token.FileSet
-	comments             []*ast.CommentGroup
-	ignoreDirectiveLines map[int]bool
+	fileSet      *token.FileSet
+	fileName     string
+	comments     []*ast.CommentGroup
+	ignoreByLine map[int]*ignoreEntry
 }
 
-// NewCommentFilter creates a new comment filter
+// ignoreEntry records the categories silenced for a given line. all=true
+// means a bare directive that silences every category.
+type ignoreEntry struct {
+	all        bool
+	categories map[string]struct{}
+}
+
+// NewCommentFilter creates a new comment filter. fileName is derived from
+// the first comment in the file when available; this lets the orchestrator
+// route filters to diagnostics by filename without an extra parameter.
 func NewCommentFilter(fset *token.FileSet, file *ast.File) *CommentFilter {
 	var comments []*ast.CommentGroup
+	var fileName string
 	if file != nil {
 		comments = file.Comments
+		if file.Pos().IsValid() && fset != nil {
+			fileName = fset.Position(file.Pos()).Filename
+		}
 	}
 	cf := &CommentFilter{
-		fileSet:              fset,
-		comments:             comments,
-		ignoreDirectiveLines: make(map[int]bool),
+		fileSet:      fset,
+		fileName:     fileName,
+		comments:     comments,
+		ignoreByLine: make(map[int]*ignoreEntry),
 	}
-	cf.indexIgnoreDirectiveLines()
+	cf.indexIgnoreDirectives()
 	return cf
 }
 
-// IsInComment checks if a position is within a comment
+// FileName returns the source filename this filter was built from.
+func (cf *CommentFilter) FileName() string {
+	return cf.fileName
+}
+
+// IsInComment checks if a position is within a comment.
 func (cf *CommentFilter) IsInComment(pos token.Pos) bool {
 	if pos == token.NoPos {
 		return false
@@ -39,7 +68,6 @@ func (cf *CommentFilter) IsInComment(pos token.Pos) bool {
 
 	position := cf.fileSet.Position(pos)
 
-	// Check all comment groups
 	for _, group := range cf.comments {
 		for _, comment := range group.List {
 			if cf.positionInComment(position, comment) {
@@ -51,28 +79,57 @@ func (cf *CommentFilter) IsInComment(pos token.Pos) bool {
 	return false
 }
 
-// ShouldSkipCall checks if a call expression should be skipped
+// ShouldSkipCall reports whether a call expression sits inside a real
+// comment. Inline ignore directives are no longer honored here: they only
+// suppress diagnostics at report time so the analyzer can still update its
+// state correctly.
 func (cf *CommentFilter) ShouldSkipCall(call *ast.CallExpr) bool {
-	return cf.IsInComment(call.Pos()) || cf.HasIgnoreDirective(call.Pos())
+	if call == nil {
+		return false
+	}
+	return cf.IsInComment(call.Pos())
 }
 
-// ShouldSkipStatement checks if an entire statement should be skipped
+// ShouldSkipStatement reports whether a statement sits inside a real
+// comment. See ShouldSkipCall for the rationale on directives.
 func (cf *CommentFilter) ShouldSkipStatement(stmt ast.Stmt) bool {
-	return cf.IsInComment(stmt.Pos()) || cf.HasIgnoreDirective(stmt.Pos())
+	if stmt == nil {
+		return false
+	}
+	return cf.IsInComment(stmt.Pos())
 }
 
-// HasIgnoreDirective checks whether a goconcurrencylint ignore directive is on
-// the same line as the given position.
+// HasIgnoreDirective reports whether any goconcurrencylint:ignore directive
+// appears on the line of pos. It does not consider categories; use
+// IsCategoryIgnored to check a specific check ID.
 func (cf *CommentFilter) HasIgnoreDirective(pos token.Pos) bool {
 	if pos == token.NoPos || cf.fileSet == nil {
 		return false
 	}
-
-	position := cf.fileSet.Position(pos)
-	return cf.ignoreDirectiveLines[position.Line]
+	line := cf.fileSet.Position(pos).Line
+	_, ok := cf.ignoreByLine[line]
+	return ok
 }
 
-func (cf *CommentFilter) indexIgnoreDirectiveLines() {
+// IsCategoryIgnored reports whether category is silenced at the given line.
+// A bare directive on that line silences every category. An empty category
+// only matches a bare directive (it never matches a per-rule list).
+func (cf *CommentFilter) IsCategoryIgnored(line int, category string) bool {
+	entry, ok := cf.ignoreByLine[line]
+	if !ok {
+		return false
+	}
+	if entry.all {
+		return true
+	}
+	if category == "" {
+		return false
+	}
+	_, ok = entry.categories[category]
+	return ok
+}
+
+func (cf *CommentFilter) indexIgnoreDirectives() {
 	if cf.fileSet == nil {
 		return
 	}
@@ -81,28 +138,93 @@ func (cf *CommentFilter) indexIgnoreDirectiveLines() {
 		for _, comment := range group.List {
 			commentStart := cf.fileSet.Position(comment.Pos())
 			for lineOffset, textLine := range strings.Split(comment.Text, "\n") {
-				if hasIgnoreDirective(textLine) {
-					cf.ignoreDirectiveLines[commentStart.Line+lineOffset] = true
+				cats, ok, all := parseIgnoreDirective(textLine)
+				if !ok {
+					continue
 				}
+				cf.recordIgnore(commentStart.Line+lineOffset, cats, all)
 			}
 		}
 	}
 }
 
-func hasIgnoreDirective(textLine string) bool {
+func (cf *CommentFilter) recordIgnore(line int, categories []string, all bool) {
+	entry, ok := cf.ignoreByLine[line]
+	if !ok {
+		entry = &ignoreEntry{categories: make(map[string]struct{})}
+		cf.ignoreByLine[line] = entry
+	}
+	if all {
+		entry.all = true
+		return
+	}
+	for _, c := range categories {
+		entry.categories[c] = struct{}{}
+	}
+}
+
+// parseIgnoreDirective scans a single comment line for the directive and
+// returns the categories listed after it. all=true is returned for a bare
+// directive (no recognised categories) — including the case where what
+// follows is a human-readable note.
+func parseIgnoreDirective(textLine string) (categories []string, found bool, all bool) {
 	start := 0
 	for {
 		idx := strings.Index(textLine[start:], ignoreDirective)
 		if idx < 0 {
-			return false
+			return nil, false, false
 		}
 
-		after := textLine[start+idx+len(ignoreDirective):]
-		if after == "" || after[0] == ' ' || after[0] == '\t' || strings.HasPrefix(after, "*/") {
+		afterStart := start + idx + len(ignoreDirective)
+		after := textLine[afterStart:]
+		switch {
+		case after == "":
+			return nil, true, true
+		case after[0] == ' ', after[0] == '\t':
+			cats := parseCategories(after)
+			return cats, true, len(cats) == 0
+		case strings.HasPrefix(after, "*/"):
+			return nil, true, true
+		}
+		start = afterStart
+	}
+}
+
+// parseCategories extracts known check IDs from the tail after the
+// directive. Tokens are read until the first one that does not match a
+// registered category — anything beyond that is treated as a human-readable
+// note (so `// goconcurrencylint:ignore lock-without-unlock because legacy`
+// silences only `lock-without-unlock`, while
+// `// goconcurrencylint:ignore explained later` is treated as a bare
+// directive that silences every check on the line).
+//
+// Recognised separators are spaces, tabs, commas and semicolons. The block
+// comment terminator "*/" ends parsing.
+func parseCategories(tail string) []string {
+	if idx := strings.Index(tail, "*/"); idx >= 0 {
+		tail = tail[:idx]
+	}
+	tail = strings.TrimSpace(tail)
+	if tail == "" {
+		return nil
+	}
+
+	fields := strings.FieldsFunc(tail, func(r rune) bool {
+		switch r {
+		case ' ', '\t', ',', ';':
 			return true
 		}
-		start += idx + len(ignoreDirective)
+		return false
+	})
+
+	out := make([]string, 0, len(fields))
+	for _, f := range fields {
+		if !category.IsKnown(f) {
+			break
+		}
+		out = append(out, f)
 	}
+	return out
 }
 
 // positionInComment checks if a position is within a specific comment
@@ -110,17 +232,14 @@ func (cf *CommentFilter) positionInComment(pos token.Position, comment *ast.Comm
 	commentStart := cf.fileSet.Position(comment.Pos())
 	commentEnd := cf.fileSet.Position(comment.End())
 
-	// Must be in the same file
 	if pos.Filename != commentStart.Filename {
 		return false
 	}
 
-	// For block comments /* */
 	if strings.HasPrefix(comment.Text, "/*") {
 		return cf.isInBlockComment(pos, commentStart, commentEnd)
 	}
 
-	// For line comments //
 	if strings.HasPrefix(comment.Text, "//") {
 		return cf.isInLineComment(pos, commentStart)
 	}
@@ -128,16 +247,13 @@ func (cf *CommentFilter) positionInComment(pos token.Position, comment *ast.Comm
 	return false
 }
 
-// isInBlockComment checks if position is within a block comment
 func (cf *CommentFilter) isInBlockComment(pos, start, end token.Position) bool {
-	// Same line start and end
 	if start.Line == end.Line {
 		return pos.Line == start.Line &&
 			pos.Column >= start.Column &&
 			pos.Column <= end.Column
 	}
 
-	// Multi-line block comment
 	if pos.Line > start.Line && pos.Line < end.Line {
 		return true
 	}
@@ -153,13 +269,9 @@ func (cf *CommentFilter) isInBlockComment(pos, start, end token.Position) bool {
 	return false
 }
 
-// isInLineComment checks if position is within a line comment
 func (cf *CommentFilter) isInLineComment(pos, commentStart token.Position) bool {
-	// Line comments only affect their own line
 	if pos.Line != commentStart.Line {
 		return false
 	}
-
-	// Position must be at or after the comment start
 	return pos.Column >= commentStart.Column
 }

--- a/pkg/analyzer/common/commentfilter/filter_test.go
+++ b/pkg/analyzer/common/commentfilter/filter_test.go
@@ -654,22 +654,30 @@ func main() {
 	require.NoError(t, err)
 
 	cf := NewCommentFilter(fset, file)
-	var skipped, reported int
+	// ShouldSkipCall ignores directives on purpose: they only filter at
+	// report time so the analyzer can keep tracking state.
 	ast.Inspect(file, func(n ast.Node) bool {
-		call, ok := n.(*ast.CallExpr)
-		if !ok {
-			return true
+		if call, ok := n.(*ast.CallExpr); ok {
+			assert.False(t, cf.ShouldSkipCall(call), "ShouldSkipCall must not honor ignore directives")
 		}
-		if cf.ShouldSkipCall(call) {
-			skipped++
-			return true
-		}
-		reported++
 		return true
 	})
 
-	assert.Equal(t, 1, skipped)
-	assert.Equal(t, 1, reported)
+	var directiveLine int
+	ast.Inspect(file, func(n ast.Node) bool {
+		if call, ok := n.(*ast.CallExpr); ok {
+			pos := fset.Position(call.Pos())
+			if cf.HasIgnoreDirective(call.Pos()) {
+				directiveLine = pos.Line
+			}
+		}
+		return true
+	})
+	assert.NotZero(t, directiveLine, "expected to locate the directive line")
+	assert.True(t, cf.IsCategoryIgnored(directiveLine, "wait-without-add"))
+	assert.False(t, cf.IsCategoryIgnored(directiveLine, "lock-without-unlock"))
+	// Other lines unaffected.
+	assert.False(t, cf.IsCategoryIgnored(directiveLine+1, "wait-without-add"))
 }
 
 func TestCommentFilter_IgnoreDirectiveRequiresBoundary(t *testing.T) {
@@ -688,20 +696,70 @@ func main() {
 	require.NoError(t, err)
 
 	cf := NewCommentFilter(fset, file)
-	var skipped, reported int
+	directiveLines := map[int]bool{}
 	ast.Inspect(file, func(n ast.Node) bool {
 		call, ok := n.(*ast.CallExpr)
 		if !ok {
 			return true
 		}
-		if cf.ShouldSkipCall(call) {
-			skipped++
-			return true
+		if cf.HasIgnoreDirective(call.Pos()) {
+			directiveLines[fset.Position(call.Pos()).Line] = true
 		}
-		reported++
 		return true
 	})
 
-	assert.Equal(t, 1, skipped)
-	assert.Equal(t, 3, reported)
+	assert.Len(t, directiveLines, 1, "only the bare ignore directive should match; near-misses must not trigger")
+}
+
+func TestCommentFilter_IgnoreDirectiveBareSilencesEverything(t *testing.T) {
+	src := `package main
+
+func main() {
+	mu.Lock() // goconcurrencylint:ignore  any human note here
+}
+`
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "test.go", src, parser.ParseComments)
+	require.NoError(t, err)
+
+	cf := NewCommentFilter(fset, file)
+
+	var line int
+	ast.Inspect(file, func(n ast.Node) bool {
+		if call, ok := n.(*ast.CallExpr); ok {
+			line = fset.Position(call.Pos()).Line
+		}
+		return true
+	})
+	require.NotZero(t, line)
+
+	assert.True(t, cf.IsCategoryIgnored(line, "lock-without-unlock"))
+	assert.True(t, cf.IsCategoryIgnored(line, "anything"))
+}
+
+func TestCommentFilter_IgnoreDirectiveMultipleCategories(t *testing.T) {
+	src := `package main
+
+func main() {
+	mu.Lock() // goconcurrencylint:ignore lock-without-unlock, defer-lock
+}
+`
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "test.go", src, parser.ParseComments)
+	require.NoError(t, err)
+
+	cf := NewCommentFilter(fset, file)
+
+	var line int
+	ast.Inspect(file, func(n ast.Node) bool {
+		if call, ok := n.(*ast.CallExpr); ok {
+			line = fset.Position(call.Pos()).Line
+		}
+		return true
+	})
+	require.NotZero(t, line)
+
+	assert.True(t, cf.IsCategoryIgnored(line, "lock-without-unlock"))
+	assert.True(t, cf.IsCategoryIgnored(line, "defer-lock"))
+	assert.False(t, cf.IsCategoryIgnored(line, "wait-without-add"))
 }

--- a/pkg/analyzer/common/report/report.go
+++ b/pkg/analyzer/common/report/report.go
@@ -7,22 +7,36 @@ import (
 	"golang.org/x/tools/go/analysis"
 )
 
-// ErrorReport represents a single error to be reported
+// ErrorReport represents a single diagnostic to be reported. Category must
+// match a stable identifier from the category package so downstream tools
+// (golangci-lint, IDE integrations) and the inline ignore directive can
+// filter by it.
 type ErrorReport struct {
-	Pos     token.Pos
-	Message string
+	Pos      token.Pos
+	Category string
+	Message  string
 }
 
-// ErrorCollector collects all errors and allows sorting them by position
+// IgnoreFunc decides whether a diagnostic should be suppressed based on its
+// location and category. It is consulted at report time; passing a nil
+// IgnoreFunc disables filtering.
+type IgnoreFunc func(filename string, line int, category string) bool
+
+// ErrorCollector accumulates diagnostics across files, deduplicates by
+// (Pos, Category, Message), and emits them sorted in deterministic order.
 type ErrorCollector struct {
 	errors []ErrorReport
 	seen   map[ErrorReport]struct{}
 }
 
-func (ec *ErrorCollector) AddError(pos token.Pos, message string) {
+// AddError records a diagnostic. category should be a constant from the
+// category package; passing an empty category is allowed for transitional
+// callers but will not match any per-rule ignore directive.
+func (ec *ErrorCollector) AddError(pos token.Pos, category, message string) {
 	report := ErrorReport{
-		Pos:     pos,
-		Message: message,
+		Pos:      pos,
+		Category: category,
+		Message:  message,
 	}
 
 	if ec.seen == nil {
@@ -35,8 +49,9 @@ func (ec *ErrorCollector) AddError(pos token.Pos, message string) {
 	ec.errors = append(ec.errors, report)
 }
 
-func (ec *ErrorCollector) ReportAll(pass *analysis.Pass) {
-	// Sort errors by position using the file set
+// ReportAll emits every collected diagnostic via pass.Report. When ignore is
+// non-nil, diagnostics for which it returns true are dropped.
+func (ec *ErrorCollector) ReportAll(pass *analysis.Pass, ignore IgnoreFunc) {
 	sort.Slice(ec.errors, func(i, j int) bool {
 		posI := pass.Fset.Position(ec.errors[i].Pos)
 		posJ := pass.Fset.Position(ec.errors[j].Pos)
@@ -46,9 +61,26 @@ func (ec *ErrorCollector) ReportAll(pass *analysis.Pass) {
 		if posI.Line != posJ.Line {
 			return posI.Line < posJ.Line
 		}
-		return posI.Column < posJ.Column
+		if posI.Column != posJ.Column {
+			return posI.Column < posJ.Column
+		}
+		if ec.errors[i].Category != ec.errors[j].Category {
+			return ec.errors[i].Category < ec.errors[j].Category
+		}
+		return ec.errors[i].Message < ec.errors[j].Message
 	})
+
 	for _, err := range ec.errors {
-		pass.Reportf(err.Pos, "%s", err.Message)
+		if ignore != nil {
+			pos := pass.Fset.Position(err.Pos)
+			if ignore(pos.Filename, pos.Line, err.Category) {
+				continue
+			}
+		}
+		pass.Report(analysis.Diagnostic{
+			Pos:      err.Pos,
+			Category: err.Category,
+			Message:  err.Message,
+		})
 	}
 }

--- a/pkg/analyzer/common/report/report_test.go
+++ b/pkg/analyzer/common/report/report_test.go
@@ -15,9 +15,9 @@ func TestErrorCollector_ReportAll(t *testing.T) {
 
 	t.Run("basic order", func(t *testing.T) {
 		ec := &ErrorCollector{}
-		ec.AddError(pos1, "first error")
-		ec.AddError(pos2, "second error")
-		ec.AddError(pos3, "third error")
+		ec.AddError(pos1, "cat", "first error")
+		ec.AddError(pos2, "cat", "second error")
+		ec.AddError(pos3, "cat", "third error")
 
 		var reported []struct {
 			Pos     token.Position
@@ -35,7 +35,7 @@ func TestErrorCollector_ReportAll(t *testing.T) {
 				})
 			},
 		}
-		ec.ReportAll(pass)
+		ec.ReportAll(pass, nil)
 		assert.Len(t, reported, 3)
 		assert.Equal(t, "foo.go", reported[0].Pos.Filename)
 		assert.Equal(t, "first error", reported[0].Message)
@@ -65,14 +65,14 @@ func TestErrorCollector_ReportAll(t *testing.T) {
 				})
 			},
 		}
-		ec.ReportAll(pass)
+		ec.ReportAll(pass, nil)
 		assert.Len(t, reported, 0)
 	})
 
 	t.Run("same position", func(t *testing.T) {
 		ec := &ErrorCollector{}
-		ec.AddError(pos1, "err1")
-		ec.AddError(pos1, "err2")
+		ec.AddError(pos1, "cat", "err1")
+		ec.AddError(pos1, "cat", "err2")
 		var reported []string
 		pass := &analysis.Pass{
 			Fset: fset,
@@ -80,7 +80,7 @@ func TestErrorCollector_ReportAll(t *testing.T) {
 				reported = append(reported, d.Message)
 			},
 		}
-		ec.ReportAll(pass)
+		ec.ReportAll(pass, nil)
 		assert.Equal(t, []string{"err1", "err2"}, reported)
 	})
 
@@ -91,8 +91,8 @@ func TestErrorCollector_ReportAll(t *testing.T) {
 		posA := fileA.Pos(5)
 		posB := fileB.Pos(5)
 		ec := &ErrorCollector{}
-		ec.AddError(posB, "errB")
-		ec.AddError(posA, "errA")
+		ec.AddError(posB, "cat", "errB")
+		ec.AddError(posA, "cat", "errA")
 		var reported []string
 		pass := &analysis.Pass{
 			Fset: fset2,
@@ -100,24 +100,22 @@ func TestErrorCollector_ReportAll(t *testing.T) {
 				reported = append(reported, d.Message)
 			},
 		}
-		ec.ReportAll(pass)
+		ec.ReportAll(pass, nil)
 		assert.Equal(t, []string{"errA", "errB"}, reported)
 	})
 
 	t.Run("different lines in same file", func(t *testing.T) {
 		ec := &ErrorCollector{}
-		// Creamos archivo con al menos 5 líneas
 		file2 := fset.AddFile("foo2.go", -1, 100)
-		// AddLine añade inicio de línea en offset creciente, para simular saltos de línea
-		file2.AddLine(10)              // línea 2
-		file2.AddLine(20)              // línea 3
-		file2.AddLine(30)              // línea 4
-		file2.AddLine(40)              // línea 5
-		posLine1 := file2.LineStart(1) // línea 1
-		posLine5 := file2.LineStart(5) // línea 5
+		file2.AddLine(10)
+		file2.AddLine(20)
+		file2.AddLine(30)
+		file2.AddLine(40)
+		posLine1 := file2.LineStart(1)
+		posLine5 := file2.LineStart(5)
 
-		ec.AddError(posLine5, "err5")
-		ec.AddError(posLine1, "err1")
+		ec.AddError(posLine5, "cat", "err5")
+		ec.AddError(posLine1, "cat", "err1")
 
 		var reported []struct {
 			Line    int
@@ -135,7 +133,7 @@ func TestErrorCollector_ReportAll(t *testing.T) {
 				})
 			},
 		}
-		ec.ReportAll(pass)
+		ec.ReportAll(pass, nil)
 		assert.Equal(t, 2, len(reported))
 		assert.Equal(t, 1, reported[0].Line)
 		assert.Equal(t, "err1", reported[0].Message)
@@ -145,7 +143,7 @@ func TestErrorCollector_ReportAll(t *testing.T) {
 
 	t.Run("empty message", func(t *testing.T) {
 		ec := &ErrorCollector{}
-		ec.AddError(pos1, "")
+		ec.AddError(pos1, "cat", "")
 		var reported []string
 		pass := &analysis.Pass{
 			Fset: fset,
@@ -153,22 +151,54 @@ func TestErrorCollector_ReportAll(t *testing.T) {
 				reported = append(reported, d.Message)
 			},
 		}
-		ec.ReportAll(pass)
+		ec.ReportAll(pass, nil)
 		assert.Equal(t, []string{""}, reported)
 	})
 
-	t.Run("error report struct", func(t *testing.T) {
-		rep := ErrorReport{Pos: token.Pos(42), Message: "msg"}
-		assert.Equal(t, token.Pos(42), rep.Pos)
-		assert.Equal(t, "msg", rep.Message)
+	t.Run("category preserved", func(t *testing.T) {
+		ec := &ErrorCollector{}
+		ec.AddError(pos1, "lock-without-unlock", "msg")
+		var got string
+		pass := &analysis.Pass{
+			Fset: fset,
+			Report: func(d analysis.Diagnostic) {
+				got = d.Category
+			},
+		}
+		ec.ReportAll(pass, nil)
+		assert.Equal(t, "lock-without-unlock", got)
 	})
 
-	t.Run("direct access to errors field", func(t *testing.T) {
+	t.Run("ignore func filters by category", func(t *testing.T) {
 		ec := &ErrorCollector{}
-		ec.AddError(pos1, "foo")
-		ec.AddError(pos2, "bar")
-		assert.Len(t, ec.errors, 2)
-		assert.Equal(t, "foo", ec.errors[0].Message)
-		assert.Equal(t, "bar", ec.errors[1].Message)
+		ec.AddError(pos1, "lock-without-unlock", "kept")
+		ec.AddError(pos2, "wait-without-add", "dropped")
+		var got []string
+		pass := &analysis.Pass{
+			Fset: fset,
+			Report: func(d analysis.Diagnostic) {
+				got = append(got, d.Message)
+			},
+		}
+		ignore := func(_ string, _ int, category string) bool {
+			return category == "wait-without-add"
+		}
+		ec.ReportAll(pass, ignore)
+		assert.Equal(t, []string{"kept"}, got)
+	})
+
+	t.Run("dedup by pos+category+message", func(t *testing.T) {
+		ec := &ErrorCollector{}
+		ec.AddError(pos1, "cat", "msg")
+		ec.AddError(pos1, "cat", "msg")          // exact dup
+		ec.AddError(pos1, "other-cat", "msg")    // different category, kept
+		ec.AddError(pos1, "cat", "different")    // different message, kept
+		var n int
+		pass := &analysis.Pass{
+			Fset: fset,
+			Report: func(d analysis.Diagnostic) { n++ },
+		}
+		ec.ReportAll(pass, nil)
+		assert.Equal(t, 3, n)
 	})
 }

--- a/pkg/analyzer/mutex/behavior.go
+++ b/pkg/analyzer/mutex/behavior.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 
 	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/common"
+	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/common/category"
 )
 
 type lockOrderEdge struct {
@@ -172,7 +173,7 @@ func (ma *Analyzer) recordHeldLockOrderEdges(varName string, pos token.Pos, held
 		}
 		reported[reportKey] = true
 		first, second := orderedLockNames(heldName, varName)
-		ma.errorCollector.AddError(pos, "mutex lock order cycle between '"+first+"' and '"+second+"'")
+		ma.errorCollector.AddError(pos, category.LockOrderCycle, "mutex lock order cycle between '"+first+"' and '"+second+"'")
 	}
 }
 
@@ -307,7 +308,7 @@ func (ma *Analyzer) scanCrossGoroutineReleaseCall(call *ast.CallExpr, parentStat
 			}
 			if ma.parentHoldsExclusiveLock(parentStats, varName) {
 				releases.unlocks[varName] = append(releases.unlocks[varName], call.Pos())
-				ma.errorCollector.AddError(call.Pos(), "mutex '"+varName+"' is unlocked in a different goroutine than it was locked")
+				ma.errorCollector.AddError(call.Pos(), category.CrossGoroutineUnlock, "mutex '"+varName+"' is unlocked in a different goroutine than it was locked")
 			}
 		}
 	case "RLock", "TryRLock":
@@ -322,7 +323,7 @@ func (ma *Analyzer) scanCrossGoroutineReleaseCall(call *ast.CallExpr, parentStat
 			}
 			if ma.parentHoldsReadLock(parentStats, varName) {
 				releases.runlocks[varName] = append(releases.runlocks[varName], call.Pos())
-				ma.errorCollector.AddError(call.Pos(), "rwmutex '"+varName+"' is runlocked in a different goroutine than it was rlocked")
+				ma.errorCollector.AddError(call.Pos(), category.CrossGoroutineUnlock, "rwmutex '"+varName+"' is runlocked in a different goroutine than it was rlocked")
 			}
 		}
 	}

--- a/pkg/analyzer/mutex/panic.go
+++ b/pkg/analyzer/mutex/panic.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 
 	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/common"
+	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/common/category"
 )
 
 func (ma *Analyzer) reportPotentialPanicWhileLocked(stmt ast.Stmt, stats map[string]*Stats) {
@@ -41,14 +42,14 @@ func (ma *Analyzer) reportPotentialPanicWhileLocked(stmt ast.Stmt, stats map[str
 			continue
 		}
 		if ma.mutexNames[name] && ma.remainingLockCount(st.lock, st.deferUnlock) > 0 {
-			ma.errorCollector.AddError(panicPos, "mutex '"+name+"' may remain locked if index expression panics before unlock")
+			ma.errorCollector.AddError(panicPos, category.PanicBeforeUnlock, "mutex '"+name+"' may remain locked if index expression panics before unlock")
 		}
 		if ma.rwMutexNames[name] {
 			if ma.remainingLockCount(st.lock, st.deferUnlock) > 0 {
-				ma.errorCollector.AddError(panicPos, "rwmutex '"+name+"' may remain locked if index expression panics before unlock")
+				ma.errorCollector.AddError(panicPos, category.PanicBeforeUnlock, "rwmutex '"+name+"' may remain locked if index expression panics before unlock")
 			}
 			if ma.remainingLockCount(st.rlock, st.deferRUnlock) > 0 {
-				ma.errorCollector.AddError(panicPos, "rwmutex '"+name+"' may remain rlocked if index expression panics before runlock")
+				ma.errorCollector.AddError(panicPos, category.PanicBeforeUnlock, "rwmutex '"+name+"' may remain rlocked if index expression panics before runlock")
 			}
 		}
 	}

--- a/pkg/analyzer/mutex/stats.go
+++ b/pkg/analyzer/mutex/stats.go
@@ -5,6 +5,7 @@ import (
 	"go/token"
 
 	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/common"
+	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/common/category"
 )
 
 // analyzeBlock analyzes a block statement starting from the provided state and
@@ -95,16 +96,16 @@ func (ma *Analyzer) analyzeExpressionStatement(stmt *ast.ExprStmt, stats map[str
 	switch sel.Sel.Name {
 	case "TryLock":
 		if ma.mutexNames[varName] {
-			ma.errorCollector.AddError(call.Pos(), "mutex '"+varName+"' TryLock return value not checked, lock may not be held")
+			ma.errorCollector.AddError(call.Pos(), category.UncheckedTryLock, "mutex '"+varName+"' TryLock return value not checked, lock may not be held")
 			return
 		}
 		if ma.rwMutexNames[varName] {
-			ma.errorCollector.AddError(call.Pos(), "rwmutex '"+varName+"' TryLock return value not checked, lock may not be held")
+			ma.errorCollector.AddError(call.Pos(), category.UncheckedTryLock, "rwmutex '"+varName+"' TryLock return value not checked, lock may not be held")
 			return
 		}
 	case "TryRLock":
 		if ma.rwMutexNames[varName] {
-			ma.errorCollector.AddError(call.Pos(), "rwmutex '"+varName+"' TryRLock return value not checked, lock may not be held")
+			ma.errorCollector.AddError(call.Pos(), category.UncheckedTryLock, "rwmutex '"+varName+"' TryRLock return value not checked, lock may not be held")
 			return
 		}
 	}
@@ -129,7 +130,7 @@ func (ma *Analyzer) handleMutexCall(varName, methodName string, pos token.Pos, s
 	switch methodName {
 	case "Lock":
 		if stats[varName].lock > 0 {
-			ma.errorCollector.AddError(pos, "mutex '"+varName+"' is re-locked before unlock")
+			ma.errorCollector.AddError(pos, category.DoubleLock, "mutex '"+varName+"' is re-locked before unlock")
 		}
 		if stats[varName].borrowedLock > 0 {
 			stats[varName].borrowedLock--
@@ -169,7 +170,7 @@ func (ma *Analyzer) handleRWMutexCall(varName, methodName string, pos token.Pos,
 	switch methodName {
 	case "Lock":
 		if stats[varName].rlock > 0 {
-			ma.errorCollector.AddError(pos, "rwmutex '"+varName+"' attempts write Lock while read lock is held")
+			ma.errorCollector.AddError(pos, category.DoubleLock, "rwmutex '"+varName+"' attempts write Lock while read lock is held")
 		}
 		if stats[varName].borrowedLock > 0 {
 			stats[varName].borrowedLock--
@@ -190,7 +191,7 @@ func (ma *Analyzer) handleRWMutexCall(varName, methodName string, pos token.Pos,
 		// Unlock called when only a read lock is held.
 		// Correct the state as if RUnlock was called to avoid cascading errors.
 		if stats[varName].rlock > 0 && stats[varName].lock == 0 {
-			ma.errorCollector.AddError(pos, "rwmutex '"+varName+"' Unlock called but only read lock is held, did you mean RUnlock?")
+			ma.errorCollector.AddError(pos, category.RWMutexAPIMismatch, "rwmutex '"+varName+"' Unlock called but only read lock is held, did you mean RUnlock?")
 			stats[varName].rlock--
 			ma.removeFirstRLockPos(stats[varName])
 			return
@@ -217,7 +218,7 @@ func (ma *Analyzer) handleRWMutexCall(varName, methodName string, pos token.Pos,
 		// RUnlock called when only a write lock is held.
 		// Correct the state as if Unlock was called to avoid cascading errors.
 		if stats[varName].lock > 0 && stats[varName].rlock == 0 {
-			ma.errorCollector.AddError(pos, "rwmutex '"+varName+"' RUnlock called but only write lock is held, did you mean Unlock?")
+			ma.errorCollector.AddError(pos, category.RWMutexAPIMismatch, "rwmutex '"+varName+"' RUnlock called but only write lock is held, did you mean Unlock?")
 			stats[varName].lock--
 			ma.removeFirstLockPos(stats[varName])
 			return
@@ -279,16 +280,16 @@ func (ma *Analyzer) handleDeferCall(call *ast.SelectorExpr, pos token.Pos, stats
 	// defer Lock / defer RLock re-acquires the lock on
 	// function return instead of releasing it, guaranteed deadlock.
 	if ma.mutexNames[varName] && call.Sel.Name == "Lock" {
-		ma.errorCollector.AddError(pos, "mutex '"+varName+"' defer calls Lock instead of Unlock, will deadlock on return")
+		ma.errorCollector.AddError(pos, category.DeferLock, "mutex '"+varName+"' defer calls Lock instead of Unlock, will deadlock on return")
 		return
 	}
 	if ma.rwMutexNames[varName] {
 		switch call.Sel.Name {
 		case "Lock":
-			ma.errorCollector.AddError(pos, "rwmutex '"+varName+"' defer calls Lock instead of Unlock, will deadlock on return")
+			ma.errorCollector.AddError(pos, category.DeferLock, "rwmutex '"+varName+"' defer calls Lock instead of Unlock, will deadlock on return")
 			return
 		case "RLock":
-			ma.errorCollector.AddError(pos, "rwmutex '"+varName+"' defer calls RLock instead of RUnlock, will deadlock on return")
+			ma.errorCollector.AddError(pos, category.DeferLock, "rwmutex '"+varName+"' defer calls RLock instead of RUnlock, will deadlock on return")
 			return
 		}
 	}

--- a/pkg/analyzer/mutex/trylock.go
+++ b/pkg/analyzer/mutex/trylock.go
@@ -4,6 +4,7 @@ import (
 	"go/ast"
 
 	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/common"
+	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/common/category"
 )
 
 func (ma *Analyzer) analyzeAssignStatement(stmt *ast.AssignStmt, stats map[string]*Stats) {
@@ -94,7 +95,7 @@ func (ma *Analyzer) reportUncheckedTryLockResult(result *tryLockResult) {
 	if result.isRWMutex {
 		mutexType = "rwmutex"
 	}
-	ma.errorCollector.AddError(result.pos, mutexType+" '"+result.varName+"' "+result.method+" return value not checked, lock may not be held")
+	ma.errorCollector.AddError(result.pos, category.UncheckedTryLock, mutexType+" '"+result.varName+"' "+result.method+" return value not checked, lock may not be held")
 }
 
 func (ma *Analyzer) applyTryLockResultToBranch(cond ast.Expr, stats map[string]*Stats) bool {

--- a/pkg/analyzer/mutex/validation.go
+++ b/pkg/analyzer/mutex/validation.go
@@ -7,6 +7,7 @@ import (
 	"maps"
 
 	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/common"
+	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/common/category"
 )
 
 // handleDeferUnlock processes defer unlock calls
@@ -16,7 +17,7 @@ func (ma *Analyzer) handleDeferUnlock(varName string, pos token.Pos, stats map[s
 		if isRWMutex {
 			mutexType = "rwmutex"
 		}
-		ma.errorCollector.AddError(pos, mutexType+" '"+varName+"' has defer unlock but no corresponding lock")
+		ma.errorCollector.AddError(pos, category.DeferUnlockWithoutLock, mutexType+" '"+varName+"' has defer unlock but no corresponding lock")
 		ma.deferErrors.badDeferUnlock[varName] = true
 	} else {
 		stats[varName].deferUnlock++
@@ -26,7 +27,7 @@ func (ma *Analyzer) handleDeferUnlock(varName string, pos token.Pos, stats map[s
 // handleDeferRUnlock processes defer runlock calls
 func (ma *Analyzer) handleDeferRUnlock(varName string, pos token.Pos, stats map[string]*Stats) {
 	if stats[varName].rlock == 0 {
-		ma.errorCollector.AddError(pos, "rwmutex '"+varName+"' has defer runlock but no corresponding rlock")
+		ma.errorCollector.AddError(pos, category.DeferUnlockWithoutLock, "rwmutex '"+varName+"' has defer runlock but no corresponding rlock")
 		ma.deferErrors.badDeferRUnlock[varName] = true
 	} else {
 		stats[varName].deferRUnlock++
@@ -226,7 +227,7 @@ func (ma *Analyzer) analyzeGoStatement(stmt *ast.GoStmt, stats map[string]*Stats
 			if stats[varName] != nil && stats[varName].lock > 0 {
 				if method, ok := ma.goroutineBodyLockCallMethod(fnLit.Body, varName, []string{"Lock"}); ok {
 					if ma.parentBlocksBeforeUnlock(stmt.Pos(), varName, []string{"Unlock"}) {
-						ma.errorCollector.AddError(stmt.Pos(),
+						ma.errorCollector.AddError(stmt.Pos(), category.GoroutineLockDeadlock,
 							ma.goroutineLockDeadlockMessage(varName, false, false, method, true))
 						continue
 					}
@@ -238,7 +239,7 @@ func (ma *Analyzer) analyzeGoStatement(stmt *ast.GoStmt, stats map[string]*Stats
 			if stats[varName] != nil && stats[varName].lock > 0 {
 				if method, ok := ma.goroutineBodyLockCallMethod(fnLit.Body, varName, []string{"Lock", "RLock"}); ok {
 					if ma.parentBlocksBeforeUnlock(stmt.Pos(), varName, []string{"Unlock"}) {
-						ma.errorCollector.AddError(stmt.Pos(),
+						ma.errorCollector.AddError(stmt.Pos(), category.GoroutineLockDeadlock,
 							ma.goroutineLockDeadlockMessage(varName, true, false, method, true))
 						continue
 					}
@@ -248,7 +249,7 @@ func (ma *Analyzer) analyzeGoStatement(stmt *ast.GoStmt, stats map[string]*Stats
 			if stats[varName] != nil && stats[varName].rlock > 0 {
 				if method, ok := ma.goroutineBodyLockCallMethod(fnLit.Body, varName, []string{"Lock"}); ok {
 					if ma.parentBlocksBeforeUnlock(stmt.Pos(), varName, []string{"RUnlock"}) {
-						ma.errorCollector.AddError(stmt.Pos(),
+						ma.errorCollector.AddError(stmt.Pos(), category.GoroutineLockDeadlock,
 							ma.goroutineLockDeadlockMessage(varName, true, true, method, true))
 						continue
 					}
@@ -413,11 +414,11 @@ func (ma *Analyzer) reportDeferredUnlocksInLoopStatements(stmts []ast.Stmt, lock
 					if ma.rwMutexNames[varName] {
 						mutexType = "rwmutex"
 					}
-					ma.errorCollector.AddError(s.Pos(), mutexType+" '"+varName+"' defers unlock inside loop")
+					ma.errorCollector.AddError(s.Pos(), category.DeferUnlockInLoop, mutexType+" '"+varName+"' defers unlock inside loop")
 				}
 			case "RUnlock":
 				if rlocked[varName] {
-					ma.errorCollector.AddError(s.Pos(), "rwmutex '"+varName+"' defers runlock inside loop")
+					ma.errorCollector.AddError(s.Pos(), category.DeferUnlockInLoop, "rwmutex '"+varName+"' defers runlock inside loop")
 				}
 			}
 
@@ -718,7 +719,7 @@ func (ma *Analyzer) reportBranchDelta(mutexName string, initial, final *Stats, i
 	lockMessage := mutexType + " '" + mutexName + "' is locked but not unlocked in " + branchType
 	if delta := ma.remainingLockCount(final.lock, final.deferUnlock) - ma.remainingLockCount(initial.lock, initial.deferUnlock); delta > 0 {
 		for _, pos := range ma.trailingPositions(final.lockPos, delta) {
-			ma.errorCollector.AddError(pos, lockMessage)
+			ma.errorCollector.AddError(pos, category.LockWithoutUnlock, lockMessage)
 		}
 	}
 
@@ -727,7 +728,7 @@ func (ma *Analyzer) reportBranchDelta(mutexName string, initial, final *Stats, i
 	unlockMessage := mutexType + " '" + mutexName + "' is unlocked but not locked"
 	if delta := final.borrowedLock - initial.borrowedLock; delta > 0 && !suppressBorrowedUnlock {
 		for _, pos := range ma.trailingPositions(final.borrowedUnlockPos, delta) {
-			ma.errorCollector.AddError(pos, unlockMessage)
+			ma.errorCollector.AddError(pos, category.UnlockWithoutLock, unlockMessage)
 		}
 	}
 
@@ -735,7 +736,7 @@ func (ma *Analyzer) reportBranchDelta(mutexName string, initial, final *Stats, i
 		rlockMessage := "rwmutex '" + mutexName + "' is rlocked but not runlocked in " + branchType
 		if delta := ma.remainingLockCount(final.rlock, final.deferRUnlock) - ma.remainingLockCount(initial.rlock, initial.deferRUnlock); delta > 0 {
 			for _, pos := range ma.trailingPositions(final.rlockPos, delta) {
-				ma.errorCollector.AddError(pos, rlockMessage)
+				ma.errorCollector.AddError(pos, category.LockWithoutUnlock, rlockMessage)
 			}
 		}
 
@@ -744,7 +745,7 @@ func (ma *Analyzer) reportBranchDelta(mutexName string, initial, final *Stats, i
 		runlockMessage := "rwmutex '" + mutexName + "' is runlocked but not rlocked"
 		if delta := final.borrowedRLock - initial.borrowedRLock; delta > 0 && !suppressBorrowedRUnlock {
 			for _, pos := range ma.trailingPositions(final.borrowedRUnlockPos, delta) {
-				ma.errorCollector.AddError(pos, runlockMessage)
+				ma.errorCollector.AddError(pos, category.UnlockWithoutLock, runlockMessage)
 			}
 		}
 	}
@@ -795,7 +796,7 @@ func (ma *Analyzer) reportUnmatchedMutexLocksWithContext(mutexName string, stats
 		if suppressFunctionLevelLock {
 			continue
 		}
-		ma.errorCollector.AddError(pos, lockMessage)
+		ma.errorCollector.AddError(pos, category.LockWithoutUnlock, lockMessage)
 	}
 
 	suppressFunctionLevelUnlock := branchType == "" &&
@@ -805,7 +806,7 @@ func (ma *Analyzer) reportUnmatchedMutexLocksWithContext(mutexName string, stats
 		if suppressFunctionLevelUnlock {
 			continue
 		}
-		ma.errorCollector.AddError(pos, mutexType+" '"+mutexName+"' is unlocked but not locked")
+		ma.errorCollector.AddError(pos, category.UnlockWithoutLock, mutexType+" '"+mutexName+"' is unlocked but not locked")
 	}
 
 	if isRWMutex {
@@ -814,7 +815,7 @@ func (ma *Analyzer) reportUnmatchedMutexLocksWithContext(mutexName string, stats
 			if suppressFunctionLevelRLock {
 				continue
 			}
-			ma.errorCollector.AddError(pos, rlockMessage)
+			ma.errorCollector.AddError(pos, category.LockWithoutUnlock, rlockMessage)
 		}
 		suppressFunctionLevelRUnlock := branchType == "" &&
 			(ma.functionIsLifecycleReleaseFor(mutexName, []string{"RLock", "TryRLock"}) ||
@@ -823,7 +824,7 @@ func (ma *Analyzer) reportUnmatchedMutexLocksWithContext(mutexName string, stats
 			if suppressFunctionLevelRUnlock {
 				continue
 			}
-			ma.errorCollector.AddError(pos, "rwmutex '"+mutexName+"' is runlocked but not rlocked")
+			ma.errorCollector.AddError(pos, category.UnlockWithoutLock, "rwmutex '"+mutexName+"' is runlocked but not rlocked")
 		}
 	}
 }
@@ -863,14 +864,14 @@ func (ma *Analyzer) reportUnmatchedLocks(stats map[string]*Stats) {
 		}
 		if conflict.parentReadLock {
 			if ma.remainingLockCount(st.rlock, st.deferRUnlock) > 0 {
-				ma.errorCollector.AddError(conflict.pos,
+				ma.errorCollector.AddError(conflict.pos, category.GoroutineLockDeadlock,
 					ma.goroutineLockDeadlockMessage(conflict.varName, true, true, conflict.requestMethod, false))
 			}
 			continue
 		}
 
 		if ma.remainingLockCount(st.lock, st.deferUnlock) > 0 {
-			ma.errorCollector.AddError(conflict.pos,
+			ma.errorCollector.AddError(conflict.pos, category.GoroutineLockDeadlock,
 				ma.goroutineLockDeadlockMessage(conflict.varName, conflict.isRWMutex, false, conflict.requestMethod, false))
 		}
 	}
@@ -919,10 +920,10 @@ func (ma *Analyzer) reportMutexInLoopValueSpec(vs *ast.ValueSpec) {
 		switch {
 		case common.IsMutex(typ):
 			ma.errorCollector.AddError(name.Pos(),
-				"mutex '"+name.Name+"' declared inside loop, each iteration creates a new mutex that cannot protect shared state")
+				category.MutexInLoop, "mutex '"+name.Name+"' declared inside loop, each iteration creates a new mutex that cannot protect shared state")
 		case common.IsRWMutex(typ):
 			ma.errorCollector.AddError(name.Pos(),
-				"rwmutex '"+name.Name+"' declared inside loop, each iteration creates a new mutex that cannot protect shared state")
+				category.MutexInLoop, "rwmutex '"+name.Name+"' declared inside loop, each iteration creates a new mutex that cannot protect shared state")
 		}
 	}
 }
@@ -943,10 +944,10 @@ func (ma *Analyzer) reportMutexInLoopAssign(s *ast.AssignStmt) {
 		switch {
 		case common.IsMutex(typ):
 			ma.errorCollector.AddError(ident.Pos(),
-				"mutex '"+ident.Name+"' declared inside loop, each iteration creates a new mutex that cannot protect shared state")
+				category.MutexInLoop, "mutex '"+ident.Name+"' declared inside loop, each iteration creates a new mutex that cannot protect shared state")
 		case common.IsRWMutex(typ):
 			ma.errorCollector.AddError(ident.Pos(),
-				"rwmutex '"+ident.Name+"' declared inside loop, each iteration creates a new mutex that cannot protect shared state")
+				category.MutexInLoop, "rwmutex '"+ident.Name+"' declared inside loop, each iteration creates a new mutex that cannot protect shared state")
 		}
 	}
 }

--- a/pkg/analyzer/testdata/src/ignoredirective/ignore_cases.go
+++ b/pkg/analyzer/testdata/src/ignoredirective/ignore_cases.go
@@ -1,0 +1,105 @@
+// Package ignoredirective verifies that the inline
+// goconcurrencylint:ignore directive suppresses diagnostics with per-category
+// granularity.
+//
+// The fixtures rely on analysistest.Run: a `want` marker on a line asserts
+// that the matching diagnostic is reported there, and the absence of a marker
+// asserts that no diagnostic is reported. Lines that would normally trigger
+// a check but are silenced by the directive must therefore have no marker.
+//
+// When a single line needs both a directive and a `want` marker (because two
+// diagnostics fire and only one is silenced), the directive is written as a
+// block comment so it does not collide with analysistest's parser.
+package ignoredirective
+
+import (
+	"sync"
+)
+
+// BareDirectiveSilencesEverything: a bare directive (no rules listed)
+// silences every diagnostic on its line. The Lock would otherwise fire
+// `lock-without-unlock`.
+func BareDirectiveSilencesEverything() {
+	var mu sync.Mutex
+	mu.Lock() // goconcurrencylint:ignore
+}
+
+// PerRuleDirectiveSilencesMatchingRule: the explicit category matches the
+// fired diagnostic, so it is silenced.
+func PerRuleDirectiveSilencesMatchingRule() {
+	var mu sync.Mutex
+	mu.Lock() // goconcurrencylint:ignore lock-without-unlock
+}
+
+// PerRuleDirectiveWrongRuleStillReports: the directive lists only
+// wait-without-add but the diagnostic is lock-without-unlock, so the
+// diagnostic must still appear.
+func PerRuleDirectiveWrongRuleStillReports() {
+	var mu sync.Mutex
+	mu.Lock() /* goconcurrencylint:ignore wait-without-add */ // want "mutex 'mu' is locked but not unlocked"
+}
+
+// MultipleRulesDirectiveSilencesAllListed: comma-separated list silences
+// each named category. Both the actual fired check and an unrelated one
+// are listed, so nothing is reported.
+func MultipleRulesDirectiveSilencesAllListed() {
+	var mu sync.Mutex
+	mu.Lock() // goconcurrencylint:ignore lock-without-unlock, defer-lock
+}
+
+// MultipleDiagnosticsSameLinePerRule: two diagnostics fire on the same
+// `mu.Lock()` (`lock-without-unlock` and `double-lock`); the directive only
+// names the first, so the second must still be reported.
+func MultipleDiagnosticsSameLinePerRule() {
+	var mu sync.Mutex
+	mu.Lock() // want "mutex 'mu' is locked but not unlocked"
+	mu.Lock() /* goconcurrencylint:ignore lock-without-unlock */ // want "mutex 'mu' is re-locked before unlock"
+}
+
+// MultipleDiagnosticsSameLineAllListed: same setup as above, but the
+// directive lists every category that fires, so neither is reported.
+func MultipleDiagnosticsSameLineAllListed() {
+	var mu sync.Mutex
+	mu.Lock() // want "mutex 'mu' is locked but not unlocked"
+	mu.Lock() // goconcurrencylint:ignore lock-without-unlock, double-lock
+}
+
+// HumanNoteAfterDirectiveBehavesAsBare: no recognised category among the
+// trailing tokens, so the directive silences every check on the line.
+func HumanNoteAfterDirectiveBehavesAsBare() {
+	var mu sync.Mutex
+	mu.Lock() // goconcurrencylint:ignore  legacy code, see issue #42
+}
+
+// UnknownRuleBehavesAsBare: a single unrecognised id (typo) currently
+// silences every check on the line. This pins the behaviour so any future
+// change is deliberate.
+func UnknownRuleBehavesAsBare() {
+	var mu sync.Mutex
+	mu.Lock() // goconcurrencylint:ignore loock-without-unlock
+}
+
+// DirectiveOnAdjacentLineDoesNotLeak: directives only affect their own
+// line; a previous-line directive must not silence a diagnostic below.
+func DirectiveOnAdjacentLineDoesNotLeak() {
+	var mu sync.Mutex
+	// goconcurrencylint:ignore lock-without-unlock
+	mu.Lock() // want "mutex 'mu' is locked but not unlocked"
+}
+
+// WaitGroupBareDirective: the original public example from the README still
+// works under the new semantics.
+func WaitGroupBareDirective() {
+	var wg sync.WaitGroup
+	wg.Wait() // goconcurrencylint:ignore wait-without-add
+}
+
+// PreservedStateAfterIgnoredLock: bare directives no longer prevent state
+// tracking. A subsequent Unlock() must therefore be balanced and silent;
+// before this change the ignored Lock left the counter at zero and the
+// Unlock would have raised unlock-without-lock.
+func PreservedStateAfterIgnoredLock() {
+	var mu sync.Mutex
+	mu.Lock() // goconcurrencylint:ignore
+	mu.Unlock()
+}

--- a/pkg/analyzer/waitgroup/analyzer.go
+++ b/pkg/analyzer/waitgroup/analyzer.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/common"
+	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/common/category"
 	commnetfilter "github.com/sanbricio/goconcurrencylint/pkg/analyzer/common/commentfilter"
 	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/common/report"
 	"golang.org/x/tools/go/analysis"
@@ -122,10 +123,10 @@ func (wga *Analyzer) handleAddCall(call *ast.CallExpr, wgName string, stats map[
 			// wg.Add(workers) the same way they see wg.Add(4).
 			addValue = constantValue
 			if addValue < 0 {
-				wga.errorCollector.AddError(call.Pos(), "waitgroup '"+wgName+"' has negative Add("+strconv.Itoa(addValue)+")")
+				wga.errorCollector.AddError(call.Pos(), category.AddNegative, "waitgroup '"+wgName+"' has negative Add("+strconv.Itoa(addValue)+")")
 			}
 			if addValue == 0 {
-				wga.errorCollector.AddError(call.Pos(), "waitgroup '"+wgName+"' Add(0) is a no-op")
+				wga.errorCollector.AddError(call.Pos(), category.AddZero, "waitgroup '"+wgName+"' Add(0) is a no-op")
 			}
 		}
 	}

--- a/pkg/analyzer/waitgroup/behavior.go
+++ b/pkg/analyzer/waitgroup/behavior.go
@@ -5,6 +5,7 @@ import (
 	"go/token"
 
 	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/common"
+	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/common/category"
 )
 
 type waitDonePositions struct {
@@ -29,7 +30,7 @@ func (wga *Analyzer) checkWaitAndDoneInSameGoroutine() {
 			positions := wga.collectWaitDonePositions(fnLit.Body, wgName)
 			for _, waitPos := range positions.waits {
 				if wga.waitDependsOnDoneInSameGoroutine(waitPos, positions) {
-					wga.errorCollector.AddError(waitPos, "waitgroup '"+wgName+"' Wait will deadlock: same goroutine has pending Done")
+					wga.errorCollector.AddError(waitPos, category.WaitDeadlock, "waitgroup '"+wgName+"' Wait will deadlock: same goroutine has pending Done")
 				}
 			}
 		}
@@ -246,7 +247,7 @@ func (wga *Analyzer) checkDoneOutsideWorkerForWaitGroup(wgName string) {
 			if wga.callInvokesDone(call, wgName) {
 				recentPositiveAdd = false
 				if workerGoroutinesWithoutDone > 0 {
-					wga.errorCollector.AddError(call.Pos(), "waitgroup '"+wgName+"' Done called outside worker goroutine")
+					wga.errorCollector.AddError(call.Pos(), category.DoneOutsideGoroutine, "waitgroup '"+wgName+"' Done called outside worker goroutine")
 					workerGoroutinesWithoutDone--
 				}
 				if pendingAdds > 0 {
@@ -257,7 +258,7 @@ func (wga *Analyzer) checkDoneOutsideWorkerForWaitGroup(wgName string) {
 			recentPositiveAdd = false
 			if wga.deferInvokesDone(s, wgName) {
 				if workerGoroutinesWithoutDone > 0 {
-					wga.errorCollector.AddError(s.Call.Pos(), "waitgroup '"+wgName+"' Done called outside worker goroutine")
+					wga.errorCollector.AddError(s.Call.Pos(), category.DoneOutsideGoroutine, "waitgroup '"+wgName+"' Done called outside worker goroutine")
 					workerGoroutinesWithoutDone--
 				}
 				if pendingAdds > 0 {
@@ -375,7 +376,7 @@ func (wga *Analyzer) checkWaitGroupGoPanic() {
 			return true
 		}
 		if wga.functionLiteralMayPanic(fnLit) {
-			wga.errorCollector.AddError(call.Pos(), "waitgroup '"+wgName+"' Go function may panic")
+			wga.errorCollector.AddError(call.Pos(), category.GoPanic, "waitgroup '"+wgName+"' Go function may panic")
 		}
 		return true
 	})
@@ -494,7 +495,7 @@ func (wga *Analyzer) checkAddInsideGoroutine() {
 			if !wga.waitGroupNames[wgName] || wga.waitGroupIdentDefinedInside(fnLit.Body, sel.X) {
 				return true
 			}
-			wga.errorCollector.AddError(call.Pos(), "waitgroup '"+wgName+"' Add called inside goroutine, may race with Wait")
+			wga.errorCollector.AddError(call.Pos(), category.AddInsideGoroutine, "waitgroup '"+wgName+"' Add called inside goroutine, may race with Wait")
 			return true
 		})
 
@@ -542,14 +543,14 @@ func (wga *Analyzer) checkMultipleDoneInBranch(stmts []ast.Stmt, wgName string, 
 			if wga.deferInvokesDone(s, wgName) {
 				current++
 				if current > 1 {
-					wga.errorCollector.AddError(s.Call.Pos(), "waitgroup '"+wgName+"' Done called multiple times in the same worker branch")
+					wga.errorCollector.AddError(s.Call.Pos(), category.MultipleDoneWorker, "waitgroup '"+wgName+"' Done called multiple times in the same worker branch")
 				}
 			}
 		case *ast.ExprStmt:
 			if call, ok := s.X.(*ast.CallExpr); ok && wga.callInvokesDone(call, wgName) {
 				current++
 				if current > 1 {
-					wga.errorCollector.AddError(call.Pos(), "waitgroup '"+wgName+"' Done called multiple times in the same worker branch")
+					wga.errorCollector.AddError(call.Pos(), category.MultipleDoneWorker, "waitgroup '"+wgName+"' Done called multiple times in the same worker branch")
 				}
 			}
 		case *ast.IfStmt:
@@ -624,7 +625,7 @@ func (wga *Analyzer) reportNestedWaitsForWorker(goStmt *ast.GoStmt, body *ast.Bl
 				continue
 			}
 			if wga.outerWaitBeforeInnerRelease(goStmt.Pos(), outerWG, innerWG) {
-				wga.errorCollector.AddError(call.Pos(),
+				wga.errorCollector.AddError(call.Pos(), category.NestedWaitGroupDeadlock,
 					"waitgroup '"+innerWG+"' Wait inside worker for waitgroup '"+outerWG+"' can deadlock")
 				return false
 			}

--- a/pkg/analyzer/waitgroup/panic.go
+++ b/pkg/analyzer/waitgroup/panic.go
@@ -5,6 +5,7 @@ import (
 	"go/types"
 
 	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/common"
+	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/common/category"
 )
 
 func (wga *Analyzer) checkDoneNotDeferredInWorker() {
@@ -45,7 +46,7 @@ func (wga *Analyzer) checkDoneNotDeferredInBlock(stmts []ast.Stmt, wgName string
 		case *ast.ExprStmt:
 			if call, ok := s.X.(*ast.CallExpr); ok && wga.callInvokesDone(call, wgName) {
 				if risky {
-					wga.errorCollector.AddError(call.Pos(), "waitgroup '"+wgName+"' Done should be deferred so it runs on panic or runtime.Goexit")
+					wga.errorCollector.AddError(call.Pos(), category.DoneNotDeferred, "waitgroup '"+wgName+"' Done should be deferred so it runs on panic or runtime.Goexit")
 				}
 				continue
 			}

--- a/pkg/analyzer/waitgroup/validation.go
+++ b/pkg/analyzer/waitgroup/validation.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/common"
+	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/common/category"
 	"golang.org/x/tools/go/ast/astutil"
 )
 
@@ -209,7 +210,7 @@ func (wga *Analyzer) countGuaranteedDoneInStatements(stmts []ast.Stmt, wgName st
 			if !doneInfo.hasAnyDone {
 				relatedAdd := wga.findRelatedAddCall(s, wgName)
 				if relatedAdd != token.NoPos {
-					wga.errorCollector.AddError(relatedAdd,
+					wga.errorCollector.AddError(relatedAdd, category.AddWithoutDone,
 						"waitgroup '"+wgName+"' has Add without corresponding Done")
 				}
 			}
@@ -384,7 +385,7 @@ func (wga *Analyzer) reportUnmatchedAdds(wgName string, stats *Stats, totalExpec
 		if remainingDone >= addCall.value {
 			remainingDone -= addCall.value
 		} else {
-			wga.errorCollector.AddError(addCall.pos, "waitgroup '"+wgName+"' has Add without corresponding Done")
+			wga.errorCollector.AddError(addCall.pos, category.AddWithoutDone, "waitgroup '"+wgName+"' has Add without corresponding Done")
 		}
 	}
 }
@@ -415,7 +416,7 @@ func (wga *Analyzer) reportExcessDones(wgName string, stats *Stats, totalExpecte
 	startIndex := len(mainFlowDoneCalls) - excessCount
 
 	for i := startIndex; i < len(mainFlowDoneCalls) && i >= 0; i++ {
-		wga.errorCollector.AddError(mainFlowDoneCalls[i], "waitgroup '"+wgName+"' has Done without corresponding Add")
+		wga.errorCollector.AddError(mainFlowDoneCalls[i], category.DoneWithoutAdd, "waitgroup '"+wgName+"' has Done without corresponding Add")
 	}
 }
 
@@ -434,7 +435,7 @@ func (wga *Analyzer) checkWaitBeforeDoneSameGoroutine(stats map[string]*Stats) {
 				continue
 			}
 			if wga.pendingMainFlowAddsBeforeWait(st, waitPos) > 0 && wga.hasMainFlowReleaseAfterWait(st, waitPos) {
-				wga.errorCollector.AddError(waitPos, "waitgroup '"+wgName+"' waits with pending Add in the same goroutine")
+				wga.errorCollector.AddError(waitPos, category.WaitDeadlock, "waitgroup '"+wgName+"' waits with pending Add in the same goroutine")
 			}
 		}
 	}
@@ -545,9 +546,9 @@ func (wga *Analyzer) checkAddInGoroutine(goStmt *ast.GoStmt, wgName string) {
 
 					switch sel.Sel.Name {
 					case "Add":
-						wga.errorCollector.AddError(call.Pos(), "waitgroup '"+wgName+"' Add called after Wait")
+						wga.errorCollector.AddError(call.Pos(), category.AddAfterWait, "waitgroup '"+wgName+"' Add called after Wait")
 					case "Go":
-						wga.errorCollector.AddError(call.Pos(), "waitgroup '"+wgName+"' Go called after Wait")
+						wga.errorCollector.AddError(call.Pos(), category.GoAfterWait, "waitgroup '"+wgName+"' Go called after Wait")
 					}
 				}
 			}
@@ -599,12 +600,12 @@ func (wga *Analyzer) checkAddAfterWaitInMainFlow(wgName string, st *Stats) {
 					if add.value == 1 && wga.hasDeferredDoneAfter(wgName, add.pos) {
 						continue
 					}
-					wga.errorCollector.AddError(add.pos, "waitgroup '"+wgName+"' Add called after Wait")
+					wga.errorCollector.AddError(add.pos, category.AddAfterWait, "waitgroup '"+wgName+"' Add called after Wait")
 				}
 			}
 			for _, goPos := range st.goCalls {
 				if goPos > wait && !wga.isInGoroutine(goPos) {
-					wga.errorCollector.AddError(goPos, "waitgroup '"+wgName+"' Go called after Wait")
+					wga.errorCollector.AddError(goPos, category.GoAfterWait, "waitgroup '"+wgName+"' Go called after Wait")
 				}
 			}
 		}
@@ -723,7 +724,7 @@ func (wga *Analyzer) analyzeLoopBalance(forStmt *ast.ForStmt) {
 		if len(stats.addCalls) > 0 {
 			if stats.unconditionalDones == 0 && stats.conditionalDones > 0 {
 				for _, addPos := range stats.addCalls {
-					wga.errorCollector.AddError(addPos,
+					wga.errorCollector.AddError(addPos, category.AddWithoutDone,
 						"waitgroup '"+wgName+"' has Add without corresponding Done")
 				}
 			}
@@ -815,7 +816,7 @@ func (wga *Analyzer) checkLiteralAddLoopGoroutineMismatch(stats map[string]*Stat
 		if launched <= 1 || launched == positiveAdds[0].value {
 			continue
 		}
-		wga.errorCollector.AddError(positiveAdds[0].pos,
+		wga.errorCollector.AddError(positiveAdds[0].pos, category.AddLoopCountMismatch,
 			"waitgroup '"+wgName+"' Add count "+strconv.Itoa(positiveAdds[0].value)+" does not match "+strconv.Itoa(launched)+" goroutines launched")
 	}
 }
@@ -894,7 +895,7 @@ func (wga *Analyzer) checkWaitWithoutAdd(stats map[string]*Stats) {
 					wga.hasAddInLocalClosure(targetObj, waitPos)) {
 				continue
 			}
-			wga.errorCollector.AddError(waitPos, "waitgroup '"+wgName+"' Wait called without any Add")
+			wga.errorCollector.AddError(waitPos, category.WaitWithoutAdd, "waitgroup '"+wgName+"' Wait called without any Add")
 		}
 	}
 }
@@ -1123,7 +1124,7 @@ func (wga *Analyzer) checkUnreachableDone() {
 				if wga.hasUnreachableDone(fnLit.Body, wgName) {
 					addPos := wga.findRelatedAddCall(goStmt, wgName)
 					if addPos != token.NoPos {
-						wga.errorCollector.AddError(addPos,
+						wga.errorCollector.AddError(addPos, category.AddWithoutDone,
 							"waitgroup '"+wgName+"' has Add without corresponding Done")
 					}
 				}


### PR DESCRIPTION
- Introduced a new category package to define stable check identifiers for diagnostics.

- Updated error reporting across mutex and waitgroup analyzers to utilize the new category identifiers.

- Added tests to ensure all diagnostics carry a valid category.

- Implemented ignore directive handling for specific categories in test cases.