### PR TITLE
refactor: introduce Reporter interface and type Category

### DIFF
--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -60,7 +60,7 @@ func ignoreFromFilters(filters map[string]*commentfilter.CommentFilter) report.I
 	if len(filters) == 0 {
 		return nil
 	}
-	return func(filename string, line int, cat string) bool {
+	return func(filename string, line int, cat category.Category) bool {
 		cf, ok := filters[filename]
 		if !ok {
 			return false
@@ -72,7 +72,7 @@ func ignoreFromFilters(filters map[string]*commentfilter.CommentFilter) report.I
 // analyzeFunctionsWithFilter processes all function declarations in a file
 // using a pre-built CommentFilter, so the same instance is reused for
 // per-file ignore-directive lookups at report time.
-func analyzeFunctionsWithFilter(file *ast.File, commentFilter *commentfilter.CommentFilter, pass *analysis.Pass, errorCollector *report.ErrorCollector, pkgPrimitives *syncPrimitive) {
+func analyzeFunctionsWithFilter(file *ast.File, commentFilter *commentfilter.CommentFilter, pass *analysis.Pass, errorCollector report.Reporter, pkgPrimitives *syncPrimitive) {
 	for _, decl := range file.Decls {
 		fn, ok := decl.(*ast.FuncDecl)
 		if !ok || fn.Body == nil {
@@ -175,24 +175,16 @@ func findSyncPrimitives(fn *ast.FuncDecl, pass *analysis.Pass) *syncPrimitive {
 			}
 
 		case *ast.AssignStmt:
-			// Handle short variable declarations
-			if node.Tok == token.DEFINE {
-				for i, lhs := range node.Lhs {
-					if ident, ok := lhs.(*ast.Ident); ok && i < len(node.Rhs) {
-						if typ := pass.TypesInfo.TypeOf(node.Rhs[i]); typ != nil {
-							classifyAndAddPrimitive(ident.Name, typ, primitives)
-						}
-					}
-				}
+			if node.Tok != token.DEFINE && node.Tok != token.ASSIGN {
+				break
 			}
-			// Handle regular assignments
-			if node.Tok == token.ASSIGN {
-				for i, lhs := range node.Lhs {
-					if ident, ok := lhs.(*ast.Ident); ok && i < len(node.Rhs) {
-						if typ := pass.TypesInfo.TypeOf(node.Rhs[i]); typ != nil {
-							classifyAndAddPrimitive(ident.Name, typ, primitives)
-						}
-					}
+			for i, lhs := range node.Lhs {
+				ident, ok := lhs.(*ast.Ident)
+				if !ok || i >= len(node.Rhs) {
+					continue
+				}
+				if typ := pass.TypesInfo.TypeOf(node.Rhs[i]); typ != nil {
+					classifyAndAddPrimitive(ident.Name, typ, primitives)
 				}
 			}
 
@@ -264,18 +256,18 @@ func hasWaitGroups(primitives *syncPrimitive) bool {
 }
 
 // analyzeMutexUsage handles mutex and rwmutex analysis
-func analyzeMutexUsage(fn *ast.FuncDecl, primitives *syncPrimitive, errorCollector *report.ErrorCollector, cf *commentfilter.CommentFilter, pass *analysis.Pass) {
+func analyzeMutexUsage(fn *ast.FuncDecl, primitives *syncPrimitive, errorCollector report.Reporter, cf *commentfilter.CommentFilter, pass *analysis.Pass) {
 	analyzer := mutex.NewAnalyzer(primitives.mutexes, primitives.rwMutexes, errorCollector, cf, pass.TypesInfo, pass.Files)
 	analyzer.AnalyzeFunction(fn)
 }
 
 // analyzeWaitGroupUsage handles waitgroup analysis
-func analyzeWaitGroupUsage(fn *ast.FuncDecl, primitives *syncPrimitive, localWaitGroups, packageLevelWaitGroups map[string]bool, errorCollector *report.ErrorCollector, cf *commentfilter.CommentFilter, pass *analysis.Pass) {
+func analyzeWaitGroupUsage(fn *ast.FuncDecl, primitives *syncPrimitive, localWaitGroups, packageLevelWaitGroups map[string]bool, errorCollector report.Reporter, cf *commentfilter.CommentFilter, pass *analysis.Pass) {
 	analyzer := waitgroup.NewAnalyzer(primitives.waitGroups, localWaitGroups, packageLevelWaitGroups, errorCollector, cf, pass)
 	analyzer.AnalyzeFunction(fn)
 }
 
-func detectCopyByValue(pass *analysis.Pass, errorCollector *report.ErrorCollector) {
+func detectCopyByValue(pass *analysis.Pass, errorCollector report.Reporter) {
 	for _, file := range pass.Files {
 		ast.Inspect(file, func(n ast.Node) bool {
 			switch node := n.(type) {
@@ -295,7 +287,7 @@ func detectCopyByValue(pass *analysis.Pass, errorCollector *report.ErrorCollecto
 	}
 }
 
-func reportCopyByValueFuncLitParams(fn *ast.FuncLit, pass *analysis.Pass, errorCollector *report.ErrorCollector) {
+func reportCopyByValueFuncLitParams(fn *ast.FuncLit, pass *analysis.Pass, errorCollector report.Reporter) {
 	if fn == nil || fn.Type == nil || fn.Type.Params == nil {
 		return
 	}
@@ -303,7 +295,7 @@ func reportCopyByValueFuncLitParams(fn *ast.FuncLit, pass *analysis.Pass, errorC
 	reportCopyByValueFieldList(fn.Type.Params, pass, errorCollector)
 }
 
-func reportCopyByValueParams(fn *ast.FuncDecl, pass *analysis.Pass, errorCollector *report.ErrorCollector) {
+func reportCopyByValueParams(fn *ast.FuncDecl, pass *analysis.Pass, errorCollector report.Reporter) {
 	if fn == nil || fn.Type == nil || fn.Type.Params == nil {
 		return
 	}
@@ -314,7 +306,7 @@ func reportCopyByValueParams(fn *ast.FuncDecl, pass *analysis.Pass, errorCollect
 	reportCopyByValueFieldList(fn.Type.Params, pass, errorCollector)
 }
 
-func reportCopyByValueFieldList(fields *ast.FieldList, pass *analysis.Pass, errorCollector *report.ErrorCollector) {
+func reportCopyByValueFieldList(fields *ast.FieldList, pass *analysis.Pass, errorCollector report.Reporter) {
 	for _, field := range fields.List {
 		kind := syncPrimitiveValueKind(pass.TypesInfo.TypeOf(field.Type))
 		if kind == "" {
@@ -326,7 +318,7 @@ func reportCopyByValueFieldList(fields *ast.FieldList, pass *analysis.Pass, erro
 	}
 }
 
-func reportCopyByValueValueSpec(vs *ast.ValueSpec, pass *analysis.Pass, errorCollector *report.ErrorCollector) {
+func reportCopyByValueValueSpec(vs *ast.ValueSpec, pass *analysis.Pass, errorCollector report.Reporter) {
 	if vs == nil {
 		return
 	}
@@ -338,7 +330,7 @@ func reportCopyByValueValueSpec(vs *ast.ValueSpec, pass *analysis.Pass, errorCol
 	}
 }
 
-func reportCopyByValueAssignments(assign *ast.AssignStmt, pass *analysis.Pass, errorCollector *report.ErrorCollector) {
+func reportCopyByValueAssignments(assign *ast.AssignStmt, pass *analysis.Pass, errorCollector report.Reporter) {
 	if assign == nil || (assign.Tok != token.ASSIGN && assign.Tok != token.DEFINE) {
 		return
 	}
@@ -353,7 +345,7 @@ func reportCopyByValueAssignments(assign *ast.AssignStmt, pass *analysis.Pass, e
 	}
 }
 
-func reportCopyByValueArgs(call *ast.CallExpr, pass *analysis.Pass, errorCollector *report.ErrorCollector) {
+func reportCopyByValueArgs(call *ast.CallExpr, pass *analysis.Pass, errorCollector report.Reporter) {
 	if call == nil {
 		return
 	}

--- a/pkg/analyzer/category_propagation_test.go
+++ b/pkg/analyzer/category_propagation_test.go
@@ -11,11 +11,9 @@ import (
 
 // TestDiagnosticCategoryPropagation runs the analyzer over the full set of
 // fixtures and verifies every emitted diagnostic carries a Category that
-// belongs to the public catalogue. This catches regressions where a new
-// AddError call site forgets to pass a category, or where a refactor breaks
-// the wire-up between ErrorCollector and pass.Report.
+// belongs to the public catalogue.
 func TestDiagnosticCategoryPropagation(t *testing.T) {
-	known := make(map[string]struct{}, len(category.All()))
+	known := make(map[category.Category]struct{}, len(category.All()))
 	for _, id := range category.All() {
 		known[id] = struct{}{}
 	}
@@ -34,7 +32,7 @@ func TestDiagnosticCategoryPropagation(t *testing.T) {
 			if diag.Category == "" {
 				continue
 			}
-			_, ok := known[diag.Category]
+			_, ok := known[category.Category(diag.Category)]
 			assert.True(t, ok,
 				"diagnostic at %s carries unknown Category %q (message: %q)",
 				pos, diag.Category, diag.Message)

--- a/pkg/analyzer/common/category/category.go
+++ b/pkg/analyzer/common/category/category.go
@@ -9,46 +9,50 @@ package category
 
 import "slices"
 
+// Category is the identifier of a check. Its value is emitted as
+// analysis.Diagnostic.Category and matched by inline ignore directives.
+type Category string
+
 const (
 	// Mutex / RWMutex checks.
-	LockWithoutUnlock      = "lock-without-unlock"
-	UnlockWithoutLock      = "unlock-without-lock"
-	DeferUnlockWithoutLock = "defer-unlock-without-lock"
-	UncheckedTryLock       = "unchecked-trylock"
-	DeferLock              = "defer-lock"
-	MutexInLoop            = "mutex-in-loop"
-	DeferUnlockInLoop      = "defer-unlock-in-loop"
-	RWMutexAPIMismatch     = "rwmutex-api-mismatch"
-	GoroutineLockDeadlock  = "goroutine-lock-deadlock"
-	PanicBeforeUnlock      = "panic-before-unlock"
-	DoubleLock             = "double-lock"
-	CrossGoroutineUnlock   = "cross-goroutine-unlock"
-	LockOrderCycle         = "lock-order-cycle"
+	LockWithoutUnlock      Category = "lock-without-unlock"
+	UnlockWithoutLock      Category = "unlock-without-lock"
+	DeferUnlockWithoutLock Category = "defer-unlock-without-lock"
+	UncheckedTryLock       Category = "unchecked-trylock"
+	DeferLock              Category = "defer-lock"
+	MutexInLoop            Category = "mutex-in-loop"
+	DeferUnlockInLoop      Category = "defer-unlock-in-loop"
+	RWMutexAPIMismatch     Category = "rwmutex-api-mismatch"
+	GoroutineLockDeadlock  Category = "goroutine-lock-deadlock"
+	PanicBeforeUnlock      Category = "panic-before-unlock"
+	DoubleLock             Category = "double-lock"
+	CrossGoroutineUnlock   Category = "cross-goroutine-unlock"
+	LockOrderCycle         Category = "lock-order-cycle"
 
 	// WaitGroup checks.
-	AddWithoutDone          = "add-without-done"
-	DoneWithoutAdd          = "done-without-add"
-	AddAfterWait            = "add-after-wait"
-	GoAfterWait             = "go-after-wait"
-	AddInsideGoroutine      = "add-inside-goroutine"
-	DoneNotDeferred         = "done-not-deferred"
-	AddLoopCountMismatch    = "add-loop-count-mismatch"
-	AddZero                 = "add-zero"
-	AddNegative             = "add-negative"
-	WaitWithoutAdd          = "wait-without-add"
-	WaitDeadlock            = "wait-deadlock"
-	MultipleDoneWorker      = "multiple-done-worker"
-	NestedWaitGroupDeadlock = "nested-waitgroup-deadlock"
-	DoneOutsideGoroutine    = "done-outside-goroutine"
-	GoPanic                 = "go-panic"
+	AddWithoutDone          Category = "add-without-done"
+	DoneWithoutAdd          Category = "done-without-add"
+	AddAfterWait            Category = "add-after-wait"
+	GoAfterWait             Category = "go-after-wait"
+	AddInsideGoroutine      Category = "add-inside-goroutine"
+	DoneNotDeferred         Category = "done-not-deferred"
+	AddLoopCountMismatch    Category = "add-loop-count-mismatch"
+	AddZero                 Category = "add-zero"
+	AddNegative             Category = "add-negative"
+	WaitWithoutAdd          Category = "wait-without-add"
+	WaitDeadlock            Category = "wait-deadlock"
+	MultipleDoneWorker      Category = "multiple-done-worker"
+	NestedWaitGroupDeadlock Category = "nested-waitgroup-deadlock"
+	DoneOutsideGoroutine    Category = "done-outside-goroutine"
+	GoPanic                 Category = "go-panic"
 
 	// Cross-primitive.
-	SyncPrimitiveCopy = "sync-primitive-copy"
+	SyncPrimitiveCopy Category = "sync-primitive-copy"
 )
 
 // All returns every known check category. Order is not significant.
-func All() []string {
-	return []string{
+func All() []Category {
+	return []Category{
 		LockWithoutUnlock,
 		UnlockWithoutLock,
 		DeferUnlockWithoutLock,
@@ -83,5 +87,5 @@ func All() []string {
 
 // IsKnown reports whether id is a recognised check category.
 func IsKnown(id string) bool {
-	return slices.Contains(All(), id)
+	return slices.Contains(All(), Category(id))
 }

--- a/pkg/analyzer/common/commentfilter/filter.go
+++ b/pkg/analyzer/common/commentfilter/filter.go
@@ -111,10 +111,10 @@ func (cf *CommentFilter) HasIgnoreDirective(pos token.Pos) bool {
 	return ok
 }
 
-// IsCategoryIgnored reports whether category is silenced at the given line.
+// IsCategoryIgnored reports whether cat is silenced at the given line.
 // A bare directive on that line silences every category. An empty category
 // only matches a bare directive (it never matches a per-rule list).
-func (cf *CommentFilter) IsCategoryIgnored(line int, category string) bool {
+func (cf *CommentFilter) IsCategoryIgnored(line int, cat category.Category) bool {
 	entry, ok := cf.ignoreByLine[line]
 	if !ok {
 		return false
@@ -122,10 +122,10 @@ func (cf *CommentFilter) IsCategoryIgnored(line int, category string) bool {
 	if entry.all {
 		return true
 	}
-	if category == "" {
+	if cat == "" {
 		return false
 	}
-	_, ok = entry.categories[category]
+	_, ok = entry.categories[string(cat)]
 	return ok
 }
 

--- a/pkg/analyzer/common/report/report.go
+++ b/pkg/analyzer/common/report/report.go
@@ -4,8 +4,15 @@ import (
 	"go/token"
 	"sort"
 
+	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/common/category"
 	"golang.org/x/tools/go/analysis"
 )
+
+// Reporter receives diagnostics from checkers as (position, category,
+// message) triplets. ErrorCollector is the standard implementation.
+type Reporter interface {
+	AddError(pos token.Pos, cat category.Category, message string)
+}
 
 // ErrorReport represents a single diagnostic to be reported. Category must
 // match a stable identifier from the category package so downstream tools
@@ -13,14 +20,14 @@ import (
 // filter by it.
 type ErrorReport struct {
 	Pos      token.Pos
-	Category string
+	Category category.Category
 	Message  string
 }
 
 // IgnoreFunc decides whether a diagnostic should be suppressed based on its
 // location and category. It is consulted at report time; passing a nil
 // IgnoreFunc disables filtering.
-type IgnoreFunc func(filename string, line int, category string) bool
+type IgnoreFunc func(filename string, line int, cat category.Category) bool
 
 // ErrorCollector accumulates diagnostics across files, deduplicates by
 // (Pos, Category, Message), and emits them sorted in deterministic order.
@@ -29,13 +36,12 @@ type ErrorCollector struct {
 	seen   map[ErrorReport]struct{}
 }
 
-// AddError records a diagnostic. category should be a constant from the
-// category package; passing an empty category is allowed for transitional
-// callers but will not match any per-rule ignore directive.
-func (ec *ErrorCollector) AddError(pos token.Pos, category, message string) {
+// AddError records a diagnostic. cat should be a constant from the category
+// package; an empty category will not match any per-rule ignore directive.
+func (ec *ErrorCollector) AddError(pos token.Pos, cat category.Category, message string) {
 	report := ErrorReport{
 		Pos:      pos,
-		Category: category,
+		Category: cat,
 		Message:  message,
 	}
 
@@ -79,7 +85,7 @@ func (ec *ErrorCollector) ReportAll(pass *analysis.Pass, ignore IgnoreFunc) {
 		}
 		pass.Report(analysis.Diagnostic{
 			Pos:      err.Pos,
-			Category: err.Category,
+			Category: string(err.Category),
 			Message:  err.Message,
 		})
 	}

--- a/pkg/analyzer/common/report/report_test.go
+++ b/pkg/analyzer/common/report/report_test.go
@@ -4,6 +4,7 @@ import (
 	"go/token"
 	"testing"
 
+	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/common/category"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/tools/go/analysis"
 )
@@ -180,8 +181,8 @@ func TestErrorCollector_ReportAll(t *testing.T) {
 				got = append(got, d.Message)
 			},
 		}
-		ignore := func(_ string, _ int, category string) bool {
-			return category == "wait-without-add"
+		ignore := func(_ string, _ int, cat category.Category) bool {
+			return cat == "wait-without-add"
 		}
 		ec.ReportAll(pass, ignore)
 		assert.Equal(t, []string{"kept"}, got)

--- a/pkg/analyzer/mutex/analyzer.go
+++ b/pkg/analyzer/mutex/analyzer.go
@@ -16,7 +16,7 @@ import (
 type Analyzer struct {
 	mutexNames             map[string]bool
 	rwMutexNames           map[string]bool
-	errorCollector         *report.ErrorCollector
+	errorCollector         report.Reporter
 	stats                  map[string]*Stats
 	deferErrors            *deferErrorCollector
 	commentFilter          *commentfilter.CommentFilter
@@ -73,7 +73,7 @@ type deferErrorCollector struct {
 }
 
 // NewAnalyzer creates a new mutex analyzer
-func NewAnalyzer(mutexNames, rwMutexNames map[string]bool, errorCollector *report.ErrorCollector, cf *commentfilter.CommentFilter, typesInfo *types.Info, files []*ast.File) *Analyzer {
+func NewAnalyzer(mutexNames, rwMutexNames map[string]bool, errorCollector report.Reporter, cf *commentfilter.CommentFilter, typesInfo *types.Info, files []*ast.File) *Analyzer {
 	return &Analyzer{
 		mutexNames:      mutexNames,
 		rwMutexNames:    rwMutexNames,

--- a/pkg/analyzer/waitgroup/analyzer.go
+++ b/pkg/analyzer/waitgroup/analyzer.go
@@ -19,7 +19,7 @@ type Analyzer struct {
 	waitGroupNames             map[string]bool
 	localWaitGroupNames        map[string]bool
 	packageLevelWaitGroupNames map[string]bool
-	errorCollector             *report.ErrorCollector
+	errorCollector             report.Reporter
 	function                   *ast.FuncDecl
 	commentFilter              *commentfilter.CommentFilter
 	typesInfo                  *types.Info
@@ -44,7 +44,7 @@ type Stats struct {
 }
 
 // NewAnalyzer creates a new WaitGroup analyzer
-func NewAnalyzer(waitGroupNames, localWaitGroupNames, packageLevelWaitGroupNames map[string]bool, errorCollector *report.ErrorCollector, cf *commentfilter.CommentFilter, pass *analysis.Pass) *Analyzer {
+func NewAnalyzer(waitGroupNames, localWaitGroupNames, packageLevelWaitGroupNames map[string]bool, errorCollector report.Reporter, cf *commentfilter.CommentFilter, pass *analysis.Pass) *Analyzer {
 	return &Analyzer{
 		waitGroupNames:             waitGroupNames,
 		localWaitGroupNames:        localWaitGroupNames,


### PR DESCRIPTION
Checkers now depend on a minimal report.Reporter (AddError) instead of the concrete ErrorCollector, and category IDs are a dedicated category.Category type propagated through Reporter, ErrorReport, IgnoreFunc and CommentFilter. Also unifies the duplicated DEFINE/ASSIGN branch in findSyncPrimitives.