### PR TITLE
fix(waitgroup): don't flag Add after Wait when the Wait early-exits

### DIFF
--- a/pkg/analyzer/testdata/src/waitgroup/waitgroup_basic_cases.go
+++ b/pkg/analyzer/testdata/src/waitgroup/waitgroup_basic_cases.go
@@ -201,6 +201,31 @@ func GoodAddInsideGoroutineWithWaitInsideSameGoroutine() {
 	<-done
 }
 
+// A Wait inside an early-exit branch (select case followed by return) must
+// not gate later Adds: control flow never reaches the surrounding code from
+// that branch, so the WaitGroup is reused legitimately across loop iterations.
+func GoodWaitInEarlyExitBranchDoesNotGateLaterAdd(batches [][]int, doneCh <-chan struct{}) {
+	var wg sync.WaitGroup
+	for _, batch := range batches {
+		for _, idx := range batch {
+			_ = idx
+			select {
+			case <-doneCh:
+				wg.Wait()
+				return
+			default:
+			}
+			if len(batch) > 1 {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+				}()
+			}
+		}
+		wg.Wait()
+	}
+}
+
 // Edge case where Add is called after Wait, but in a different flow
 func EdgeCaseAddAfterWaitMainFlow() {
 	var wg sync.WaitGroup

--- a/pkg/analyzer/waitgroup/reachability.go
+++ b/pkg/analyzer/waitgroup/reachability.go
@@ -74,6 +74,51 @@ func (wga *Analyzer) containsDoneCall(stmt ast.Stmt, wgName string) bool {
 	return found
 }
 
+// waitInEarlyExitBranch reports whether the Wait at waitPos is the last
+// meaningful statement of its branch: the next stmt in the enclosing list
+// is a return / break / goto / abort. Such a Wait belongs to a control-flow
+// branch that never reaches the surrounding code — e.g.
+//
+//	case <-done:
+//	    wg.Wait()
+//	    return
+func (wga *Analyzer) waitInEarlyExitBranch(waitPos token.Pos) bool {
+	found := false
+	ast.Inspect(wga.function.Body, func(n ast.Node) bool {
+		if found {
+			return false
+		}
+		stmts := stmtListOf(n)
+		for i, stmt := range stmts {
+			if !nodeContainsPos(stmt, waitPos) {
+				continue
+			}
+			if i+1 < len(stmts) && wga.isTerminatingStatement(stmts[i+1]) {
+				found = true
+				return false
+			}
+			break // Let Inspect descend to the directly-enclosing list.
+		}
+		return true
+	})
+	return found
+}
+
+// stmtListOf returns the statement list directly held by n, or nil for nodes
+// that don't carry one. Centralises the BlockStmt / CaseClause / CommClause
+// dispatch so callers can iterate stmts uniformly.
+func stmtListOf(n ast.Node) []ast.Stmt {
+	switch s := n.(type) {
+	case *ast.BlockStmt:
+		return s.List
+	case *ast.CaseClause:
+		return s.Body
+	case *ast.CommClause:
+		return s.Body
+	}
+	return nil
+}
+
 // blockAlwaysTerminates checks if a block always terminates execution (return, panic, etc.)
 func (wga *Analyzer) blockAlwaysTerminates(block *ast.BlockStmt) bool {
 	for _, stmt := range block.List {

--- a/pkg/analyzer/waitgroup/validation.go
+++ b/pkg/analyzer/waitgroup/validation.go
@@ -845,6 +845,12 @@ func (wga *Analyzer) checkAddAfterWaitInMainFlow(wgName string, st *Stats) {
 		return
 	}
 	for _, wait := range st.waitCalls {
+		// Early-exit Waits don't gate later Adds (their branch never returns
+		// to the surrounding flow).
+		if wga.waitInEarlyExitBranch(wait) {
+			continue
+		}
+
 		// Check if this Wait has any Add or Done operations before it in main flow
 		hasOperationsBefore := false
 


### PR DESCRIPTION
Skip Waits whose enclosing statement list returns/breaks/gotos right after them: they belong to a branch that never reaches surrounding code, so they can't gate later Adds in the WaitGroup-reuse pattern.