### PR TITLE
fix(waitgroup): fix two Add/Done balance false positives

### DIFF
--- a/pkg/analyzer/testdata/src/waitgroup/helpers.go
+++ b/pkg/analyzer/testdata/src/waitgroup/helpers.go
@@ -112,6 +112,10 @@ func doSomething() any {
 	return nil
 }
 
+func loadItems(items []int) ([]int, error) {
+	return items, nil
+}
+
 type readerLifecycleOwner struct {
 	pendingReaders sync.WaitGroup
 	closing        bool

--- a/pkg/analyzer/testdata/src/waitgroup/waitgroup_goroutine_cases.go
+++ b/pkg/analyzer/testdata/src/waitgroup/waitgroup_goroutine_cases.go
@@ -592,3 +592,50 @@ func GoodWorkerDoneOnContextCancellationInTickerRange() {
 	cancel()
 	wg.Wait()
 }
+
+// Slice declared empty then reassigned from a multi-return call inside an
+// if/else: its length is not statically knowable, so the range multiplier
+// must not collapse to 0 and drop the per-iteration Done from the balance.
+func GoodAddDonePairedInsideRangeOverAssignedSlice(items []int, err error) {
+	var clusters []int
+	if len(items) > 0 {
+		clusters, err = loadItems(items)
+	} else {
+		clusters, err = loadItems(nil)
+	}
+	if err != nil {
+		return
+	}
+
+	var wg sync.WaitGroup
+	for _, cluster := range clusters {
+		wg.Add(1)
+		go func(c int) {
+			defer wg.Done()
+			_ = c
+		}(cluster)
+	}
+	wg.Wait()
+}
+
+// Cancellation via close() of a local channel: `case <-chClose` drains when
+// the channel is closed, equivalent to `<-ctx.Done()` for context cancellation.
+func GoodWorkerDoneOnCloseOfLocalChannel() {
+	chClose := make(chan struct{})
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+
+	go func() {
+		for {
+			select {
+			case <-chClose:
+				wg.Done()
+				return
+			default:
+			}
+		}
+	}()
+
+	close(chClose)
+	wg.Wait()
+}

--- a/pkg/analyzer/waitgroup/goroutines.go
+++ b/pkg/analyzer/waitgroup/goroutines.go
@@ -418,12 +418,42 @@ func (wga *Analyzer) exprReceivesDoneSignal(expr ast.Expr) bool {
 	if !ok || unary.Op != token.ARROW {
 		return false
 	}
-	call, ok := unary.X.(*ast.CallExpr)
-	if !ok {
+	switch x := unary.X.(type) {
+	case *ast.CallExpr:
+		sel, ok := x.Fun.(*ast.SelectorExpr)
+		return ok && sel.Sel.Name == "Done" && wga.callReturnsContextDoneSignal(sel.X, x)
+	case *ast.Ident:
+		// `case <-chClose:` where chClose is closed in the enclosing function —
+		// the "close to broadcast cancellation" pattern.
+		return wga.identIsClosedChannel(x.Name)
+	}
+	return false
+}
+
+func (wga *Analyzer) identIsClosedChannel(name string) bool {
+	if name == "" || wga.function == nil || wga.function.Body == nil {
 		return false
 	}
-	sel, ok := call.Fun.(*ast.SelectorExpr)
-	return ok && sel.Sel.Name == "Done" && wga.callReturnsContextDoneSignal(sel.X, call)
+	found := false
+	ast.Inspect(wga.function.Body, func(n ast.Node) bool {
+		if found {
+			return false
+		}
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		callee, ok := call.Fun.(*ast.Ident)
+		if !ok || callee.Name != "close" || len(call.Args) != 1 {
+			return true
+		}
+		if arg, ok := call.Args[0].(*ast.Ident); ok && arg.Name == name {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
 }
 
 func (wga *Analyzer) callReturnsContextDoneSignal(receiver ast.Expr, call *ast.CallExpr) bool {

--- a/pkg/analyzer/waitgroup/validation.go
+++ b/pkg/analyzer/waitgroup/validation.go
@@ -555,8 +555,11 @@ func (wga *Analyzer) makeCollectionLength(call *ast.CallExpr) (int, bool) {
 func (wga *Analyzer) collectionLengthFromType(expr ast.Expr) (int, bool) {
 	switch typ := expr.(type) {
 	case *ast.ArrayType:
+		// `var x []T` starts at length 0 but can be mutated through control-flow
+		// branches the walker doesn't descend into; treating it as known-zero
+		// would zero out the loop multiplier and drop per-iteration Dones.
 		if typ.Len == nil {
-			return 0, true
+			return 0, false
 		}
 		return common.ConstantIntValue(typ.Len, wga.typesInfo)
 	default:


### PR DESCRIPTION
(1) `var x []T` is no longer treated as a known-zero-length slice when estimating range iterations, preventing the loop multiplier from collapsing to 0 and dropping a goroutine's per-iteration Done. (2) `<-chName` is treated as a cancellation receive when chName is closed in the enclosing function, matching the `<-ctx.Done()` heuristic.