### PR TITLE
refactor: simplify with modernize suggestions

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,6 +6,7 @@ linters:
     - staticcheck
     - errcheck
     - ineffassign
+    - modernize
     - unused
   settings:
     govet:

--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -35,7 +35,7 @@ type syncPrimitive struct {
 	waitGroups map[string]bool
 }
 
-func run(pass *analysis.Pass) (interface{}, error) {
+func run(pass *analysis.Pass) (any, error) {
 	errorCollector := &report.ErrorCollector{}
 	pkgPrimitives := collectPackageLevelPrimitives(pass)
 
@@ -122,15 +122,9 @@ func collectPackageLevelPrimitives(pass *analysis.Pass) *syncPrimitive {
 
 // mergePrimitives merges src primitives into dst
 func mergePrimitives(dst, src *syncPrimitive) {
-	for k, v := range src.mutexes {
-		dst.mutexes[k] = v
-	}
-	for k, v := range src.rwMutexes {
-		dst.rwMutexes[k] = v
-	}
-	for k, v := range src.waitGroups {
-		dst.waitGroups[k] = v
-	}
+	maps.Copy(dst.mutexes, src.mutexes)
+	maps.Copy(dst.rwMutexes, src.rwMutexes)
+	maps.Copy(dst.waitGroups, src.waitGroups)
 }
 
 func copyPrimitiveNames(src map[string]bool) map[string]bool {
@@ -467,8 +461,8 @@ func containedSyncPrimitiveValueKind(typ types.Type, visited map[types.Type]bool
 		}
 		return containedSyncPrimitiveValueKind(t.Underlying(), visited)
 	case *types.Struct:
-		for i := 0; i < t.NumFields(); i++ {
-			fieldType := types.Unalias(t.Field(i).Type())
+		for field := range t.Fields() {
+			fieldType := types.Unalias(field.Type())
 			if _, ok := fieldType.(*types.Pointer); ok {
 				continue
 			}

--- a/pkg/analyzer/common/category/category.go
+++ b/pkg/analyzer/common/category/category.go
@@ -7,6 +7,8 @@
 // a breaking change for downstream consumers and ignore directives.
 package category
 
+import "slices"
+
 const (
 	// Mutex / RWMutex checks.
 	LockWithoutUnlock      = "lock-without-unlock"
@@ -81,10 +83,5 @@ func All() []string {
 
 // IsKnown reports whether id is a recognised check category.
 func IsKnown(id string) bool {
-	for _, c := range All() {
-		if c == id {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(All(), id)
 }

--- a/pkg/analyzer/mutex/analyzer.go
+++ b/pkg/analyzer/mutex/analyzer.go
@@ -4,6 +4,7 @@ import (
 	"go/ast"
 	"go/token"
 	"go/types"
+	"slices"
 	"strings"
 
 	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/common"
@@ -441,12 +442,7 @@ func functionBodyContainsFieldSuffixCall(body *ast.BlockStmt, fieldSuffix string
 }
 
 func containsMethod(methodNames []string, methodName string) bool {
-	for _, candidate := range methodNames {
-		if candidate == methodName {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(methodNames, methodName)
 }
 
 func relativeMutexPath(varName, prefix string) (string, bool) {

--- a/pkg/analyzer/mutex/behavior.go
+++ b/pkg/analyzer/mutex/behavior.go
@@ -4,6 +4,7 @@ import (
 	"go/ast"
 	"go/token"
 	"go/types"
+	"maps"
 	"sort"
 
 	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/common"
@@ -48,22 +49,22 @@ func (ma *Analyzer) scanLockOrderStatements(stmts []ast.Stmt, held map[string]bo
 				ma.scanLockOrderStatements(fnLit.Body.List, make(map[string]bool), edges, reported)
 			}
 		case *ast.IfStmt:
-			thenHeld := cloneBoolMap(held)
+			thenHeld := maps.Clone(held)
 			if varName, ok := ma.tryLockCallVar(s.Cond); ok {
 				ma.recordHeldLockOrderEdges(varName, s.Cond.Pos(), thenHeld, edges, reported)
 				thenHeld[varName] = true
 			}
 			ma.scanLockOrderStatements(s.Body.List, thenHeld, edges, reported)
 			if s.Else != nil {
-				ma.scanLockOrderElse(s.Else, cloneBoolMap(held), edges, reported)
+				ma.scanLockOrderElse(s.Else, maps.Clone(held), edges, reported)
 			}
 		case *ast.ForStmt:
 			if s.Body != nil {
-				ma.scanLockOrderStatements(s.Body.List, cloneBoolMap(held), edges, reported)
+				ma.scanLockOrderStatements(s.Body.List, maps.Clone(held), edges, reported)
 			}
 		case *ast.RangeStmt:
 			if s.Body != nil {
-				ma.scanLockOrderStatements(s.Body.List, cloneBoolMap(held), edges, reported)
+				ma.scanLockOrderStatements(s.Body.List, maps.Clone(held), edges, reported)
 			}
 		case *ast.BlockStmt:
 			ma.scanLockOrderStatements(s.List, held, edges, reported)
@@ -72,19 +73,19 @@ func (ma *Analyzer) scanLockOrderStatements(stmts []ast.Stmt, held map[string]bo
 		case *ast.SwitchStmt:
 			for _, clause := range s.Body.List {
 				if cc, ok := clause.(*ast.CaseClause); ok {
-					ma.scanLockOrderStatements(cc.Body, cloneBoolMap(held), edges, reported)
+					ma.scanLockOrderStatements(cc.Body, maps.Clone(held), edges, reported)
 				}
 			}
 		case *ast.TypeSwitchStmt:
 			for _, clause := range s.Body.List {
 				if cc, ok := clause.(*ast.CaseClause); ok {
-					ma.scanLockOrderStatements(cc.Body, cloneBoolMap(held), edges, reported)
+					ma.scanLockOrderStatements(cc.Body, maps.Clone(held), edges, reported)
 				}
 			}
 		case *ast.SelectStmt:
 			for _, clause := range s.Body.List {
 				if cc, ok := clause.(*ast.CommClause); ok {
-					ma.scanLockOrderStatements(cc.Body, cloneBoolMap(held), edges, reported)
+					ma.scanLockOrderStatements(cc.Body, maps.Clone(held), edges, reported)
 				}
 			}
 		}
@@ -116,7 +117,7 @@ func (ma *Analyzer) scanLockOrderDefer(stmt *ast.DeferStmt, held map[string]bool
 		return
 	}
 	if call, ok := stmt.Call.Fun.(*ast.FuncLit); ok && call.Body != nil {
-		ma.scanLockOrderStatements(call.Body.List, cloneBoolMap(held), edges, reported)
+		ma.scanLockOrderStatements(call.Body.List, maps.Clone(held), edges, reported)
 	}
 }
 
@@ -237,17 +238,17 @@ func (ma *Analyzer) scanCrossGoroutineReleaseStatements(stmts []ast.Stmt, parent
 		case *ast.DeferStmt:
 			ma.scanCrossGoroutineReleaseCall(s.Call, parentStats, localLocks, localRLocks, releases)
 		case *ast.IfStmt:
-			ma.scanCrossGoroutineReleaseStatements(s.Body.List, parentStats, cloneIntMap(localLocks), cloneIntMap(localRLocks), releases)
+			ma.scanCrossGoroutineReleaseStatements(s.Body.List, parentStats, maps.Clone(localLocks), maps.Clone(localRLocks), releases)
 			if s.Else != nil {
-				ma.scanCrossGoroutineReleaseElse(s.Else, parentStats, cloneIntMap(localLocks), cloneIntMap(localRLocks), releases)
+				ma.scanCrossGoroutineReleaseElse(s.Else, parentStats, maps.Clone(localLocks), maps.Clone(localRLocks), releases)
 			}
 		case *ast.ForStmt:
 			if s.Body != nil {
-				ma.scanCrossGoroutineReleaseStatements(s.Body.List, parentStats, cloneIntMap(localLocks), cloneIntMap(localRLocks), releases)
+				ma.scanCrossGoroutineReleaseStatements(s.Body.List, parentStats, maps.Clone(localLocks), maps.Clone(localRLocks), releases)
 			}
 		case *ast.RangeStmt:
 			if s.Body != nil {
-				ma.scanCrossGoroutineReleaseStatements(s.Body.List, parentStats, cloneIntMap(localLocks), cloneIntMap(localRLocks), releases)
+				ma.scanCrossGoroutineReleaseStatements(s.Body.List, parentStats, maps.Clone(localLocks), maps.Clone(localRLocks), releases)
 			}
 		case *ast.BlockStmt:
 			ma.scanCrossGoroutineReleaseStatements(s.List, parentStats, localLocks, localRLocks, releases)
@@ -256,19 +257,19 @@ func (ma *Analyzer) scanCrossGoroutineReleaseStatements(stmts []ast.Stmt, parent
 		case *ast.SwitchStmt:
 			for _, clause := range s.Body.List {
 				if cc, ok := clause.(*ast.CaseClause); ok {
-					ma.scanCrossGoroutineReleaseStatements(cc.Body, parentStats, cloneIntMap(localLocks), cloneIntMap(localRLocks), releases)
+					ma.scanCrossGoroutineReleaseStatements(cc.Body, parentStats, maps.Clone(localLocks), maps.Clone(localRLocks), releases)
 				}
 			}
 		case *ast.TypeSwitchStmt:
 			for _, clause := range s.Body.List {
 				if cc, ok := clause.(*ast.CaseClause); ok {
-					ma.scanCrossGoroutineReleaseStatements(cc.Body, parentStats, cloneIntMap(localLocks), cloneIntMap(localRLocks), releases)
+					ma.scanCrossGoroutineReleaseStatements(cc.Body, parentStats, maps.Clone(localLocks), maps.Clone(localRLocks), releases)
 				}
 			}
 		case *ast.SelectStmt:
 			for _, clause := range s.Body.List {
 				if cc, ok := clause.(*ast.CommClause); ok {
-					ma.scanCrossGoroutineReleaseStatements(cc.Body, parentStats, cloneIntMap(localLocks), cloneIntMap(localRLocks), releases)
+					ma.scanCrossGoroutineReleaseStatements(cc.Body, parentStats, maps.Clone(localLocks), maps.Clone(localRLocks), releases)
 				}
 			}
 		}
@@ -408,14 +409,6 @@ func removePos(positions *[]token.Pos, pos token.Pos) bool {
 		return true
 	}
 	return false
-}
-
-func cloneIntMap(src map[string]int) map[string]int {
-	dst := make(map[string]int, len(src))
-	for k, v := range src {
-		dst[k] = v
-	}
-	return dst
 }
 
 // goroutineBodyLockCallMethod returns the first direct lock method call found

--- a/pkg/analyzer/mutex/validation.go
+++ b/pkg/analyzer/mutex/validation.go
@@ -414,34 +414,34 @@ func (ma *Analyzer) reportDeferredUnlocksInLoopStatements(stmts []ast.Stmt, lock
 			}
 
 		case *ast.BlockStmt:
-			ma.reportDeferredUnlocksInLoopStatements(s.List, cloneBoolMap(locked), cloneBoolMap(rlocked))
+			ma.reportDeferredUnlocksInLoopStatements(s.List, maps.Clone(locked), maps.Clone(rlocked))
 		case *ast.LabeledStmt:
-			ma.reportDeferredUnlocksInLoopStatements([]ast.Stmt{s.Stmt}, cloneBoolMap(locked), cloneBoolMap(rlocked))
+			ma.reportDeferredUnlocksInLoopStatements([]ast.Stmt{s.Stmt}, maps.Clone(locked), maps.Clone(rlocked))
 		case *ast.IfStmt:
-			ma.reportDeferredUnlocksInLoopStatements(s.Body.List, cloneBoolMap(locked), cloneBoolMap(rlocked))
+			ma.reportDeferredUnlocksInLoopStatements(s.Body.List, maps.Clone(locked), maps.Clone(rlocked))
 			if s.Else != nil {
-				ma.reportDeferredUnlocksInLoopElse(s.Else, cloneBoolMap(locked), cloneBoolMap(rlocked))
+				ma.reportDeferredUnlocksInLoopElse(s.Else, maps.Clone(locked), maps.Clone(rlocked))
 			}
 		case *ast.ForStmt:
-			ma.reportDeferredUnlocksInLoopStatements(s.Body.List, cloneBoolMap(locked), cloneBoolMap(rlocked))
+			ma.reportDeferredUnlocksInLoopStatements(s.Body.List, maps.Clone(locked), maps.Clone(rlocked))
 		case *ast.RangeStmt:
-			ma.reportDeferredUnlocksInLoopStatements(s.Body.List, cloneBoolMap(locked), cloneBoolMap(rlocked))
+			ma.reportDeferredUnlocksInLoopStatements(s.Body.List, maps.Clone(locked), maps.Clone(rlocked))
 		case *ast.SwitchStmt:
 			for _, clause := range s.Body.List {
 				if cc, ok := clause.(*ast.CaseClause); ok {
-					ma.reportDeferredUnlocksInLoopStatements(cc.Body, cloneBoolMap(locked), cloneBoolMap(rlocked))
+					ma.reportDeferredUnlocksInLoopStatements(cc.Body, maps.Clone(locked), maps.Clone(rlocked))
 				}
 			}
 		case *ast.TypeSwitchStmt:
 			for _, clause := range s.Body.List {
 				if cc, ok := clause.(*ast.CaseClause); ok {
-					ma.reportDeferredUnlocksInLoopStatements(cc.Body, cloneBoolMap(locked), cloneBoolMap(rlocked))
+					ma.reportDeferredUnlocksInLoopStatements(cc.Body, maps.Clone(locked), maps.Clone(rlocked))
 				}
 			}
 		case *ast.SelectStmt:
 			for _, clause := range s.Body.List {
 				if cc, ok := clause.(*ast.CommClause); ok {
-					ma.reportDeferredUnlocksInLoopStatements(cc.Body, cloneBoolMap(locked), cloneBoolMap(rlocked))
+					ma.reportDeferredUnlocksInLoopStatements(cc.Body, maps.Clone(locked), maps.Clone(rlocked))
 				}
 			}
 		}
@@ -455,10 +455,6 @@ func (ma *Analyzer) reportDeferredUnlocksInLoopElse(stmt ast.Stmt, locked, rlock
 	case *ast.IfStmt:
 		ma.reportDeferredUnlocksInLoopStatements([]ast.Stmt{s}, locked, rlocked)
 	}
-}
-
-func cloneBoolMap(src map[string]bool) map[string]bool {
-	return maps.Clone(src)
 }
 
 func (ma *Analyzer) applyLoopExitLocks(stmt *ast.ForStmt, initial, final map[string]*Stats) {

--- a/pkg/analyzer/waitgroup/validation.go
+++ b/pkg/analyzer/waitgroup/validation.go
@@ -5,6 +5,7 @@ import (
 	"go/constant"
 	"go/token"
 	"go/types"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -393,9 +394,7 @@ func (wga *Analyzer) reportExcessDones(wgName string, stats *Stats, totalExpecte
 		return
 	}
 
-	sort.Slice(mainFlowDoneCalls, func(i, j int) bool {
-		return mainFlowDoneCalls[i] < mainFlowDoneCalls[j]
-	})
+	slices.Sort(mainFlowDoneCalls)
 
 	excessCount := len(mainFlowDoneCalls) - stats.totalAdd
 	startIndex := len(mainFlowDoneCalls) - excessCount


### PR DESCRIPTION
Enable `modernize` and refactor with `golangci-lint run --fix`.