### PR TITLE
fix(waitgroup): only flag Add(0) for compile-time constants

### DIFF
--- a/pkg/analyzer/common/common.go
+++ b/pkg/analyzer/common/common.go
@@ -154,6 +154,23 @@ func ConstantIntValue(expr ast.Expr, info *types.Info) (int, bool) {
 	return int(value), true
 }
 
+// IsConstantIntExpr reports whether expr is a compile-time integer constant
+// (literal, named const, or unary +/- of those). Returns false for runtime
+// expressions like len(x), variables, or function calls.
+func IsConstantIntExpr(expr ast.Expr, info *types.Info) bool {
+	if expr == nil {
+		return false
+	}
+	if _, ok := IntegerLiteralValue(expr); ok {
+		return true
+	}
+	if info == nil {
+		return false
+	}
+	tv, ok := info.Types[expr]
+	return ok && tv.Value != nil && tv.Value.Kind() == constant.Int
+}
+
 // IntegerLiteralValue extracts a signed integer literal value when expr is a
 // basic integer literal or a unary +/- integer literal.
 func IntegerLiteralValue(expr ast.Expr) (int, bool) {

--- a/pkg/analyzer/common/common_test.go
+++ b/pkg/analyzer/common/common_test.go
@@ -159,6 +159,36 @@ func TestIntegerLiteralValue(t *testing.T) {
 	}
 }
 
+func TestIsConstantIntExpr(t *testing.T) {
+	literalZero := &ast.BasicLit{Kind: token.INT, Value: "0"}
+	literalFive := &ast.BasicLit{Kind: token.INT, Value: "5"}
+	constIdent := &ast.Ident{Name: "K"}
+	unaryNegLit := &ast.UnaryExpr{Op: token.SUB, X: &ast.BasicLit{Kind: token.INT, Value: "3"}}
+	lenCall := &ast.CallExpr{Fun: &ast.Ident{Name: "len"}, Args: []ast.Expr{&ast.Ident{Name: "s"}}}
+	varIdent := &ast.Ident{Name: "n"}
+
+	info := &types.Info{
+		Types: map[ast.Expr]types.TypeAndValue{
+			constIdent: {Value: constant.MakeInt64(7)},
+			lenCall:    {Value: nil},
+			varIdent:   {Value: nil},
+		},
+	}
+
+	assert.True(t, IsConstantIntExpr(literalZero, info))
+	assert.True(t, IsConstantIntExpr(literalFive, info))
+	assert.True(t, IsConstantIntExpr(unaryNegLit, info))
+	assert.True(t, IsConstantIntExpr(constIdent, info))
+
+	assert.False(t, IsConstantIntExpr(lenCall, info))
+	assert.False(t, IsConstantIntExpr(varIdent, info))
+	assert.False(t, IsConstantIntExpr(nil, info))
+
+	// Literals resolve without types.Info; non-literal idents do not.
+	assert.True(t, IsConstantIntExpr(literalZero, nil))
+	assert.False(t, IsConstantIntExpr(constIdent, nil))
+}
+
 func TestConstantBoolValue(t *testing.T) {
 	trueExpr := &ast.Ident{Name: "always"}
 	falseExpr := &ast.Ident{Name: "never"}

--- a/pkg/analyzer/testdata/src/waitgroup/waitgroup_basic_cases.go
+++ b/pkg/analyzer/testdata/src/waitgroup/waitgroup_basic_cases.go
@@ -136,6 +136,43 @@ func GoodAddPositive() {
 	wg.Wait()
 }
 
+// Slice mutated through a captured closure before the Add: len(senders) is
+// statically 0 but non-zero at runtime, so Add(0) must not fire.
+func GoodAddLenSliceMutatedThroughClosure() {
+	var senders []int
+	createSenders := func() {
+		for i := 0; i < 25; i++ {
+			senders = append(senders, i)
+		}
+	}
+	createSenders()
+	var wg sync.WaitGroup
+	wg.Add(len(senders))
+	for range senders {
+		go func() {
+			defer wg.Done()
+		}()
+	}
+	wg.Wait()
+}
+
+// Map populated dynamically from an input parameter: len() is a runtime
+// expression, Add(0) must not fire.
+func GoodAddLenMapPopulatedDynamically(inputs []int) {
+	taskInfoPerShard := map[int]int{}
+	for _, taskInfo := range inputs {
+		taskInfoPerShard[taskInfo] = taskInfo
+	}
+	var wg sync.WaitGroup
+	wg.Add(len(taskInfoPerShard))
+	for range taskInfoPerShard {
+		go func() {
+			defer wg.Done()
+		}()
+	}
+	wg.Wait()
+}
+
 // ---------- Wait Ordering Patterns ----------
 
 // Add after Wait (illegal, Wait should be called after all Adds)

--- a/pkg/analyzer/waitgroup/analyzer.go
+++ b/pkg/analyzer/waitgroup/analyzer.go
@@ -130,7 +130,9 @@ func (wga *Analyzer) handleAddCall(call *ast.CallExpr, wgName string, stats map[
 			if addValue < 0 {
 				wga.errorCollector.AddError(call.Pos(), category.AddNegative, "waitgroup '"+wgName+"' has negative Add("+strconv.Itoa(addValue)+")")
 			}
-			if addValue == 0 {
+			// Require a compile-time constant: the len(ident) heuristic above
+			// can underestimate when the collection is mutated through a closure.
+			if addValue == 0 && common.IsConstantIntExpr(call.Args[0], wga.typesInfo) {
 				wga.errorCollector.AddError(call.Pos(), category.AddZero, "waitgroup '"+wgName+"' Add(0) is a no-op")
 			}
 		}


### PR DESCRIPTION
Gate the diagnostic behind IsConstantIntExpr so heuristic-resolved lengths (e.g. len(slice) where the slice is mutated through a closure) no longer trigger false positives. The heuristic still feeds the Add/Done balance computation.