### PR TITLE
Add flag-guarded mutex detection and related tests

### DIFF
--- a/pkg/analyzer/internal/mutex/analyzer.go
+++ b/pkg/analyzer/internal/mutex/analyzer.go
@@ -94,6 +94,7 @@ func (c *Checker) AnalyzeFunction(fn *ast.FuncDecl) {
 	c.wrapper = newWrapperResolver(c.receiverMethods, c.function, c.rawBodyEffects)
 	c.lifecycle = newLifecycleResolver(c.receiverMethods, c.functions, c.typesInfo, c.explicitTransferCache, c.function)
 	c.panicDetector = newLockedPanicDetector(c.mutexNames, c.rwMutexNames, c.typesInfo, c.errorCollector, c.rawBodyEffects)
+	c.flagGuardedMutexes = c.detectFlagGuardedReleases(fn)
 	c.stats = initialStats(c.mutexNames, c.rwMutexNames)
 	lockOrder := newLockOrderDetector(c.mutexNames, c.rwMutexNames, c.commentFilter, c.typesInfo, c.errorCollector)
 	lockOrder.check(fn.Body)
@@ -385,6 +386,121 @@ func (c *Checker) applyLocalMethodLifecycleEffects(call *ast.CallExpr, stats map
 	}
 
 	return changed
+}
+
+// applyLocalFunctionCallLifecycleEffects models a call to a top-level (non-method)
+// function that releases a lock held on one of its arguments, e.g.
+// `releaseShardLock(shard)` whose body runs `shard.mu.Unlock()`. Without this the
+// caller appears to leak the lock on the delegated path. It mirrors
+// applyLocalMethodLifecycleEffects but maps the locked variable through the
+// argument position to the callee's parameter name.
+func (c *Checker) applyLocalFunctionCallLifecycleEffects(call *ast.CallExpr, stats map[string]*Stats) bool {
+	ident, ok := call.Fun.(*ast.Ident)
+	if !ok {
+		return false
+	}
+
+	callee := c.topLevelFunctionNamed(ident.Name)
+	if callee == nil || callee.Body == nil || callee == c.function {
+		return false
+	}
+
+	changed := false
+	applyAll := func(names map[string]bool, isRWMutex bool) {
+		for name := range names {
+			if c.applyArgumentReleaseEffect(call, callee, name, isRWMutex, stats) {
+				changed = true
+			}
+		}
+	}
+
+	applyAll(c.mutexNames, false)
+	applyAll(c.rwMutexNames, true)
+	return changed
+}
+
+// applyArgumentReleaseEffect simulates the callee's effect on a single mutex that
+// the caller passes in as an argument, remapping the caller's variable to the
+// matching parameter name inside the callee.
+func (c *Checker) applyArgumentReleaseEffect(call *ast.CallExpr, callee *ast.FuncDecl, mutexName string, isRWMutex bool, stats map[string]*Stats) bool {
+	base, suffix, ok := splitBaseAndSuffix(mutexName)
+	if !ok {
+		return false
+	}
+
+	paramName, ok := calleeParamNameForArg(call, callee, base)
+	if !ok {
+		return false
+	}
+
+	simulated := c.simulateMethodEffect(callee, paramName+"."+suffix, isRWMutex, stats[mutexName])
+	if simulated == nil {
+		return false
+	}
+
+	stats[mutexName] = simulated
+	return true
+}
+
+// topLevelFunctionNamed returns the package-level (non-method) function with the
+// given name, or nil when there is none.
+func (c *Checker) topLevelFunctionNamed(name string) *ast.FuncDecl {
+	for _, fn := range c.functions {
+		if fn != nil && fn.Recv == nil && fn.Name != nil && fn.Name.Name == name {
+			return fn
+		}
+	}
+	return nil
+}
+
+// calleeParamNameForArg returns the callee parameter name that receives the
+// argument whose variable name equals base. It returns false when the argument
+// is absent or the matching parameter is unnamed or blank.
+func calleeParamNameForArg(call *ast.CallExpr, callee *ast.FuncDecl, base string) (string, bool) {
+	if callee.Type == nil {
+		return "", false
+	}
+
+	argIndex := -1
+	for i, arg := range call.Args {
+		if common.GetVarName(arg) == base {
+			argIndex = i
+			break
+		}
+	}
+	if argIndex < 0 {
+		return "", false
+	}
+
+	names := flattenParamNames(callee.Type.Params)
+	if argIndex >= len(names) || names[argIndex] == "" {
+		return "", false
+	}
+	return names[argIndex], true
+}
+
+// flattenParamNames returns one entry per positional parameter, using "" for
+// unnamed or blank ("_") parameters so the slice index lines up with call args.
+func flattenParamNames(params *ast.FieldList) []string {
+	if params == nil {
+		return nil
+	}
+
+	var names []string
+	for _, field := range params.List {
+		if len(field.Names) == 0 {
+			names = append(names, "")
+			continue
+		}
+		for _, name := range field.Names {
+			if name == nil || name.Name == "_" {
+				names = append(names, "")
+				continue
+			}
+			names = append(names, name.Name)
+		}
+	}
+	return names
 }
 
 // removeFirstLockPos removes the first lock position from the list

--- a/pkg/analyzer/internal/mutex/branches.go
+++ b/pkg/analyzer/internal/mutex/branches.go
@@ -187,12 +187,14 @@ func (c *Checker) sameBranchState(a, b *Stats) bool {
 		return a == b
 	}
 
-	return a.lock == b.lock &&
-		a.rlock == b.rlock &&
+	// Compare the net outstanding lock count rather than the raw lock and
+	// deferUnlock fields. Two branches that both leave the lock released by
+	// function exit are equivalent even when one releases directly and the
+	// other defers it (lock=1,deferUnlock=1 vs lock=0,deferUnlock=0).
+	return remainingLockCount(a.lock, a.deferUnlock) == remainingLockCount(b.lock, b.deferUnlock) &&
+		remainingLockCount(a.rlock, a.deferRUnlock) == remainingLockCount(b.rlock, b.deferRUnlock) &&
 		a.borrowedLock == b.borrowedLock &&
-		a.borrowedRLock == b.borrowedRLock &&
-		a.deferUnlock == b.deferUnlock &&
-		a.deferRUnlock == b.deferRUnlock
+		a.borrowedRLock == b.borrowedRLock
 }
 
 // analyzeGoStatement handles goroutine statements

--- a/pkg/analyzer/internal/mutex/branches_test.go
+++ b/pkg/analyzer/internal/mutex/branches_test.go
@@ -1,0 +1,68 @@
+package mutex
+
+import "testing"
+
+// TestSameBranchState documents the merge invariant: two branch states are
+// equivalent when they leave the same NET outstanding lock counts, so a branch
+// that defers its release (lock=1, deferUnlock=1) matches a sibling that releases
+// directly (lock=0). Borrowed counts must still match exactly.
+func TestSameBranchState(t *testing.T) {
+	c := &Checker{}
+
+	tests := []struct {
+		name string
+		a, b *Stats
+		want bool
+	}{
+		{
+			name: "deferred release equals direct release (same net write lock)",
+			a:    &Stats{lock: 1, deferUnlock: 1},
+			b:    &Stats{},
+			want: true,
+		},
+		{
+			name: "different net write-lock counts differ",
+			a:    &Stats{lock: 1},
+			b:    &Stats{},
+			want: false,
+		},
+		{
+			name: "deferred read release equals direct read release",
+			a:    &Stats{rlock: 1, deferRUnlock: 1},
+			b:    &Stats{},
+			want: true,
+		},
+		{
+			name: "borrowed write unlock must match exactly",
+			a:    &Stats{borrowedLock: 1},
+			b:    &Stats{},
+			want: false,
+		},
+		{
+			name: "borrowed read unlock must match exactly",
+			a:    &Stats{borrowedRLock: 1},
+			b:    &Stats{},
+			want: false,
+		},
+		{
+			name: "both nil are equal",
+			a:    nil,
+			b:    nil,
+			want: true,
+		},
+		{
+			name: "nil and non-nil differ",
+			a:    nil,
+			b:    &Stats{},
+			want: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := c.sameBranchState(tc.a, tc.b); got != tc.want {
+				t.Errorf("sameBranchState(%+v, %+v) = %v, want %v", tc.a, tc.b, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/analyzer/internal/mutex/defer.go
+++ b/pkg/analyzer/internal/mutex/defer.go
@@ -133,6 +133,9 @@ func (c *Checker) handleDeferFunctionLiteral(fnlit *ast.FuncLit, pos token.Pos, 
 	// Check for mutex unlocks in function literal
 	for mutexName := range c.mutexNames {
 		if guard.containsUnlock(fnlit.Body, mutexName) && !guard.containsLock(fnlit.Body, mutexName) {
+			if c.flagGuardedMutexes[mutexName] {
+				continue
+			}
 			if stats[mutexName].lock == 0 && guard.unlocksOnlyInRecoverGuard(fnlit.Body, mutexName, "Unlock") {
 				continue
 			}
@@ -143,6 +146,9 @@ func (c *Checker) handleDeferFunctionLiteral(fnlit *ast.FuncLit, pos token.Pos, 
 	// Check for rwmutex unlocks in function literal
 	for rwMutexName := range c.rwMutexNames {
 		if guard.containsUnlock(fnlit.Body, rwMutexName) && !guard.containsLock(fnlit.Body, rwMutexName) {
+			if c.flagGuardedMutexes[rwMutexName] {
+				continue
+			}
 			if stats[rwMutexName].lock == 0 && guard.unlocksOnlyInRecoverGuard(fnlit.Body, rwMutexName, "Unlock") {
 				continue
 			}

--- a/pkg/analyzer/internal/mutex/flagguard.go
+++ b/pkg/analyzer/internal/mutex/flagguard.go
@@ -1,0 +1,189 @@
+package mutex
+
+import (
+	"go/ast"
+
+	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/internal/common"
+)
+
+// detectFlagGuardedReleases returns the set of mutex/rwmutex names whose lock is
+// released by a deferred, flag-guarded unlock. The pattern is:
+//
+//	held := false
+//	defer func() { if held { mu.Unlock() } }()
+//	...
+//	mu.Lock()
+//	held = true
+//
+// The deferred closure unlocks exactly when a lock was taken, so each acquisition
+// is balanced by the deferred release.
+//
+// To stay sound, a mutex only qualifies when every Lock is immediately followed
+// by `flag = true`: a Lock that does not set the flag is not covered by the
+// deferred release and must still be reported.
+func (c *Checker) detectFlagGuardedReleases(fn *ast.FuncDecl) map[string]bool {
+	if fn == nil || fn.Body == nil {
+		return nil
+	}
+
+	var result map[string]bool
+	consider := func(names map[string]bool) {
+		for name := range names {
+			flag, ok := deferredFlagGuardedUnlock(fn.Body, name, "Unlock")
+			if !ok || !everyLockPairsWithSetFlag(fn.Body, name, "Lock", flag) {
+				continue
+			}
+			if result == nil {
+				result = make(map[string]bool)
+			}
+			result[name] = true
+		}
+	}
+
+	consider(c.mutexNames)
+	consider(c.rwMutexNames)
+	return result
+}
+
+// deferredFlagGuardedUnlock finds a deferred closure in body whose unlocks of
+// mutexName (via unlockMethod) all sit inside a single `if <flag> { ... }`, and
+// returns the guard flag name.
+func deferredFlagGuardedUnlock(body *ast.BlockStmt, mutexName, unlockMethod string) (string, bool) {
+	for _, stmt := range body.List {
+		deferStmt, ok := stmt.(*ast.DeferStmt)
+		if !ok {
+			continue
+		}
+		fnlit, ok := deferStmt.Call.Fun.(*ast.FuncLit)
+		if !ok || fnlit.Body == nil {
+			continue
+		}
+
+		total := countMutexMethodCalls(fnlit.Body, mutexName, unlockMethod)
+		if total == 0 {
+			continue
+		}
+
+		for _, inner := range fnlit.Body.List {
+			ifStmt, ok := inner.(*ast.IfStmt)
+			if !ok || ifStmt.Init != nil {
+				continue
+			}
+			flagIdent, ok := ifStmt.Cond.(*ast.Ident)
+			if !ok {
+				continue
+			}
+			// Every unlock in the closure must be under this single flag guard.
+			if countMutexMethodCalls(ifStmt.Body, mutexName, unlockMethod) == total {
+				return flagIdent.Name, true
+			}
+		}
+	}
+	return "", false
+}
+
+// everyLockPairsWithSetFlag reports whether body contains at least one
+// `mutexName.lockMethod()` and every such call is immediately followed by
+// `flag = true` in the same statement list. Function literals, deferred calls and
+// goroutines run in a different frame and are not traversed.
+func everyLockPairsWithSetFlag(body *ast.BlockStmt, mutexName, lockMethod, flag string) bool {
+	foundLock := false
+	paired := true
+
+	var visit func(stmts []ast.Stmt)
+	visit = func(stmts []ast.Stmt) {
+		for i, stmt := range stmts {
+			if isMutexMethodCallStmt(stmt, mutexName, lockMethod) {
+				foundLock = true
+				if i+1 >= len(stmts) || !isAssignTrue(stmts[i+1], flag) {
+					paired = false
+				}
+				continue
+			}
+
+			switch s := stmt.(type) {
+			case *ast.BlockStmt:
+				visit(s.List)
+			case *ast.IfStmt:
+				if s.Body != nil {
+					visit(s.Body.List)
+				}
+				if s.Else != nil {
+					visit([]ast.Stmt{s.Else})
+				}
+			case *ast.ForStmt:
+				if s.Body != nil {
+					visit(s.Body.List)
+				}
+			case *ast.RangeStmt:
+				if s.Body != nil {
+					visit(s.Body.List)
+				}
+			case *ast.SwitchStmt:
+				if s.Body != nil {
+					visit(s.Body.List)
+				}
+			case *ast.TypeSwitchStmt:
+				if s.Body != nil {
+					visit(s.Body.List)
+				}
+			case *ast.SelectStmt:
+				if s.Body != nil {
+					visit(s.Body.List)
+				}
+			case *ast.CaseClause:
+				visit(s.Body)
+			case *ast.CommClause:
+				visit(s.Body)
+			case *ast.LabeledStmt:
+				visit([]ast.Stmt{s.Stmt})
+			}
+		}
+	}
+
+	visit(body.List)
+	return foundLock && paired
+}
+
+func countMutexMethodCalls(block *ast.BlockStmt, mutexName, method string) int {
+	count := 0
+	ast.Inspect(block, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		if sel, ok := call.Fun.(*ast.SelectorExpr); ok &&
+			sel.Sel.Name == method && common.GetVarName(sel.X) == mutexName {
+			count++
+		}
+		return true
+	})
+	return count
+}
+
+func isMutexMethodCallStmt(stmt ast.Stmt, mutexName, method string) bool {
+	exprStmt, ok := stmt.(*ast.ExprStmt)
+	if !ok {
+		return false
+	}
+	call, ok := exprStmt.X.(*ast.CallExpr)
+	if !ok {
+		return false
+	}
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	return ok && sel.Sel.Name == method && common.GetVarName(sel.X) == mutexName
+}
+
+// isAssignTrue reports whether stmt assigns the boolean literal true to flag.
+func isAssignTrue(stmt ast.Stmt, flag string) bool {
+	assign, ok := stmt.(*ast.AssignStmt)
+	if !ok || len(assign.Lhs) != 1 || len(assign.Rhs) != 1 {
+		return false
+	}
+	lhs, ok := assign.Lhs[0].(*ast.Ident)
+	if !ok || lhs.Name != flag {
+		return false
+	}
+	rhs, ok := assign.Rhs[0].(*ast.Ident)
+	return ok && rhs.Name == "true"
+}

--- a/pkg/analyzer/internal/mutex/flagguard_test.go
+++ b/pkg/analyzer/internal/mutex/flagguard_test.go
@@ -1,0 +1,451 @@
+package mutex
+
+import (
+	"go/ast"
+	"testing"
+)
+
+// flagGuardFuncDecl parses src with the typed lifecycle helper and returns the
+// top-level function named name, ready to feed to detectFlagGuardedReleases.
+func flagGuardFuncDecl(t *testing.T, src, name string) *ast.FuncDecl {
+	t.Helper()
+	file, _ := parseTypedLifecycleFile(t, src)
+	for _, decl := range file.Decls {
+		if fn, ok := decl.(*ast.FuncDecl); ok && fn.Name.Name == name {
+			return fn
+		}
+	}
+	t.Fatalf("function %q not found", name)
+	return nil
+}
+
+// firstStmt parses src and returns the first statement in f's body. It lets the
+// single-statement helper tests feed a real ast.Stmt to the predicate.
+func firstStmt(t *testing.T, src string) ast.Stmt {
+	t.Helper()
+	file, _ := parseTypedLifecycleFile(t, src)
+	body := funcBody(t, file, "f")
+	if len(body.List) == 0 {
+		t.Fatal("function body is empty")
+	}
+	return body.List[0]
+}
+
+// TestDetectFlagGuardedReleases drives the whole detector end-to-end: it wires a
+// minimal Checker (only the name sets are consulted) and asserts which mutexes
+// are recognised as flag-guarded releases.
+func TestDetectFlagGuardedReleases(t *testing.T) {
+	tests := []struct {
+		name    string
+		src     string
+		mutex   map[string]bool
+		rwMutex map[string]bool
+		varName string
+		want    bool
+	}{
+		{
+			// held := false; defer func(){ if held { mu.Unlock() } }();
+			// if c { mu.Lock(); held = true } — the canonical pattern.
+			name:    "flag-guarded release qualifies",
+			varName: "mu",
+			mutex:   map[string]bool{"mu": true},
+			want:    true,
+			src: `package p
+import "sync"
+func f(c bool) {
+	var mu sync.Mutex
+	held := false
+	defer func() {
+		if held {
+			mu.Unlock()
+		}
+	}()
+	if c {
+		mu.Lock()
+		held = true
+	}
+}`,
+		},
+		{
+			// The Lock is not followed by held = true, so the deferred release does
+			// not cover it: reporting must stay on. This is the false-negative guard.
+			name:    "lock without set-flag does not qualify",
+			varName: "mu",
+			mutex:   map[string]bool{"mu": true},
+			want:    false,
+			src: `package p
+import "sync"
+func f(c bool) {
+	var mu sync.Mutex
+	held := false
+	defer func() {
+		if held {
+			mu.Unlock()
+		}
+	}()
+	if c {
+		mu.Lock()
+	}
+}`,
+		},
+		{
+			// The deferred closure unlocks unconditionally — there is no flag guard,
+			// so the acquire cannot borrow a guarded release.
+			name:    "unguarded unlock in defer does not qualify",
+			varName: "mu",
+			mutex:   map[string]bool{"mu": true},
+			want:    false,
+			src: `package p
+import "sync"
+func f(c bool) {
+	var mu sync.Mutex
+	defer func() {
+		mu.Unlock()
+	}()
+	if c {
+		mu.Lock()
+	}
+}`,
+		},
+		{
+			// No deferred closure at all: nothing to pair the acquisition with.
+			name:    "no deferred closure does not qualify",
+			varName: "mu",
+			mutex:   map[string]bool{"mu": true},
+			want:    false,
+			src: `package p
+import "sync"
+func f(c bool) {
+	var mu sync.Mutex
+	if c {
+		mu.Lock()
+		mu.Unlock()
+	}
+}`,
+		},
+		{
+			// The rwMutexNames set is consulted as well: an RWMutex driven through
+			// the write Lock/Unlock pair qualifies via the same shape.
+			name:    "rwmutex write lock qualifies via rwMutexNames",
+			varName: "rw",
+			rwMutex: map[string]bool{"rw": true},
+			want:    true,
+			src: `package p
+import "sync"
+func f(c bool) {
+	var rw sync.RWMutex
+	held := false
+	defer func() {
+		if held {
+			rw.Unlock()
+		}
+	}()
+	if c {
+		rw.Lock()
+		held = true
+	}
+}`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fn := flagGuardFuncDecl(t, tc.src, "f")
+			c := &Checker{mutexNames: tc.mutex, rwMutexNames: tc.rwMutex}
+
+			got := c.detectFlagGuardedReleases(fn)
+			if got[tc.varName] != tc.want {
+				t.Errorf("detectFlagGuardedReleases()[%q] = %v, want %v", tc.varName, got[tc.varName], tc.want)
+			}
+		})
+	}
+}
+
+func TestDetectFlagGuardedReleases_NilFunc(t *testing.T) {
+	c := &Checker{mutexNames: map[string]bool{"mu": true}}
+	if got := c.detectFlagGuardedReleases(nil); got != nil {
+		t.Errorf("detectFlagGuardedReleases(nil) = %v, want nil", got)
+	}
+}
+
+// TestDeferredFlagGuardedUnlock isolates the closure scan: it must report the
+// guard flag only when every unlock in a deferred closure sits under one
+// `if <flag>` guard.
+func TestDeferredFlagGuardedUnlock(t *testing.T) {
+	tests := []struct {
+		name     string
+		src      string
+		wantFlag string
+		wantOK   bool
+	}{
+		{
+			name:     "guarded unlock returns flag",
+			wantFlag: "held",
+			wantOK:   true,
+			src: `package p
+import "sync"
+func f() {
+	var mu sync.Mutex
+	held := false
+	defer func() {
+		if held {
+			mu.Unlock()
+		}
+	}()
+}`,
+		},
+		{
+			name:     "unconditional unlock is not guarded",
+			wantFlag: "",
+			wantOK:   false,
+			src: `package p
+import "sync"
+func f() {
+	var mu sync.Mutex
+	defer func() {
+		mu.Unlock()
+	}()
+}`,
+		},
+		{
+			// Two unlocks but only one under the guard: the closure is not fully
+			// covered, so it must not qualify.
+			name:     "partially guarded unlocks do not qualify",
+			wantFlag: "",
+			wantOK:   false,
+			src: `package p
+import "sync"
+func f() {
+	var mu sync.Mutex
+	held := false
+	defer func() {
+		mu.Unlock()
+		if held {
+			mu.Unlock()
+		}
+	}()
+}`,
+		},
+		{
+			name:     "no deferred closure",
+			wantFlag: "",
+			wantOK:   false,
+			src: `package p
+import "sync"
+func f() {
+	var mu sync.Mutex
+	mu.Lock()
+	mu.Unlock()
+}`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			file, _ := parseTypedLifecycleFile(t, tc.src)
+			body := funcBody(t, file, "f")
+
+			flag, ok := deferredFlagGuardedUnlock(body, "mu", "Unlock")
+			if flag != tc.wantFlag || ok != tc.wantOK {
+				t.Errorf("deferredFlagGuardedUnlock() = (%q, %v), want (%q, %v)", flag, ok, tc.wantFlag, tc.wantOK)
+			}
+		})
+	}
+}
+
+// TestEveryLockPairsWithSetFlag checks the acquire-site rule: there must be at
+// least one Lock and every Lock must be immediately followed by `flag = true`.
+func TestEveryLockPairsWithSetFlag(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want bool
+	}{
+		{
+			name: "lock immediately sets flag",
+			want: true,
+			src: `package p
+import "sync"
+func f(held bool) {
+	var mu sync.Mutex
+	mu.Lock()
+	held = true
+}`,
+		},
+		{
+			name: "lock without following flag",
+			want: false,
+			src: `package p
+import "sync"
+func f() {
+	var mu sync.Mutex
+	mu.Lock()
+}`,
+		},
+		{
+			// The Lock sits inside an if; visit recurses into nested blocks and
+			// still finds the paired flag assignment.
+			name: "lock nested in if still pairs",
+			want: true,
+			src: `package p
+import "sync"
+func f(c bool, held bool) {
+	var mu sync.Mutex
+	if c {
+		mu.Lock()
+		held = true
+	}
+}`,
+		},
+		{
+			// No Lock at all: foundLock stays false, so the body never qualifies
+			// even though a flag is set.
+			name: "no lock returns false",
+			want: false,
+			src: `package p
+import "sync"
+func f(held bool) {
+	var mu sync.Mutex
+	mu.Unlock()
+	held = true
+}`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			file, _ := parseTypedLifecycleFile(t, tc.src)
+			body := funcBody(t, file, "f")
+
+			if got := everyLockPairsWithSetFlag(body, "mu", "Lock", "held"); got != tc.want {
+				t.Errorf("everyLockPairsWithSetFlag() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsAssignTrue(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		flag string
+		want bool
+	}{
+		{
+			name: "assigns true to flag",
+			flag: "held",
+			want: true,
+			src:  "package p\nfunc f(held bool, other bool) { held = true }",
+		},
+		{
+			name: "assigns false to flag",
+			flag: "held",
+			want: false,
+			src:  "package p\nfunc f(held bool, other bool) { held = false }",
+		},
+		{
+			name: "assigns true to a different name",
+			flag: "held",
+			want: false,
+			src:  "package p\nfunc f(held bool, other bool) { other = true }",
+		},
+		{
+			name: "multi-assignment is rejected",
+			flag: "held",
+			want: false,
+			src:  "package p\nfunc f(held bool, other bool) { held, other = true, false }",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isAssignTrue(firstStmt(t, tc.src), tc.flag); got != tc.want {
+				t.Errorf("isAssignTrue() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsMutexMethodCallStmt(t *testing.T) {
+	tests := []struct {
+		name   string
+		src    string
+		mutex  string
+		method string
+		want   bool
+	}{
+		{
+			name:   "matching receiver and method",
+			mutex:  "mu",
+			method: "Lock",
+			want:   true,
+			src:    "package p\nimport \"sync\"\nfunc f(mu *sync.Mutex) { mu.Lock() }",
+		},
+		{
+			name:   "wrong method",
+			mutex:  "mu",
+			method: "Lock",
+			want:   false,
+			src:    "package p\nimport \"sync\"\nfunc f(mu *sync.Mutex) { mu.Unlock() }",
+		},
+		{
+			name:   "wrong receiver",
+			mutex:  "mu",
+			method: "Lock",
+			want:   false,
+			src:    "package p\nimport \"sync\"\nfunc f(other *sync.Mutex) { other.Lock() }",
+		},
+		{
+			name:   "not a call statement",
+			mutex:  "mu",
+			method: "Lock",
+			want:   false,
+			src:    "package p\nfunc f() { x := 1; _ = x }",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isMutexMethodCallStmt(firstStmt(t, tc.src), tc.mutex, tc.method); got != tc.want {
+				t.Errorf("isMutexMethodCallStmt() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestCountMutexMethodCalls confirms the count walks nested blocks (via
+// ast.Inspect) and only matches the requested receiver and method.
+func TestCountMutexMethodCalls(t *testing.T) {
+	src := `package p
+import "sync"
+func f(c bool) {
+	var mu sync.Mutex
+	mu.Unlock()
+	mu.Unlock()
+	if c {
+		mu.Unlock()
+	}
+}`
+
+	tests := []struct {
+		name   string
+		mutex  string
+		method string
+		want   int
+	}{
+		{name: "counts all calls including nested", mutex: "mu", method: "Unlock", want: 3},
+		{name: "wrong method counts zero", mutex: "mu", method: "Lock", want: 0},
+		{name: "unknown receiver counts zero", mutex: "other", method: "Unlock", want: 0},
+	}
+
+	file, _ := parseTypedLifecycleFile(t, src)
+	body := funcBody(t, file, "f")
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := countMutexMethodCalls(body, tc.mutex, tc.method); got != tc.want {
+				t.Errorf("countMutexMethodCalls() = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/analyzer/internal/mutex/funcanalysis.go
+++ b/pkg/analyzer/internal/mutex/funcanalysis.go
@@ -21,6 +21,10 @@ type funcAnalysis struct {
 	labelGotoSnapshots     map[string]map[string]*Stats
 	simulationStack        map[methodSimulationKey]bool
 	localFuncStack         map[*ast.FuncLit]bool
+
+	// flagGuardedMutexes holds mutexes released by a deferred, flag-guarded unlock
+	// (see detectFlagGuardedReleases). Populated once per real function.
+	flagGuardedMutexes map[string]bool
 }
 
 func newFuncAnalysis(fn *ast.FuncDecl) *funcAnalysis {

--- a/pkg/analyzer/internal/mutex/lockstate.go
+++ b/pkg/analyzer/internal/mutex/lockstate.go
@@ -25,6 +25,10 @@ func (c *Checker) analyzeExpressionStatement(stmt *ast.ExprStmt, stats map[strin
 		return
 	}
 
+	if c.applyLocalFunctionCallLifecycleEffects(call, stats) {
+		return
+	}
+
 	sel, ok := call.Fun.(*ast.SelectorExpr)
 	if !ok {
 		return
@@ -88,6 +92,7 @@ func (c *Checker) handleMutexCall(varName, methodName string, pos token.Pos, sta
 		}
 		stats[varName].lock++
 		stats[varName].lockPos = append(stats[varName].lockPos, pos)
+		c.creditFlagGuardedRelease(varName, stats)
 	case "TryLock":
 		if stats[varName].borrowedLock > 0 {
 			stats[varName].borrowedLock--
@@ -110,6 +115,16 @@ func (c *Checker) handleMutexCall(varName, methodName string, pos token.Pos, sta
 	}
 }
 
+// creditFlagGuardedRelease records a deferred-unlock credit for a lock whose
+// release is delegated to a deferred, flag-guarded unlock (see
+// detectFlagGuardedReleases): the acquisition is balanced like
+// `mu.Lock(); defer mu.Unlock()`.
+func (c *Checker) creditFlagGuardedRelease(varName string, stats map[string]*Stats) {
+	if c.flagGuardedMutexes[varName] {
+		stats[varName].deferUnlock++
+	}
+}
+
 // handleRWMutexCall processes rwmutex method calls
 func (c *Checker) handleRWMutexCall(varName, methodName string, pos token.Pos, stats map[string]*Stats) {
 	if c.wrapper.resolve(varName, methodName) {
@@ -128,6 +143,7 @@ func (c *Checker) handleRWMutexCall(varName, methodName string, pos token.Pos, s
 		}
 		stats[varName].lock++
 		stats[varName].lockPos = append(stats[varName].lockPos, pos)
+		c.creditFlagGuardedRelease(varName, stats)
 	case "TryLock":
 		if stats[varName].borrowedLock > 0 {
 			stats[varName].borrowedLock--

--- a/pkg/analyzer/internal/mutex/loopdecl.go
+++ b/pkg/analyzer/internal/mutex/loopdecl.go
@@ -44,35 +44,27 @@ func (d *loopMutexDetector) check(loopBody *ast.BlockStmt) {
 				if !ok {
 					continue
 				}
-				d.reportValueSpec(vs)
+				d.reportValueSpec(vs, loopBody)
 			}
 		case *ast.AssignStmt:
 			if s.Tok == token.DEFINE {
-				d.reportAssign(s)
+				d.reportAssign(s, loopBody)
 			}
 		}
 	}
 }
 
-func (d *loopMutexDetector) reportValueSpec(vs *ast.ValueSpec) {
+func (d *loopMutexDetector) reportValueSpec(vs *ast.ValueSpec, loopBody *ast.BlockStmt) {
 	for _, name := range vs.Names {
 		obj := d.typesInfo.Defs[name]
 		if obj == nil {
 			continue
 		}
-		typ := obj.Type()
-		switch {
-		case common.IsMutex(typ):
-			d.reporter.AddError(name.Pos(),
-				category.MutexInLoop, "mutex '"+name.Name+"' declared inside loop, each iteration creates a new mutex that cannot protect shared state")
-		case common.IsRWMutex(typ):
-			d.reporter.AddError(name.Pos(),
-				category.MutexInLoop, "rwmutex '"+name.Name+"' declared inside loop, each iteration creates a new mutex that cannot protect shared state")
-		}
+		d.reportMutexDecl(obj.Type(), name.Name, name.Pos(), loopBody)
 	}
 }
 
-func (d *loopMutexDetector) reportAssign(s *ast.AssignStmt) {
+func (d *loopMutexDetector) reportAssign(s *ast.AssignStmt, loopBody *ast.BlockStmt) {
 	for i, lhs := range s.Lhs {
 		ident, ok := lhs.(*ast.Ident)
 		if !ok || i >= len(s.Rhs) {
@@ -82,14 +74,78 @@ func (d *loopMutexDetector) reportAssign(s *ast.AssignStmt) {
 		if typ == nil {
 			continue
 		}
-		typ = common.DerefOnceAndUnalias(typ)
-		switch {
-		case common.IsMutex(typ):
-			d.reporter.AddError(ident.Pos(),
-				category.MutexInLoop, "mutex '"+ident.Name+"' declared inside loop, each iteration creates a new mutex that cannot protect shared state")
-		case common.IsRWMutex(typ):
-			d.reporter.AddError(ident.Pos(),
-				category.MutexInLoop, "rwmutex '"+ident.Name+"' declared inside loop, each iteration creates a new mutex that cannot protect shared state")
-		}
+		d.reportMutexDecl(common.DerefOnceAndUnalias(typ), ident.Name, ident.Pos(), loopBody)
 	}
+}
+
+// reportMutexDecl flags a mutex/rwmutex declared inside a loop, unless the mutex
+// is shared with per-iteration goroutines that are joined before the iteration
+// ends, in which case a fresh mutex per iteration is intentional.
+func (d *loopMutexDetector) reportMutexDecl(typ types.Type, name string, pos token.Pos, loopBody *ast.BlockStmt) {
+	isMutex := common.IsMutex(typ)
+	isRWMutex := common.IsRWMutex(typ)
+	if !isMutex && !isRWMutex {
+		return
+	}
+
+	if mutexProtectsJoinedWorkers(loopBody, name) {
+		return
+	}
+
+	mutexType := "mutex"
+	if isRWMutex {
+		mutexType = "rwmutex"
+	}
+	d.reporter.AddError(pos, category.MutexInLoop,
+		mutexType+" '"+name+"' declared inside loop, each iteration creates a new mutex that cannot protect shared state")
+}
+
+// mutexProtectsJoinedWorkers reports whether the loop-declared mutex is captured
+// by a goroutine in the same iteration that is then joined (a `.Wait()` call), so
+// the workers cannot outlive the iteration.
+func mutexProtectsJoinedWorkers(loopBody *ast.BlockStmt, varName string) bool {
+	return blockContainsWaitCall(loopBody) && goroutineCapturesVar(loopBody, varName)
+}
+
+// blockContainsWaitCall reports whether block contains a `.Wait()` call
+// (sync.WaitGroup, errgroup.Group, etc.).
+func blockContainsWaitCall(block *ast.BlockStmt) bool {
+	found := false
+	ast.Inspect(block, func(n ast.Node) bool {
+		if found {
+			return false
+		}
+		if call, ok := n.(*ast.CallExpr); ok {
+			if sel, ok := call.Fun.(*ast.SelectorExpr); ok && sel.Sel.Name == "Wait" {
+				found = true
+				return false
+			}
+		}
+		return true
+	})
+	return found
+}
+
+// goroutineCapturesVar reports whether block launches a goroutine whose call
+// references varName.
+func goroutineCapturesVar(block *ast.BlockStmt, varName string) bool {
+	found := false
+	ast.Inspect(block, func(n ast.Node) bool {
+		if found {
+			return false
+		}
+		goStmt, ok := n.(*ast.GoStmt)
+		if !ok {
+			return true
+		}
+		ast.Inspect(goStmt.Call, func(inner ast.Node) bool {
+			if ident, ok := inner.(*ast.Ident); ok && ident.Name == varName {
+				found = true
+				return false
+			}
+			return true
+		})
+		return !found
+	})
+	return found
 }

--- a/pkg/analyzer/internal/mutex/loopdecl_test.go
+++ b/pkg/analyzer/internal/mutex/loopdecl_test.go
@@ -167,3 +167,87 @@ func f() {
 		t.Fatalf("expected 0 diagnostics for non-mutex decl, got %d", len(rep.calls))
 	}
 }
+
+// TestMutexProtectsJoinedWorkers covers the per-iteration-mutex suppression: a
+// mutex declared in a loop is legitimate (not flagged) only when it is captured
+// by a goroutine in the same iteration AND that iteration joins (a `.Wait()`),
+// so the workers cannot outlive the iteration.
+func TestMutexProtectsJoinedWorkers(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want bool
+	}{
+		{
+			name: "goroutine uses mutex and iteration joins",
+			want: true,
+			src: `package p
+import "sync"
+func f(items []int) {
+	for range items {
+		var mu sync.Mutex
+		var wg sync.WaitGroup
+		for i := 0; i < 2; i++ {
+			wg.Add(1)
+			go func() { defer wg.Done(); mu.Lock(); mu.Unlock() }()
+		}
+		wg.Wait()
+	}
+}`,
+		},
+		{
+			name: "goroutine uses mutex but no join",
+			want: false,
+			src: `package p
+import "sync"
+func f(items []int) {
+	for range items {
+		var mu sync.Mutex
+		go func() { mu.Lock(); mu.Unlock() }()
+	}
+}`,
+		},
+		{
+			name: "join present but goroutine does not use the mutex",
+			want: false,
+			src: `package p
+import "sync"
+func f(items []int) {
+	for range items {
+		var mu sync.Mutex
+		var wg sync.WaitGroup
+		_ = mu
+		go func() { defer wg.Done() }()
+		wg.Wait()
+	}
+}`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			file, _ := parseFile(t, tc.src)
+
+			var body *ast.BlockStmt
+			ast.Inspect(file, func(n ast.Node) bool {
+				if body != nil {
+					return false
+				}
+				switch loop := n.(type) {
+				case *ast.RangeStmt:
+					body = loop.Body
+				case *ast.ForStmt:
+					body = loop.Body
+				}
+				return body == nil
+			})
+			if body == nil {
+				t.Fatal("no loop body found")
+			}
+
+			if got := mutexProtectsJoinedWorkers(body, "mu"); got != tc.want {
+				t.Errorf("mutexProtectsJoinedWorkers() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/analyzer/internal/mutex/wrapper.go
+++ b/pkg/analyzer/internal/mutex/wrapper.go
@@ -54,6 +54,12 @@ func (w *wrapperResolver) resolve(varName, methodName string) bool {
 		return false
 	}
 
+	// A single-statement Lock/Unlock split across sibling methods is an
+	// intentional cross-method barrier, not a leak.
+	if w.isBarrierPairHalf(varName, methodName, oppositeMethods) {
+		return true
+	}
+
 	if _, fieldSuffix, ok := splitBaseAndSuffix(varName); ok &&
 		methodNameLooksLikeWrapper(w.function.Name.Name, methodName) &&
 		w.anySiblingMethodContainsFieldSuffix(fieldSuffix, w.function.Name.Name, oppositeMethods, oppositeMethods) {
@@ -173,6 +179,67 @@ func (w *wrapperResolver) anySiblingMethodContainsFieldSuffix(fieldSuffix, exclu
 
 func methodNameLooksLikeWrapper(fnName, syncMethod string) bool {
 	return methodNameMatchesAnyHint(fnName, []string{syncMethod})
+}
+
+// isBarrierPairHalf reports whether the current method consists of exactly one
+// mutex call on a field, balanced by a sibling method consisting of exactly one
+// matching opposite call on the same field. Both halves being single statements
+// is the signal that the split across methods is an intentional barrier/latch
+// rather than a forgotten unlock, so it holds regardless of the method names.
+func (w *wrapperResolver) isBarrierPairHalf(varName, methodName string, oppositeMethods []string) bool {
+	_, fieldSuffix, ok := splitBaseAndSuffix(varName)
+	if !ok {
+		return false
+	}
+	if !bodyIsSingleFieldSuffixCall(w.function.Body, fieldSuffix, []string{methodName}) {
+		return false
+	}
+	return w.anySiblingBodyIsSingleFieldSuffixCall(fieldSuffix, w.function.Name.Name, oppositeMethods)
+}
+
+func (w *wrapperResolver) anySiblingBodyIsSingleFieldSuffixCall(fieldSuffix, excludeMethod string, methodNames []string) bool {
+	receiverType := receiverTypeName(w.function)
+	if receiverType == "" {
+		return false
+	}
+
+	for methodName, fn := range w.receiverMethods[receiverType] {
+		if methodName == excludeMethod || fn == nil {
+			continue
+		}
+		if bodyIsSingleFieldSuffixCall(fn.Body, fieldSuffix, methodNames) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// bodyIsSingleFieldSuffixCall reports whether body is exactly one expression
+// statement calling one of methodNames on a field whose suffix equals
+// fieldSuffix (e.g. body `{ b.lock.Unlock() }` with suffix "lock").
+func bodyIsSingleFieldSuffixCall(body *ast.BlockStmt, fieldSuffix string, methodNames []string) bool {
+	if body == nil || len(body.List) != 1 {
+		return false
+	}
+
+	exprStmt, ok := body.List[0].(*ast.ExprStmt)
+	if !ok {
+		return false
+	}
+
+	call, ok := exprStmt.X.(*ast.CallExpr)
+	if !ok {
+		return false
+	}
+
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok || !containsMethod(methodNames, sel.Sel.Name) {
+		return false
+	}
+
+	_, suffix, ok := splitBaseAndSuffix(common.GetVarName(sel.X))
+	return ok && suffix == fieldSuffix
 }
 
 func functionBodyContainsFieldSuffixCall(body *ast.BlockStmt, fieldSuffix string, methodNames []string) bool {

--- a/pkg/analyzer/internal/mutex/wrapper_test.go
+++ b/pkg/analyzer/internal/mutex/wrapper_test.go
@@ -75,3 +75,51 @@ func (s *S) RUnlock() { s.mu.RUnlock() }`
 		t.Error("expected s.mu.RUnlock() to be recognized as a borrowed wrapper")
 	}
 }
+
+func TestWrapperResolver_CrossMethodBarrierByRole(t *testing.T) {
+	// Methods named by role rather than "Lock"/"Unlock", each a single statement:
+	// a write Lock balanced by a sibling write Unlock on the same field is an
+	// intentional barrier, recognized structurally without a name hint.
+	src := `package p
+import "sync"
+type B struct{ lock sync.RWMutex }
+func (b *B) Hold()    { b.lock.Lock() }
+func (b *B) Release() { b.lock.Unlock() }`
+
+	w := buildResolver(t, src, "B", "Hold", false)
+	if !w.resolve("b.lock", "Lock") {
+		t.Error("a single-statement Lock balanced by a single-statement Unlock sibling must be recognized as a barrier pair")
+	}
+}
+
+func TestWrapperResolver_BarrierRequiresSingleStatement(t *testing.T) {
+	// The Lock method does work besides locking, so it is not a pure barrier
+	// half; with role names and no opposite call inside, it stays unmatched.
+	src := `package p
+import "sync"
+type B struct{ lock sync.RWMutex }
+func (b *B) Hold()    { b.lock.Lock(); b.work() }
+func (b *B) Release() { b.lock.Unlock() }
+func (b *B) work()    {}`
+
+	w := buildResolver(t, src, "B", "Hold", false)
+	if w.resolve("b.lock", "Lock") {
+		t.Error("a multi-statement method must not be treated as a barrier half")
+	}
+}
+
+func TestWrapperResolver_BarrierNeedsOppositeSibling(t *testing.T) {
+	// RLock with no single-statement RUnlock sibling (the read side is never
+	// released): the lock is genuinely unmatched and must be reported.
+	src := `package p
+import "sync"
+type B struct{ lock sync.RWMutex }
+func (b *B) Hold()     { b.lock.Lock() }
+func (b *B) Release()  { b.lock.Unlock() }
+func (b *B) ReadHold() { b.lock.RLock() }`
+
+	w := buildResolver(t, src, "B", "ReadHold", false)
+	if w.resolve("b.lock", "RLock") {
+		t.Error("RLock without a matching RUnlock sibling must stay unmatched")
+	}
+}

--- a/pkg/analyzer/testdata/src/mutex/mutex_basic_cases.go
+++ b/pkg/analyzer/testdata/src/mutex/mutex_basic_cases.go
@@ -112,6 +112,28 @@ func GoodDeferUnlock() {
 	defer mu.Unlock()
 }
 
+type conditionalBufferedConn struct {
+	mu           sync.Mutex
+	buffered     bool
+	flushStarted bool
+}
+
+// Good: the lock is released immediately on the non-buffered path, and by the
+// deferred closure on the buffered path.
+func (c *conditionalBufferedConn) GoodConditionalDeferFunctionUnlock() {
+	c.mu.Lock()
+	if c.buffered {
+		defer func() {
+			c.flushStarted = true
+			c.mu.Unlock()
+		}()
+	} else {
+		c.mu.Unlock()
+	}
+
+	_ = c.flushStarted
+}
+
 // TryLock success branch owns the lock and may unlock it.
 func GoodTryLockUnlocksOnlyOnSuccess() {
 	var mu sync.Mutex

--- a/pkg/analyzer/testdata/src/mutex/mutex_extended_cases.go
+++ b/pkg/analyzer/testdata/src/mutex/mutex_extended_cases.go
@@ -168,6 +168,27 @@ func GoodMutexInFuncLiteralInsideLoop() {
 	}
 }
 
+func GoodPerIterationMutexProtectsPerIterationState(shards []int) {
+	for _, shard := range shards {
+		var mu sync.Mutex
+		var wg sync.WaitGroup
+		results := make([]int, 0, 2)
+
+		for i := 0; i < 2; i++ {
+			wg.Add(1)
+			go func(value int) {
+				defer wg.Done()
+				mu.Lock()
+				results = append(results, value)
+				mu.Unlock()
+			}(shard)
+		}
+
+		wg.Wait()
+		_ = results
+	}
+}
+
 // Bad: Lock with defer Unlock in a loop stacks defers until the function returns.
 func BadForLoopDeferUnlock() {
 	var mu sync.Mutex
@@ -945,6 +966,24 @@ func (h *HelperUnlockedState) GoodHelperReleasesCallerLockSync() {
 	h.releaseHelper()
 }
 
+type helperReleasedShard struct {
+	mu   sync.RWMutex
+	size int
+}
+
+func GoodHelperReleasesRWMutexField(shard *helperReleasedShard) {
+	shard.mu.Lock()
+	if shard.size > 10 {
+		releaseShardLock(shard)
+		return
+	}
+	shard.mu.Unlock()
+}
+
+func releaseShardLock(shard *helperReleasedShard) {
+	shard.mu.Unlock()
+}
+
 // Asynchronous release: `go h.releaseHelper()` runs the Unlock in a separate
 // goroutine that may not have started by the time the function returns, so
 // the caller exits while the lock is still held. Flag as locked-but-not-unlocked.
@@ -1383,6 +1422,29 @@ func GoodConditionalUnlockBeforePanic(isRecovering bool) {
 	}
 }
 
+type chunkedStream struct {
+	mu                sync.Mutex
+	chunkingEnabled   bool
+	accumulatedEnough bool
+}
+
+// Good: the deferred unlock is guarded by the same local flag that is set only
+// after the later lock acquisition succeeds.
+func (s *chunkedStream) GoodDeferredUnlockGuardedByHeldFlag() {
+	lockHeld := false
+	defer func() {
+		if lockHeld {
+			s.mu.Unlock()
+			lockHeld = false
+		}
+	}()
+
+	if s.chunkingEnabled && s.accumulatedEnough {
+		s.mu.Lock()
+		lockHeld = true
+	}
+}
+
 type goodCallerManagedStream struct {
 	mu sync.RWMutex
 }
@@ -1410,6 +1472,26 @@ func GoodCallerManagedByParameter(mu *sync.Mutex, needLock bool) error {
 		return err
 	}
 	return nil
+}
+
+type closeLockedEngine struct {
+	mu     sync.Mutex
+	isOpen bool
+}
+
+func (e *closeLockedEngine) GoodCloseTransfersUnlockToCloseLocked() {
+	e.mu.Lock()
+	if !e.isOpen {
+		e.mu.Unlock()
+		return
+	}
+
+	e.closeLocked()
+}
+
+func (e *closeLockedEngine) closeLocked() {
+	e.isOpen = false
+	e.mu.Unlock()
 }
 
 func decodeFP() error   { return nil }

--- a/pkg/analyzer/testdata/src/mutex/rwmutex_cases.go
+++ b/pkg/analyzer/testdata/src/mutex/rwmutex_cases.go
@@ -303,6 +303,38 @@ func GoodRWMutexCorrectWriteAPI() {
 	mu.Unlock()
 }
 
+type oneWayLatchPendingResult struct {
+	executing sync.RWMutex
+}
+
+func (r *oneWayLatchPendingResult) GoodCreateLocksUntilBroadcast() {
+	r.executing.Lock()
+}
+
+func (r *oneWayLatchPendingResult) GoodBroadcastUnlocksCreateLock() {
+	r.executing.Unlock()
+}
+
+func (r *oneWayLatchPendingResult) BadWaitUsesReadLockAsOneWayLatch() {
+	r.executing.RLock() // want "rwmutex 'r.executing' is rlocked but not runlocked"
+}
+
+type crossMethodBarrier struct {
+	lock sync.RWMutex
+}
+
+func (b *crossMethodBarrier) GoodCreateThreadsHoldsBarrier() {
+	b.lock.Lock()
+}
+
+func (b *crossMethodBarrier) GoodRunTestReleasesBarrier() {
+	b.lock.Unlock()
+}
+
+func (b *crossMethodBarrier) BadWorkerNeverReleasesReadBarrier() {
+	b.lock.RLock() // want "rwmutex 'b.lock' is rlocked but not runlocked"
+}
+
 // Double unlocks (runlock twice)
 func BadRWDoubleRUnlock() {
 	var mu sync.RWMutex

--- a/pkg/analyzer/testdata/src/waitgroup/waitgroup_extended_cases.go
+++ b/pkg/analyzer/testdata/src/waitgroup/waitgroup_extended_cases.go
@@ -121,6 +121,33 @@ func GoodReuseWaitGroup() {
 	wg.Wait()
 }
 
+type TwoPhaseBench struct {
+	wg      sync.WaitGroup
+	barrier sync.RWMutex
+	threads int
+}
+
+func (b *TwoPhaseBench) GoodTwoPhaseWaitGroupLifecycle() {
+	b.barrier.Lock()
+
+	for i := 0; i < b.threads; i++ {
+		b.wg.Add(1)
+		go b.clientLoop()
+	}
+
+	b.wg.Wait()
+	b.wg.Add(b.threads)
+	b.barrier.Unlock()
+	b.wg.Wait()
+}
+
+func (b *TwoPhaseBench) clientLoop() {
+	b.wg.Done()
+	b.barrier.RLock()
+	b.barrier.RUnlock()
+	b.wg.Done()
+}
+
 // ---------- Struct Member Patterns ----------
 
 type MyStruct struct {

--- a/pkg/analyzer/testdata/src/waitgroup/waitgroup_goroutine_cases.go
+++ b/pkg/analyzer/testdata/src/waitgroup/waitgroup_goroutine_cases.go
@@ -73,6 +73,47 @@ func GoodConstCountMatchesMultipleForLoopGoroutines() {
 	wg.Wait()
 }
 
+func GoodRangeLoopAddWithDeferredGoroutineDone(shardsByKeyspace map[string][]string) {
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+
+	mu.Lock()
+	for keyspace, shards := range shardsByKeyspace {
+		wg.Add(1)
+		go func(keyspace string, shards []string) {
+			defer wg.Done()
+
+			if len(shards) == 0 {
+				mu.Lock()
+				defer mu.Unlock()
+				shardsByKeyspace[keyspace] = []string{"0"}
+				return
+			}
+
+			mu.Lock()
+			defer mu.Unlock()
+			shardsByKeyspace[keyspace] = shards[:1]
+		}(keyspace, shards)
+	}
+	mu.Unlock()
+
+	wg.Wait()
+}
+
+func GoodAddLenThenLaunchRangeWorkers(trace []int) {
+	var wg sync.WaitGroup
+
+	wg.Add(len(trace))
+	for _, req := range trace {
+		go func(req int) {
+			defer wg.Done()
+			_ = req
+		}(req)
+	}
+
+	wg.Wait()
+}
+
 // Add inside a loop but Done may be missing in some paths
 func BadLoopAddMissingDone() {
 	var wg sync.WaitGroup
@@ -373,6 +414,28 @@ func BadConditionalDone() {
 			wg.Done()
 		}
 	}()
+	wg.Wait()
+}
+
+func BadConditionalEventDoneCanLeaveWaitHanging(events <-chan string) {
+	shards := []string{"-40", "40-80", "80-"}
+	seen := make(map[string]bool, len(shards))
+	var wg sync.WaitGroup
+
+	for _, shard := range shards {
+		seen[shard] = false
+		wg.Add(1) // want "waitgroup 'wg' has Add without corresponding Done"
+	}
+
+	go func() {
+		for shard := range events {
+			if !seen[shard] {
+				seen[shard] = true
+				wg.Done()
+			}
+		}
+	}()
+
 	wg.Wait()
 }
 


### PR DESCRIPTION
- Introduced flagGuardFuncDecl and firstStmt functions to facilitate testing of flag-guarded releases.

- Implemented TestDetectFlagGuardedReleases to validate detection of flag-guarded mutex releases.

- Enhanced funcAnalysis struct to include flagGuardedMutexes for tracking mutexes released by deferred, flag-guarded unlocks.

- Updated Checker methods to credit flag-guarded releases appropriately.

- Modified loopMutexDetector to report mutex declarations inside loops, considering goroutine joins.

- Added tests for mutex protection in loop scenarios and cross-method barriers.

- Expanded test cases for mutex and waitgroup scenarios to cover new functionality.