### PR TITLE
feat: enhance WaitGroup and Mutex Analyzers with New Cases and Logic

### DIFF
--- a/pkg/analyzer/mutex/behavior.go
+++ b/pkg/analyzer/mutex/behavior.go
@@ -15,6 +15,12 @@ type lockOrderEdge struct {
 	to   string
 }
 
+type waitGroupReleaseEvent struct {
+	wgName    string
+	goPos     token.Pos
+	lockNames map[string]bool
+}
+
 type crossGoroutineReleases struct {
 	unlocks  map[string][]token.Pos
 	runlocks map[string][]token.Pos
@@ -27,10 +33,11 @@ func (ma *Analyzer) checkLockOrderCycles(block *ast.BlockStmt) {
 
 	edges := make(map[lockOrderEdge]token.Pos)
 	reported := make(map[lockOrderEdge]bool)
-	ma.scanLockOrderStatements(block.List, make(map[string]bool), edges, reported)
+	waitReleases := ma.waitGroupReleasedLocks(block)
+	ma.scanLockOrderStatements(block.List, make(map[string]bool), edges, reported, waitReleases)
 }
 
-func (ma *Analyzer) scanLockOrderStatements(stmts []ast.Stmt, held map[string]bool, edges map[lockOrderEdge]token.Pos, reported map[lockOrderEdge]bool) {
+func (ma *Analyzer) scanLockOrderStatements(stmts []ast.Stmt, held map[string]bool, edges map[lockOrderEdge]token.Pos, reported map[lockOrderEdge]bool, waitReleases []waitGroupReleaseEvent) {
 	for _, stmt := range stmts {
 		if stmt == nil || ma.commentFilter.ShouldSkipStatement(stmt) {
 			continue
@@ -39,13 +46,13 @@ func (ma *Analyzer) scanLockOrderStatements(stmts []ast.Stmt, held map[string]bo
 		switch s := stmt.(type) {
 		case *ast.ExprStmt:
 			if call, ok := s.X.(*ast.CallExpr); ok {
-				ma.scanLockOrderCall(call, held, edges, reported)
+				ma.scanLockOrderCall(call, held, edges, reported, waitReleases)
 			}
 		case *ast.DeferStmt:
-			ma.scanLockOrderDefer(s, held, edges, reported)
+			ma.scanLockOrderDefer(s, held, edges, reported, waitReleases)
 		case *ast.GoStmt:
 			if fnLit, ok := s.Call.Fun.(*ast.FuncLit); ok && fnLit.Body != nil {
-				ma.scanLockOrderStatements(fnLit.Body.List, make(map[string]bool), edges, reported)
+				ma.scanLockOrderStatements(fnLit.Body.List, make(map[string]bool), edges, reported, waitReleases)
 			}
 		case *ast.IfStmt:
 			thenHeld := maps.Clone(held)
@@ -53,45 +60,45 @@ func (ma *Analyzer) scanLockOrderStatements(stmts []ast.Stmt, held map[string]bo
 				ma.recordHeldLockOrderEdges(varName, s.Cond.Pos(), thenHeld, edges, reported)
 				thenHeld[varName] = true
 			}
-			ma.scanLockOrderStatements(s.Body.List, thenHeld, edges, reported)
+			ma.scanLockOrderStatements(s.Body.List, thenHeld, edges, reported, waitReleases)
 			if s.Else != nil {
-				ma.scanLockOrderElse(s.Else, maps.Clone(held), edges, reported)
+				ma.scanLockOrderElse(s.Else, maps.Clone(held), edges, reported, waitReleases)
 			}
 		case *ast.ForStmt:
 			if s.Body != nil {
-				ma.scanLockOrderStatements(s.Body.List, maps.Clone(held), edges, reported)
+				ma.scanLockOrderStatements(s.Body.List, maps.Clone(held), edges, reported, waitReleases)
 			}
 		case *ast.RangeStmt:
 			if s.Body != nil {
-				ma.scanLockOrderStatements(s.Body.List, maps.Clone(held), edges, reported)
+				ma.scanLockOrderStatements(s.Body.List, maps.Clone(held), edges, reported, waitReleases)
 			}
 		case *ast.BlockStmt:
-			ma.scanLockOrderStatements(s.List, held, edges, reported)
+			ma.scanLockOrderStatements(s.List, held, edges, reported, waitReleases)
 		case *ast.LabeledStmt:
-			ma.scanLockOrderStatements([]ast.Stmt{s.Stmt}, held, edges, reported)
+			ma.scanLockOrderStatements([]ast.Stmt{s.Stmt}, held, edges, reported, waitReleases)
 		case *ast.SwitchStmt:
 			for _, clause := range s.Body.List {
 				if cc, ok := clause.(*ast.CaseClause); ok {
-					ma.scanLockOrderStatements(cc.Body, maps.Clone(held), edges, reported)
+					ma.scanLockOrderStatements(cc.Body, maps.Clone(held), edges, reported, waitReleases)
 				}
 			}
 		case *ast.TypeSwitchStmt:
 			for _, clause := range s.Body.List {
 				if cc, ok := clause.(*ast.CaseClause); ok {
-					ma.scanLockOrderStatements(cc.Body, maps.Clone(held), edges, reported)
+					ma.scanLockOrderStatements(cc.Body, maps.Clone(held), edges, reported, waitReleases)
 				}
 			}
 		case *ast.SelectStmt:
 			for _, clause := range s.Body.List {
 				if cc, ok := clause.(*ast.CommClause); ok {
-					ma.scanLockOrderStatements(cc.Body, maps.Clone(held), edges, reported)
+					ma.scanLockOrderStatements(cc.Body, maps.Clone(held), edges, reported, waitReleases)
 				}
 			}
 		}
 	}
 }
 
-func (ma *Analyzer) scanLockOrderCall(call *ast.CallExpr, held map[string]bool, edges map[lockOrderEdge]token.Pos, reported map[lockOrderEdge]bool) {
+func (ma *Analyzer) scanLockOrderCall(call *ast.CallExpr, held map[string]bool, edges map[lockOrderEdge]token.Pos, reported map[lockOrderEdge]bool, waitReleases []waitGroupReleaseEvent) {
 	if call == nil || ma.commentFilter.ShouldSkipCall(call) {
 		return
 	}
@@ -109,24 +116,179 @@ func (ma *Analyzer) scanLockOrderCall(call *ast.CallExpr, held map[string]bool, 
 	case ma.isLockOrderRelease(varName, sel.Sel.Name):
 		delete(held, varName)
 	}
+
+	if sel.Sel.Name == "Wait" && ma.isWaitGroupReceiver(sel.X) {
+		ma.applyWaitGroupReleaseEvents(held, varName, call.Pos(), waitReleases)
+	}
 }
 
-func (ma *Analyzer) scanLockOrderDefer(stmt *ast.DeferStmt, held map[string]bool, edges map[lockOrderEdge]token.Pos, reported map[lockOrderEdge]bool) {
+func (ma *Analyzer) scanLockOrderDefer(stmt *ast.DeferStmt, held map[string]bool, edges map[lockOrderEdge]token.Pos, reported map[lockOrderEdge]bool, waitReleases []waitGroupReleaseEvent) {
 	if stmt == nil || ma.commentFilter.ShouldSkipCall(stmt.Call) {
 		return
 	}
 	if call, ok := stmt.Call.Fun.(*ast.FuncLit); ok && call.Body != nil {
-		ma.scanLockOrderStatements(call.Body.List, maps.Clone(held), edges, reported)
+		ma.scanLockOrderStatements(call.Body.List, maps.Clone(held), edges, reported, waitReleases)
 	}
 }
 
-func (ma *Analyzer) scanLockOrderElse(stmt ast.Stmt, held map[string]bool, edges map[lockOrderEdge]token.Pos, reported map[lockOrderEdge]bool) {
+func (ma *Analyzer) scanLockOrderElse(stmt ast.Stmt, held map[string]bool, edges map[lockOrderEdge]token.Pos, reported map[lockOrderEdge]bool, waitReleases []waitGroupReleaseEvent) {
 	switch s := stmt.(type) {
 	case *ast.BlockStmt:
-		ma.scanLockOrderStatements(s.List, held, edges, reported)
+		ma.scanLockOrderStatements(s.List, held, edges, reported, waitReleases)
 	case *ast.IfStmt:
-		ma.scanLockOrderStatements([]ast.Stmt{s}, held, edges, reported)
+		ma.scanLockOrderStatements([]ast.Stmt{s}, held, edges, reported, waitReleases)
 	}
+}
+
+func (ma *Analyzer) applyWaitGroupReleaseEvents(held map[string]bool, wgName string, waitPos token.Pos, waitReleases []waitGroupReleaseEvent) {
+	for _, event := range waitReleases {
+		if event.wgName != wgName || event.goPos >= waitPos {
+			continue
+		}
+		for releasedName := range event.lockNames {
+			delete(held, releasedName)
+		}
+	}
+}
+
+func (ma *Analyzer) waitGroupReleasedLocks(block *ast.BlockStmt) []waitGroupReleaseEvent {
+	var releases []waitGroupReleaseEvent
+	if block == nil {
+		return releases
+	}
+
+	ast.Inspect(block, func(n ast.Node) bool {
+		if _, ok := n.(*ast.FuncLit); ok {
+			return false
+		}
+		goStmt, ok := n.(*ast.GoStmt)
+		if !ok || ma.commentFilter.ShouldSkipStatement(goStmt) {
+			return true
+		}
+		fnLit, ok := goStmt.Call.Fun.(*ast.FuncLit)
+		if !ok || fnLit.Body == nil {
+			return false
+		}
+		for wgName, lockNames := range ma.goroutineReleasedLocksBeforeDone(fnLit.Body) {
+			releases = append(releases, waitGroupReleaseEvent{
+				wgName:    wgName,
+				goPos:     goStmt.Pos(),
+				lockNames: lockNames,
+			})
+		}
+		return false
+	})
+	return releases
+}
+
+func (ma *Analyzer) goroutineReleasedLocksBeforeDone(body *ast.BlockStmt) map[string]map[string]bool {
+	releases := make(map[string]map[string]bool)
+	if body == nil {
+		return releases
+	}
+
+	deferredDone := make(map[string]bool)
+	directDone := make(map[string][]token.Pos)
+	unlocks := make(map[string][]token.Pos)
+
+	ast.Inspect(body, func(n ast.Node) bool {
+		switch node := n.(type) {
+		case *ast.FuncLit:
+			return false
+		case *ast.DeferStmt:
+			if wgName, ok := ma.waitGroupDoneCallName(node.Call); ok {
+				deferredDone[wgName] = true
+			}
+			return false
+		case *ast.CallExpr:
+			if ma.commentFilter.ShouldSkipCall(node) {
+				return true
+			}
+			if wgName, ok := ma.waitGroupDoneCallName(node); ok {
+				directDone[wgName] = append(directDone[wgName], node.Pos())
+				return true
+			}
+			if lockName, ok := ma.lockOrderReleaseCallName(node); ok {
+				unlocks[lockName] = append(unlocks[lockName], node.Pos())
+			}
+		}
+		return true
+	})
+
+	for wgName := range deferredDone {
+		ma.addReleasedLocks(releases, wgName, unlocks)
+	}
+	for wgName, donePositions := range directDone {
+		firstDone := firstPos(donePositions)
+		beforeDone := make(map[string][]token.Pos)
+		for lockName, positions := range unlocks {
+			for _, pos := range positions {
+				if pos < firstDone {
+					beforeDone[lockName] = append(beforeDone[lockName], pos)
+				}
+			}
+		}
+		ma.addReleasedLocks(releases, wgName, beforeDone)
+	}
+
+	return releases
+}
+
+func (ma *Analyzer) addReleasedLocks(releases map[string]map[string]bool, wgName string, unlocks map[string][]token.Pos) {
+	if len(unlocks) == 0 {
+		return
+	}
+	if releases[wgName] == nil {
+		releases[wgName] = make(map[string]bool)
+	}
+	for lockName := range unlocks {
+		releases[wgName][lockName] = true
+	}
+}
+
+func firstPos(positions []token.Pos) token.Pos {
+	first := token.NoPos
+	for _, pos := range positions {
+		if first == token.NoPos || pos < first {
+			first = pos
+		}
+	}
+	return first
+}
+
+func (ma *Analyzer) waitGroupDoneCallName(call *ast.CallExpr) (string, bool) {
+	if call == nil || ma.commentFilter.ShouldSkipCall(call) {
+		return "", false
+	}
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok || sel.Sel.Name != "Done" || !ma.isWaitGroupReceiver(sel.X) {
+		return "", false
+	}
+	return common.GetVarName(sel.X), true
+}
+
+func (ma *Analyzer) lockOrderReleaseCallName(call *ast.CallExpr) (string, bool) {
+	if call == nil || ma.commentFilter.ShouldSkipCall(call) {
+		return "", false
+	}
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return "", false
+	}
+	varName := common.GetVarName(sel.X)
+	if !ma.isLockOrderRelease(varName, sel.Sel.Name) {
+		return "", false
+	}
+	return varName, true
+}
+
+func (ma *Analyzer) isWaitGroupReceiver(expr ast.Expr) bool {
+	if ma.typesInfo == nil {
+		return false
+	}
+	typ := ma.typesInfo.TypeOf(expr)
+	typ = common.DerefOnceAndUnalias(typ)
+	return common.MatchesPkgAndName(typ, "sync", "WaitGroup")
 }
 
 func (ma *Analyzer) tryLockCallVar(expr ast.Expr) (string, bool) {

--- a/pkg/analyzer/mutex/stats.go
+++ b/pkg/analyzer/mutex/stats.go
@@ -6,6 +6,7 @@ import (
 	"go/printer"
 	"go/token"
 	"go/types"
+	"slices"
 
 	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/common"
 	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/common/category"
@@ -51,7 +52,7 @@ func (ma *Analyzer) analyzeStatementWithTail(stmt ast.Stmt, stats map[string]*St
 
 func (ma *Analyzer) terminatingTailByIndex(stmts []ast.Stmt) []bool {
 	tail := make([]bool, len(stmts)+1)
-	for i := len(stmts) - 1; i >= 0; i-- {
+	for i := range slices.Backward(stmts) {
 		tail[i] = tail[i+1] || ma.statementAlwaysTerminates(stmts[i])
 	}
 	return tail

--- a/pkg/analyzer/testdata/src/mutex/mutex_goroutine_cases.go
+++ b/pkg/analyzer/testdata/src/mutex/mutex_goroutine_cases.go
@@ -59,6 +59,53 @@ func BadGoroutineWaitGroupWaitsBeforeParentUnlocks() {
 	mu.Unlock()
 }
 
+func BadCrossGoroutineUnlockCompletedBeforeLaterLockOrder() {
+	var fsMu, blockMu sync.RWMutex
+	var ready sync.WaitGroup
+	var wg sync.WaitGroup
+
+	ready.Add(1)
+	wg.Add(1)
+	blockMu.Lock()
+	go func() {
+		ready.Done()
+		defer wg.Done()
+		fsMu.Lock()
+		fsMu.Unlock()
+		blockMu.Unlock() // want "mutex 'blockMu' is unlocked in a different goroutine than it was locked"
+	}()
+
+	ready.Wait()
+	wg.Wait()
+
+	fsMu.RLock()
+	blockMu.RLock()
+	blockMu.RUnlock()
+	fsMu.RUnlock()
+}
+
+func BadFutureWaitGroupReleaseDoesNotBreakCurrentLockOrder() {
+	var a, b sync.Mutex
+	var wg sync.WaitGroup
+
+	b.Lock()
+	a.Lock()
+	a.Unlock()
+	b.Unlock()
+
+	wg.Add(1)
+	a.Lock()
+	wg.Wait()
+
+	b.Lock() // want "mutex lock order cycle between 'a' and 'b'"
+	b.Unlock()
+
+	go func() {
+		defer wg.Done()
+		a.Unlock() // want "mutex 'a' is unlocked in a different goroutine than it was locked"
+	}()
+}
+
 type customWaiter struct{}
 
 func (customWaiter) Wait() {}

--- a/pkg/analyzer/testdata/src/waitgroup/helpers.go
+++ b/pkg/analyzer/testdata/src/waitgroup/helpers.go
@@ -37,6 +37,13 @@ func runWithOnceCallback(done func()) {
 	once.Do(done)
 }
 
+type startRoutineHelper struct{}
+
+func (startRoutineHelper) startGoRoutine(fn func()) bool {
+	go fn()
+	return true
+}
+
 func registerCallback(callback func()) {
 	go callback()
 }
@@ -90,6 +97,15 @@ func trySpawnHelper(wg *sync.WaitGroup, fn func()) {
 
 func (o *callbackOwner) markDone() {
 	o.wg.Done()
+}
+
+type mirrorWorkerLike struct {
+	wg sync.WaitGroup
+}
+
+func processMirrorLike(mirror *mirrorWorkerLike, ready *sync.WaitGroup) {
+	defer mirror.wg.Done()
+	ready.Done()
 }
 
 func doSomething() any {

--- a/pkg/analyzer/testdata/src/waitgroup/waitgroup_callbacks_cases.go
+++ b/pkg/analyzer/testdata/src/waitgroup/waitgroup_callbacks_cases.go
@@ -124,6 +124,77 @@ func GoodWaitGroupDoneInRegisteredCallback() {
 	wg.Wait()
 }
 
+func GoodWaitGroupDoneInClosureSentToExternalWorkerQueue(tasks chan<- func()) {
+	var wg sync.WaitGroup
+	items := []int{1, 2, 3}
+
+	wg.Add(3)
+	for _, item := range items {
+		item := item
+		tasks <- func() {
+			_ = item
+			wg.Done()
+		}
+	}
+	wg.Wait()
+}
+
+func BadWaitGroupDoneInClosureSentToLocalQueueOnly() {
+	var wg sync.WaitGroup
+	tasks := make(chan func(), 1)
+
+	wg.Add(1) // want "waitgroup 'wg' has Add without corresponding Done"
+	tasks <- func() {
+		wg.Done()
+	}
+	wg.Wait()
+}
+
+func GoodWaitGroupDoneViaStartGoRoutineHelper() {
+	var ready sync.WaitGroup
+	mirror := &mirrorWorkerLike{}
+	runner := startRoutineHelper{}
+
+	mirror.wg.Add(1)
+	ready.Add(1)
+	if !runner.startGoRoutine(func() {
+		processMirrorLike(mirror, &ready)
+	}) {
+		mirror.wg.Done()
+		ready.Done()
+	}
+
+	ready.Wait()
+	mirror.wg.Wait()
+}
+
+func GoodWaitGroupDoneViaStartGoRoutineUnderLabel() {
+	responses := make(chan struct{})
+	runner := startRoutineHelper{}
+
+	go func() {
+	SELECT:
+		select {
+		case <-responses:
+			ready := sync.WaitGroup{}
+			mirror := &mirrorWorkerLike{}
+			mirror.wg.Add(1)
+			ready.Add(1)
+			if !runner.startGoRoutine(func() {
+				processMirrorLike(mirror, &ready)
+			}) {
+				mirror.wg.Done()
+				ready.Done()
+			}
+			ready.Wait()
+			mirror.wg.Wait()
+		default:
+			responses <- struct{}{}
+			goto SELECT
+		}
+	}()
+}
+
 func GoodWaitGroupDoneInCallbackVariable() {
 	var wg sync.WaitGroup
 	wg.Add(3)

--- a/pkg/analyzer/testdata/src/waitgroup/waitgroup_goroutine_cases.go
+++ b/pkg/analyzer/testdata/src/waitgroup/waitgroup_goroutine_cases.go
@@ -1,8 +1,10 @@
 package waitgroup
 
 import (
+	"context"
 	"runtime"
 	"sync"
+	"time"
 )
 
 // ---------- Loop Patterns ----------
@@ -488,5 +490,105 @@ func GoodIIFEGoroutineDoneForDynamicAdd(items map[int]string) {
 		}(item)
 	}
 
+	wg.Wait()
+}
+
+func GoodAddCountMatchesDynamicRangeWorkers() {
+	var wg sync.WaitGroup
+	base := [5]int{}
+	items := base[:0]
+	for i := 0; i < 5; i++ {
+		items = append(items, i)
+	}
+
+	wg.Add(5)
+	for _, item := range items {
+		item := item
+		go func() {
+			defer wg.Done()
+			_ = item
+		}()
+	}
+	wg.Wait()
+}
+
+func BadUnknownDynamicRangeMayNotCoverAdd(items []int) {
+	var wg sync.WaitGroup
+	wg.Add(2) // want "waitgroup 'wg' has Add without corresponding Done"
+	for _, item := range items {
+		item := item
+		go func() {
+			defer wg.Done()
+			_ = item
+		}()
+	}
+	wg.Wait()
+}
+
+func GoodWorkerDoneOnContextCancellation() {
+	ctx, cancel := context.WithCancel(context.Background())
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		tick := time.NewTicker(time.Millisecond)
+		for {
+			select {
+			case <-ctx.Done():
+				wg.Done()
+				return
+			case <-tick.C:
+				doSomething()
+			}
+		}
+	}()
+
+	cancel()
+	wg.Wait()
+}
+
+type customDoneSignal struct {
+	ch chan struct{}
+}
+
+func (s customDoneSignal) Done() <-chan struct{} {
+	return s.ch
+}
+
+func BadWorkerDoneOnNonContextSignalMissingDefaultDone(sig customDoneSignal) {
+	var wg sync.WaitGroup
+	wg.Add(1) // want "waitgroup 'wg' has Add without corresponding Done"
+	go func() {
+		for {
+			select {
+			case <-sig.Done():
+				wg.Done()
+				return
+			default:
+				return
+			}
+		}
+	}()
+	wg.Wait()
+}
+
+func GoodWorkerDoneOnContextCancellationInTickerRange() {
+	ctx, cancel := context.WithCancel(context.Background())
+	var wg sync.WaitGroup
+
+	go func() {
+		for range time.NewTicker(time.Millisecond).C {
+			select {
+			case <-ctx.Done():
+				wg.Done()
+				return
+			default:
+			}
+			doSomething()
+		}
+	}()
+	wg.Add(1)
+
+	cancel()
 	wg.Wait()
 }

--- a/pkg/analyzer/waitgroup/analyzer.go
+++ b/pkg/analyzer/waitgroup/analyzer.go
@@ -30,6 +30,7 @@ type Analyzer struct {
 type addCall struct {
 	pos   token.Pos
 	value int
+	known bool
 }
 
 // Stats tracks the state of a WaitGroup within a function
@@ -119,11 +120,13 @@ func (wga *Analyzer) handleAddCall(call *ast.CallExpr, wgName string, stats map[
 	}
 
 	addValue := common.GetAddValue(call)
+	addKnown := false
 	if len(call.Args) > 0 {
-		if constantValue, ok := common.ConstantIntValue(call.Args[0], wga.typesInfo); ok {
+		if constantValue, ok := wga.addValueAt(call.Args[0], call.Pos()); ok {
 			// Keep exact typed constants so balance and literal loop checks see
 			// wg.Add(workers) the same way they see wg.Add(4).
 			addValue = constantValue
+			addKnown = true
 			if addValue < 0 {
 				wga.errorCollector.AddError(call.Pos(), category.AddNegative, "waitgroup '"+wgName+"' has negative Add("+strconv.Itoa(addValue)+")")
 			}
@@ -135,8 +138,28 @@ func (wga *Analyzer) handleAddCall(call *ast.CallExpr, wgName string, stats map[
 	stats[wgName].addCalls = append(stats[wgName].addCalls, addCall{
 		pos:   call.Pos(),
 		value: addValue,
+		known: addKnown,
 	})
 	stats[wgName].totalAdd += addValue
+}
+
+func (wga *Analyzer) addValueAt(expr ast.Expr, pos token.Pos) (int, bool) {
+	if value, ok := common.ConstantIntValue(expr, wga.typesInfo); ok {
+		return value, true
+	}
+	call, ok := expr.(*ast.CallExpr)
+	if !ok || len(call.Args) != 1 {
+		return 0, false
+	}
+	ident, ok := call.Fun.(*ast.Ident)
+	if !ok || ident.Name != "len" {
+		return 0, false
+	}
+	argIdent, ok := call.Args[0].(*ast.Ident)
+	if !ok {
+		return 0, false
+	}
+	return wga.collectionLengthBefore(argIdent.Name, pos)
 }
 
 // handleDoneCall processes Done() calls
@@ -225,6 +248,11 @@ func (wga *Analyzer) isWaitGroupPassedToOtherFunctions(wgName string) bool {
 					return false
 				}
 			}
+		case *ast.SendStmt:
+			if wga.sendEscapesWaitGroup(node, wgName, localCallbacks) {
+				found = true
+				return false
+			}
 		case *ast.ReturnStmt:
 			for _, result := range node.Results {
 				if wga.exprEscapesWaitGroup(result, wgName, localCallbacks, make(map[string]bool)) {
@@ -236,6 +264,17 @@ func (wga *Analyzer) isWaitGroupPassedToOtherFunctions(wgName string) bool {
 		return true
 	})
 	return found
+}
+
+func (wga *Analyzer) sendEscapesWaitGroup(send *ast.SendStmt, wgName string, callbacks map[string]ast.Expr) bool {
+	if send == nil || !wga.exprEscapesWaitGroup(send.Value, wgName, callbacks, make(map[string]bool)) {
+		return false
+	}
+	chanName := common.GetVarName(send.Chan)
+	if chanName == "" || chanName == "?" {
+		return true
+	}
+	return !wga.isLocallyCreatedChannel(chanName)
 }
 
 func (wga *Analyzer) collectLocalCallbackExprs() map[string]ast.Expr {
@@ -495,6 +534,9 @@ func (wga *Analyzer) relatedWaitGroupForCall(call *ast.CallExpr, wgName string) 
 
 		for i := 0; i < fieldArity && argIndex < len(call.Args); i++ {
 			if !wga.isWaitGroupArgument(call.Args[argIndex], wgName) {
+				if calleeWGName, ok := wga.calleeWaitGroupNameForArg(call.Args[argIndex], wgName, field, i); ok {
+					return fn, calleeWGName, true
+				}
 				argIndex++
 				continue
 			}
@@ -512,4 +554,18 @@ func (wga *Analyzer) relatedWaitGroupForCall(call *ast.CallExpr, wgName string) 
 	}
 
 	return nil, "", false
+}
+
+func (wga *Analyzer) calleeWaitGroupNameForArg(arg ast.Expr, wgName string, field *ast.Field, fieldIndex int) (string, bool) {
+	argName := common.GetVarName(arg)
+	if argName == "" || argName == "?" {
+		return "", false
+	}
+
+	prefix := argName + "."
+	if !strings.HasPrefix(wgName, prefix) || fieldIndex >= len(field.Names) {
+		return "", false
+	}
+
+	return field.Names[fieldIndex].Name + strings.TrimPrefix(wgName, argName), true
 }

--- a/pkg/analyzer/waitgroup/goroutines.go
+++ b/pkg/analyzer/waitgroup/goroutines.go
@@ -3,6 +3,8 @@ package waitgroup
 import (
 	"go/ast"
 	"go/token"
+	"go/types"
+	"slices"
 
 	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/common"
 )
@@ -226,8 +228,18 @@ func (wga *Analyzer) analyzeDoneCallsWithVisited(block *ast.BlockStmt, wgName st
 			var loopInfo doneCallInfo
 			if forStmt, ok := s.(*ast.ForStmt); ok && forStmt.Body != nil {
 				loopInfo = wga.analyzeDoneCallsWithVisited(forStmt.Body, wgName, visited)
+				if wga.loopHasCancellationDoneExit(forStmt.Body, wgName, visited) && !mightExitEarly {
+					info.hasAnyDone = true
+					info.hasGuaranteedDone = true
+					return info
+				}
 			} else if rangeStmt, ok := s.(*ast.RangeStmt); ok && rangeStmt.Body != nil {
 				loopInfo = wga.analyzeDoneCallsWithVisited(rangeStmt.Body, wgName, visited)
+				if wga.loopHasCancellationDoneExit(rangeStmt.Body, wgName, visited) && !mightExitEarly {
+					info.hasAnyDone = true
+					info.hasGuaranteedDone = true
+					return info
+				}
 			}
 			info.hasAnyDone = info.hasAnyDone || loopInfo.hasAnyDone
 			// Note: We don't set hasGuaranteedDone for loops
@@ -237,6 +249,14 @@ func (wga *Analyzer) analyzeDoneCallsWithVisited(block *ast.BlockStmt, wgName st
 			blockInfo := wga.analyzeDoneCallsWithVisited(s, wgName, visited)
 			info.hasAnyDone = info.hasAnyDone || blockInfo.hasAnyDone
 			if blockInfo.hasGuaranteedDone {
+				info.hasGuaranteedDone = true
+				return info
+			}
+
+		case *ast.LabeledStmt:
+			labeledInfo := wga.analyzeDoneCallsWithVisited(&ast.BlockStmt{List: []ast.Stmt{s.Stmt}}, wgName, visited)
+			info.hasAnyDone = info.hasAnyDone || labeledInfo.hasAnyDone
+			if labeledInfo.hasGuaranteedDone {
 				info.hasGuaranteedDone = true
 				return info
 			}
@@ -344,6 +364,84 @@ func (wga *Analyzer) analyzeSelectStatementWithVisited(selectStmt *ast.SelectStm
 	}
 
 	return info
+}
+
+func (wga *Analyzer) loopHasCancellationDoneExit(body *ast.BlockStmt, wgName string, visited map[token.Pos]bool) bool {
+	if body == nil {
+		return false
+	}
+
+	found := false
+	ast.Inspect(body, func(n ast.Node) bool {
+		if found {
+			return false
+		}
+		selectStmt, ok := n.(*ast.SelectStmt)
+		if !ok {
+			return true
+		}
+		for _, stmt := range selectStmt.Body.List {
+			cc, ok := stmt.(*ast.CommClause)
+			if !ok || !wga.commClauseReceivesDoneSignal(cc) {
+				continue
+			}
+			caseBlock := &ast.BlockStmt{List: cc.Body}
+			caseInfo := wga.analyzeDoneCallsWithVisited(caseBlock, wgName, visited)
+			if caseInfo.hasGuaranteedDone && wga.blockAlwaysTerminates(caseBlock) {
+				found = true
+				return false
+			}
+		}
+		return true
+	})
+	return found
+}
+
+func (wga *Analyzer) commClauseReceivesDoneSignal(cc *ast.CommClause) bool {
+	if cc == nil || cc.Comm == nil {
+		return false
+	}
+
+	switch comm := cc.Comm.(type) {
+	case *ast.ExprStmt:
+		return wga.exprReceivesDoneSignal(comm.X)
+	case *ast.AssignStmt:
+		if slices.ContainsFunc(comm.Rhs, wga.exprReceivesDoneSignal) {
+			return true
+		}
+	}
+	return false
+}
+
+func (wga *Analyzer) exprReceivesDoneSignal(expr ast.Expr) bool {
+	unary, ok := expr.(*ast.UnaryExpr)
+	if !ok || unary.Op != token.ARROW {
+		return false
+	}
+	call, ok := unary.X.(*ast.CallExpr)
+	if !ok {
+		return false
+	}
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	return ok && sel.Sel.Name == "Done" && wga.callReturnsContextDoneSignal(sel.X, call)
+}
+
+func (wga *Analyzer) callReturnsContextDoneSignal(receiver ast.Expr, call *ast.CallExpr) bool {
+	if wga.typesInfo == nil {
+		return false
+	}
+	receiverType := types.Unalias(wga.typesInfo.TypeOf(receiver))
+	if !common.MatchesPkgAndName(receiverType, "context", "Context") {
+		return false
+	}
+	typ := types.Unalias(wga.typesInfo.TypeOf(call))
+	ch, ok := typ.(*types.Chan)
+	if !ok || ch.Dir() == types.SendOnly {
+		return false
+	}
+	elem := types.Unalias(ch.Elem()).Underlying()
+	st, ok := elem.(*types.Struct)
+	return ok && st.NumFields() == 0
 }
 
 func (wga *Analyzer) analyzeRelatedCall(call *ast.CallExpr, wgName string, visited map[token.Pos]bool) (doneCallInfo, bool) {
@@ -464,7 +562,7 @@ func (wga *Analyzer) isSyncOnceDoWithCallback(call *ast.CallExpr, callbackName s
 
 	typ := wga.typesInfo.TypeOf(sel.X)
 	typ = common.DerefOnce(typ)
-	
+
 	return common.MatchesPkgAndName(typ, "sync", "Once")
 }
 

--- a/pkg/analyzer/waitgroup/stats.go
+++ b/pkg/analyzer/waitgroup/stats.go
@@ -75,6 +75,14 @@ func (wga *Analyzer) traverseWithContext(n ast.Node, forStack []*ast.ForStmt, st
 		wga.handleBlockStatement(node, forStack, stats, alreadyReported)
 	case *ast.IfStmt:
 		wga.handleIfStatement(node, forStack, stats, alreadyReported)
+	case *ast.SwitchStmt:
+		wga.handleSwitchStatement(node, forStack, stats, alreadyReported)
+	case *ast.TypeSwitchStmt:
+		wga.handleTypeSwitchStatement(node, forStack, stats, alreadyReported)
+	case *ast.SelectStmt:
+		wga.handleSelectStatement(node, forStack, stats, alreadyReported)
+	case *ast.LabeledStmt:
+		wga.traverseWithContext(node.Stmt, forStack, stats, alreadyReported)
 	case *ast.ExprStmt:
 		if wga.handleImmediatelyInvokedFunction(node, forStack, stats, alreadyReported) {
 			return
@@ -134,6 +142,57 @@ func (wga *Analyzer) handleIfStatement(stmt *ast.IfStmt, forStack []*ast.ForStmt
 	wga.traverseWithContext(stmt.Body, forStack, stats, alreadyReported)
 	if stmt.Else != nil {
 		wga.traverseWithContext(stmt.Else, forStack, stats, alreadyReported)
+	}
+}
+
+func (wga *Analyzer) handleSwitchStatement(stmt *ast.SwitchStmt, forStack []*ast.ForStmt, stats map[string]*Stats, alreadyReported map[token.Pos]bool) {
+	if wga.commentFilter.ShouldSkipStatement(stmt) {
+		return
+	}
+	if stmt.Init != nil {
+		wga.traverseWithContext(stmt.Init, forStack, stats, alreadyReported)
+	}
+	for _, nestedStmt := range stmt.Body.List {
+		if cc, ok := nestedStmt.(*ast.CaseClause); ok {
+			for _, caseStmt := range cc.Body {
+				wga.traverseWithContext(caseStmt, forStack, stats, alreadyReported)
+			}
+		}
+	}
+}
+
+func (wga *Analyzer) handleTypeSwitchStatement(stmt *ast.TypeSwitchStmt, forStack []*ast.ForStmt, stats map[string]*Stats, alreadyReported map[token.Pos]bool) {
+	if wga.commentFilter.ShouldSkipStatement(stmt) {
+		return
+	}
+	if stmt.Init != nil {
+		wga.traverseWithContext(stmt.Init, forStack, stats, alreadyReported)
+	}
+	if stmt.Assign != nil {
+		wga.traverseWithContext(stmt.Assign, forStack, stats, alreadyReported)
+	}
+	for _, nestedStmt := range stmt.Body.List {
+		if cc, ok := nestedStmt.(*ast.CaseClause); ok {
+			for _, caseStmt := range cc.Body {
+				wga.traverseWithContext(caseStmt, forStack, stats, alreadyReported)
+			}
+		}
+	}
+}
+
+func (wga *Analyzer) handleSelectStatement(stmt *ast.SelectStmt, forStack []*ast.ForStmt, stats map[string]*Stats, alreadyReported map[token.Pos]bool) {
+	if wga.commentFilter.ShouldSkipStatement(stmt) {
+		return
+	}
+	for _, nestedStmt := range stmt.Body.List {
+		if cc, ok := nestedStmt.(*ast.CommClause); ok {
+			if cc.Comm != nil {
+				wga.traverseWithContext(cc.Comm, forStack, stats, alreadyReported)
+			}
+			for _, caseStmt := range cc.Body {
+				wga.traverseWithContext(caseStmt, forStack, stats, alreadyReported)
+			}
+		}
 	}
 }
 
@@ -198,6 +257,14 @@ func (wga *Analyzer) traverseWithReportMap(n ast.Node, forStack []*ast.ForStmt, 
 		wga.handleBlockStatement(node, forStack, stats, alreadyReported)
 	case *ast.IfStmt:
 		wga.handleIfStatement(node, forStack, stats, alreadyReported)
+	case *ast.SwitchStmt:
+		wga.handleSwitchStatement(node, forStack, stats, alreadyReported)
+	case *ast.TypeSwitchStmt:
+		wga.handleTypeSwitchStatement(node, forStack, stats, alreadyReported)
+	case *ast.SelectStmt:
+		wga.handleSelectStatement(node, forStack, stats, alreadyReported)
+	case *ast.LabeledStmt:
+		wga.traverseWithReportMap(node.Stmt, forStack, stats, alreadyReported)
 	case *ast.ExprStmt:
 		if wga.handleImmediatelyInvokedFunction(node, forStack, stats, alreadyReported) {
 			return

--- a/pkg/analyzer/waitgroup/validation.go
+++ b/pkg/analyzer/waitgroup/validation.go
@@ -50,7 +50,6 @@ func (wga *Analyzer) validateBalance(wgName string, stats *Stats) {
 	guaranteedFromGoroutines := wga.countGuaranteedDoneInGoroutines(wgName)
 	totalDone += guaranteedFromGoroutines
 
-	// Check for balance and report errors
 	if stats.totalAdd > totalDone {
 		wga.reportUnmatchedAdds(wgName, stats, totalDone)
 	}
@@ -260,8 +259,15 @@ func (wga *Analyzer) countGuaranteedDoneInStatements(stmts []ast.Stmt, wgName st
 }
 
 func (wga *Analyzer) estimateForIterations(forStmt *ast.ForStmt) int {
+	if iterations, ok := wga.estimateForIterationsKnown(forStmt); ok {
+		return iterations
+	}
+	return 1
+}
+
+func (wga *Analyzer) estimateForIterationsKnown(forStmt *ast.ForStmt) (int, bool) {
 	if forStmt == nil {
-		return 1
+		return 0, false
 	}
 
 	start := 0
@@ -277,73 +283,285 @@ func (wga *Analyzer) estimateForIterations(forStmt *ast.ForStmt) int {
 	}
 
 	if counterName == "" {
-		return 1
+		return 0, false
 	}
 
 	cond, ok := forStmt.Cond.(*ast.BinaryExpr)
 	if !ok {
-		return 1
+		return 0, false
 	}
 	left, ok := cond.X.(*ast.Ident)
 	if !ok || left.Name != counterName {
-		return 1
+		return 0, false
 	}
 	limit, ok := common.ConstantIntValue(cond.Y, wga.typesInfo)
 	if !ok {
-		return 1
+		return 0, false
 	}
 
-	switch post := forStmt.Post.(type) {
-	case *ast.IncDecStmt:
-		if ident, ok := post.X.(*ast.Ident); !ok || ident.Name != counterName || post.Tok != token.INC {
-			return 1
-		}
-	case *ast.AssignStmt:
-		if len(post.Lhs) != 1 || len(post.Rhs) != 1 {
-			return 1
-		}
-		ident, ok := post.Lhs[0].(*ast.Ident)
-		if !ok || ident.Name != counterName {
-			return 1
-		}
-		if post.Tok != token.ADD_ASSIGN {
-			return 1
-		}
-		if lit, ok := post.Rhs[0].(*ast.BasicLit); !ok || lit.Kind != token.INT || parseIntLiteral(lit) != 1 {
-			return 1
-		}
-	default:
-		return 1
+	if !wga.loopIncrementsCounterByOne(forStmt, counterName) {
+		return 0, false
 	}
 
 	switch cond.Op {
 	case token.LSS:
 		if limit <= start {
-			return 1
+			return 1, true
 		}
-		return limit - start
+		return limit - start, true
 	case token.LEQ:
 		if limit < start {
-			return 1
+			return 1, true
 		}
-		return limit - start + 1
+		return limit - start + 1, true
 	default:
-		return 1
+		return 0, false
 	}
 }
 
 func (wga *Analyzer) estimateRangeIterations(rangeStmt *ast.RangeStmt) int {
+	if iterations, ok := wga.estimateRangeIterationsKnown(rangeStmt); ok {
+		return iterations
+	}
+	return 1
+}
+
+func (wga *Analyzer) estimateRangeIterationsKnown(rangeStmt *ast.RangeStmt) (int, bool) {
 	if rangeStmt == nil || rangeStmt.X == nil {
-		return 1
+		return 0, false
+	}
+
+	if lit, ok := rangeStmt.X.(*ast.CompositeLit); ok {
+		return len(lit.Elts), true
+	}
+	if ident, ok := rangeStmt.X.(*ast.Ident); ok {
+		if length, ok := wga.collectionLengthBefore(ident.Name, rangeStmt.Pos()); ok {
+			return length, true
+		}
 	}
 
 	if tv, ok := wga.typesInfo.Types[rangeStmt.X]; ok && tv.Value != nil {
 		if value, ok := constant.Int64Val(tv.Value); ok && value > 0 {
-			return int(value)
+			return int(value), true
 		}
 	}
 
-	return 1
+	return 0, false
+}
+
+func (wga *Analyzer) loopIncrementsCounterByOne(forStmt *ast.ForStmt, counterName string) bool {
+	if forStmt == nil || counterName == "" {
+		return false
+	}
+	if forStmt.Post != nil {
+		return wga.statementIncrementsCounterByOne(forStmt.Post, counterName)
+	}
+	for _, stmt := range forStmt.Body.List {
+		if wga.statementIncrementsCounterByOne(stmt, counterName) {
+			return true
+		}
+	}
+	return false
+}
+
+func (wga *Analyzer) statementIncrementsCounterByOne(stmt ast.Stmt, counterName string) bool {
+	switch post := stmt.(type) {
+	case *ast.IncDecStmt:
+		ident, ok := post.X.(*ast.Ident)
+		return ok && ident.Name == counterName && post.Tok == token.INC
+	case *ast.AssignStmt:
+		if len(post.Lhs) != 1 || len(post.Rhs) != 1 || post.Tok != token.ADD_ASSIGN {
+			return false
+		}
+		ident, ok := post.Lhs[0].(*ast.Ident)
+		if !ok || ident.Name != counterName {
+			return false
+		}
+		lit, ok := post.Rhs[0].(*ast.BasicLit)
+		return ok && lit.Kind == token.INT && parseIntLiteral(lit) == 1
+	default:
+		return false
+	}
+}
+
+func (wga *Analyzer) collectionLengthBefore(name string, before token.Pos) (int, bool) {
+	if wga.function == nil || wga.function.Body == nil || name == "" {
+		return 0, false
+	}
+
+	lengths := make(map[string]int)
+	known := make(map[string]bool)
+	wga.collectCollectionLengthsBefore(wga.function.Body.List, before, 1, lengths, known)
+	length, ok := lengths[name]
+	return length, ok && known[name]
+}
+
+func (wga *Analyzer) collectCollectionLengthsBefore(stmts []ast.Stmt, before token.Pos, multiplier int, lengths map[string]int, known map[string]bool) bool {
+	for _, stmt := range stmts {
+		if stmt == nil || stmt.Pos() >= before {
+			return false
+		}
+		if wga.commentFilter.ShouldSkipStatement(stmt) {
+			continue
+		}
+		switch s := stmt.(type) {
+		case *ast.DeclStmt:
+			wga.recordCollectionDeclLengths(s, lengths, known)
+		case *ast.AssignStmt:
+			wga.recordCollectionAssignLengths(s, multiplier, lengths, known)
+		case *ast.ForStmt:
+			iterations, ok := wga.estimateForIterationsKnown(s)
+			if !ok || s.Body == nil {
+				continue
+			}
+			if !wga.collectCollectionLengthsBefore(s.Body.List, before, multiplier*iterations, lengths, known) {
+				return false
+			}
+		case *ast.RangeStmt:
+			iterations, ok := wga.estimateRangeIterationsKnown(s)
+			if !ok || s.Body == nil {
+				continue
+			}
+			if !wga.collectCollectionLengthsBefore(s.Body.List, before, multiplier*iterations, lengths, known) {
+				return false
+			}
+		case *ast.BlockStmt:
+			if !wga.collectCollectionLengthsBefore(s.List, before, multiplier, lengths, known) {
+				return false
+			}
+		case *ast.LabeledStmt:
+			if !wga.collectCollectionLengthsBefore([]ast.Stmt{s.Stmt}, before, multiplier, lengths, known) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func (wga *Analyzer) recordCollectionDeclLengths(stmt *ast.DeclStmt, lengths map[string]int, known map[string]bool) {
+	gen, ok := stmt.Decl.(*ast.GenDecl)
+	if !ok {
+		return
+	}
+	for _, spec := range gen.Specs {
+		vs, ok := spec.(*ast.ValueSpec)
+		if !ok {
+			continue
+		}
+		for i, name := range vs.Names {
+			if i < len(vs.Values) {
+				wga.setCollectionLength(name.Name, vs.Values[i], lengths, known)
+				continue
+			}
+			if length, ok := wga.collectionLengthFromType(vs.Type); ok {
+				lengths[name.Name] = length
+				known[name.Name] = true
+			}
+		}
+	}
+}
+
+func (wga *Analyzer) recordCollectionAssignLengths(stmt *ast.AssignStmt, multiplier int, lengths map[string]int, known map[string]bool) {
+	for i, lhs := range stmt.Lhs {
+		ident, ok := lhs.(*ast.Ident)
+		if !ok || i >= len(stmt.Rhs) {
+			continue
+		}
+		if wga.recordAppendLength(ident.Name, stmt.Rhs[i], multiplier, lengths, known) {
+			continue
+		}
+		wga.setCollectionLength(ident.Name, stmt.Rhs[i], lengths, known)
+	}
+}
+
+func (wga *Analyzer) setCollectionLength(name string, expr ast.Expr, lengths map[string]int, known map[string]bool) {
+	length, ok := wga.collectionLengthFromExpr(expr, lengths, known)
+	if !ok {
+		delete(lengths, name)
+		delete(known, name)
+		return
+	}
+	lengths[name] = length
+	known[name] = true
+}
+
+func (wga *Analyzer) recordAppendLength(name string, expr ast.Expr, multiplier int, lengths map[string]int, known map[string]bool) bool {
+	call, ok := expr.(*ast.CallExpr)
+	if !ok {
+		return false
+	}
+	ident, ok := call.Fun.(*ast.Ident)
+	if !ok || ident.Name != "append" || len(call.Args) < 2 {
+		return false
+	}
+	target, ok := call.Args[0].(*ast.Ident)
+	if !ok || target.Name != name || !known[name] || call.Ellipsis.IsValid() {
+		delete(lengths, name)
+		delete(known, name)
+		return true
+	}
+	lengths[name] += (len(call.Args) - 1) * multiplier
+	return true
+}
+
+func (wga *Analyzer) collectionLengthFromExpr(expr ast.Expr, lengths map[string]int, known map[string]bool) (int, bool) {
+	switch e := expr.(type) {
+	case *ast.CompositeLit:
+		return len(e.Elts), true
+	case *ast.Ident:
+		length, ok := lengths[e.Name]
+		return length, ok && known[e.Name]
+	case *ast.SliceExpr:
+		return wga.sliceExprLength(e, lengths, known)
+	case *ast.CallExpr:
+		return wga.makeCollectionLength(e)
+	default:
+		return 0, false
+	}
+}
+
+func (wga *Analyzer) sliceExprLength(expr *ast.SliceExpr, lengths map[string]int, known map[string]bool) (int, bool) {
+	low := 0
+	if expr.Low != nil {
+		value, ok := common.ConstantIntValue(expr.Low, wga.typesInfo)
+		if !ok {
+			return 0, false
+		}
+		low = value
+	}
+	if expr.High != nil {
+		high, ok := common.ConstantIntValue(expr.High, wga.typesInfo)
+		if !ok || high < low {
+			return 0, false
+		}
+		return high - low, true
+	}
+	if ident, ok := expr.X.(*ast.Ident); ok {
+		length, ok := lengths[ident.Name]
+		return length - low, ok && known[ident.Name] && length >= low
+	}
+	return 0, false
+}
+
+func (wga *Analyzer) makeCollectionLength(call *ast.CallExpr) (int, bool) {
+	ident, ok := call.Fun.(*ast.Ident)
+	if !ok || ident.Name != "make" || len(call.Args) < 2 {
+		return 0, false
+	}
+	length, ok := common.ConstantIntValue(call.Args[1], wga.typesInfo)
+	return length, ok
+}
+
+func (wga *Analyzer) collectionLengthFromType(expr ast.Expr) (int, bool) {
+	switch typ := expr.(type) {
+	case *ast.ArrayType:
+		if typ.Len == nil {
+			return 0, true
+		}
+		return common.ConstantIntValue(typ.Len, wga.typesInfo)
+	default:
+		return 0, false
+	}
 }
 
 func parseIntLiteral(lit *ast.BasicLit) int {
@@ -370,10 +588,87 @@ func (wga *Analyzer) reportUnmatchedAdds(wgName string, stats *Stats, totalExpec
 	for _, addCall := range stats.addCalls {
 		if remainingDone >= addCall.value {
 			remainingDone -= addCall.value
+		} else if !addCall.known && wga.addCoveredByVariableDoneLoop(addCall.pos, wgName) {
+			continue
 		} else {
 			wga.errorCollector.AddError(addCall.pos, category.AddWithoutDone, "waitgroup '"+wgName+"' has Add without corresponding Done")
 		}
 	}
+}
+
+func (wga *Analyzer) addCoveredByVariableDoneLoop(addPos token.Pos, wgName string) bool {
+	found := false
+	ast.Inspect(wga.function.Body, func(n ast.Node) bool {
+		if found {
+			return false
+		}
+		switch loop := n.(type) {
+		case *ast.ForStmt:
+			if nodeContainsPos(loop.Body, addPos) && wga.loopBodyHasVariableDoneWorker(loop.Body, addPos, wgName) {
+				found = true
+				return false
+			}
+		case *ast.RangeStmt:
+			if nodeContainsPos(loop.Body, addPos) && wga.loopBodyHasVariableDoneWorker(loop.Body, addPos, wgName) {
+				found = true
+				return false
+			}
+		}
+		return true
+	})
+	return found
+}
+
+func (wga *Analyzer) loopBodyHasVariableDoneWorker(body *ast.BlockStmt, after token.Pos, wgName string) bool {
+	if body == nil {
+		return false
+	}
+	for _, stmt := range body.List {
+		if stmt == nil || stmt.Pos() <= after {
+			continue
+		}
+		goStmt, ok := stmt.(*ast.GoStmt)
+		if !ok {
+			continue
+		}
+		fnLit, ok := goStmt.Call.Fun.(*ast.FuncLit)
+		if !ok || fnLit.Body == nil {
+			continue
+		}
+		if wga.blockHasVariableDoneLoop(fnLit.Body, wgName) {
+			return true
+		}
+	}
+	return false
+}
+
+func (wga *Analyzer) blockHasVariableDoneLoop(body *ast.BlockStmt, wgName string) bool {
+	found := false
+	ast.Inspect(body, func(n ast.Node) bool {
+		if found {
+			return false
+		}
+		switch loop := n.(type) {
+		case *ast.ForStmt:
+			if _, ok := wga.estimateForIterationsKnown(loop); ok {
+				return true
+			}
+			if wga.containsDoneCall(loop.Body, wgName) {
+				found = true
+				return false
+			}
+		case *ast.RangeStmt:
+			if _, ok := wga.estimateRangeIterationsKnown(loop); ok {
+				return true
+			}
+			if wga.containsDoneCall(loop.Body, wgName) {
+				found = true
+				return false
+			}
+		}
+		return true
+	})
+	return found
 }
 
 // reportExcessDones reports Done calls that don't have corresponding Add calls


### PR DESCRIPTION
- Introduced new test cases for WaitGroup and Mutex to cover various scenarios, including:
  - Cross-goroutine unlocks and lock order violations.
  - Dynamic range worker counts and context cancellation handling.
- Improved the Analyzer's ability to track and validate WaitGroup usage, including:
  - Enhanced logic for estimating iterations in for loops and range statements.
  - Added support for handling select statements and labeled statements in the analysis.
  - Implemented checks for variable done signals in goroutines.
- Refactored existing code for better readability and maintainability, including the addition of helper functions for managing collection lengths and loop iterations.
- Updated validation logic to ensure proper matching of Add and Done calls in WaitGroup usage.