### PR TITLE
feat(mutex,waitgroup): detect ownership-transfer and one-way lock pat…

### DIFF
--- a/pkg/analyzer/internal/mutex/analyzer.go
+++ b/pkg/analyzer/internal/mutex/analyzer.go
@@ -34,6 +34,10 @@ type Checker struct {
 	// treat it as read-only.
 	explicitTransferCache map[*ast.BlockStmt]map[token.Pos]struct{}
 
+	// lifecycleScanCache memoizes per-function AST scans (returned idents and
+	// composite literals), shared by reference across functions; read-only.
+	lifecycleScanCache *lifecycleScanCache
+
 	*funcAnalysis
 }
 
@@ -69,9 +73,31 @@ type deferErrorCollector struct {
 	badDeferRUnlock map[string]bool
 }
 
-// NewChecker creates a new mutex checker. fr supplies the mutex and
-// rwmutex names visible inside the function being analyzed.
-func NewChecker(fr *primitives.FunctionResult, errorCollector report.Reporter, cf *commentfilter.CommentFilter, typesInfo *types.Info, files []*ast.File) *Checker {
+// packageScope holds analysis state shared by every function in a package: the
+// receiver-method index, the function list, and the lifecycle caches. Building
+// it once per pass (instead of once per function) is what keeps the lifecycle
+// ownership checks from rescanning every package function for each analyzed
+// function.
+type packageScope struct {
+	receiverMethods       map[string]map[string]*ast.FuncDecl
+	functions             []*ast.FuncDecl
+	explicitTransferCache map[*ast.BlockStmt]map[token.Pos]struct{}
+	scanCache             *lifecycleScanCache
+}
+
+func newPackageScope(files []*ast.File) *packageScope {
+	return &packageScope{
+		receiverMethods:       buildReceiverMethodMap(files),
+		functions:             collectFunctionDecls(files),
+		explicitTransferCache: make(map[*ast.BlockStmt]map[token.Pos]struct{}),
+		scanCache:             newLifecycleScanCache(),
+	}
+}
+
+// NewChecker creates a new mutex checker. fr supplies the mutex and rwmutex
+// names visible inside the function being analyzed; scope carries the
+// package-wide state shared across functions.
+func NewChecker(fr *primitives.FunctionResult, errorCollector report.Reporter, cf *commentfilter.CommentFilter, typesInfo *types.Info, scope *packageScope) *Checker {
 	term := newTerminationAnalyzer(typesInfo)
 	c := &Checker{
 		mutexNames:            fr.Mutexes,
@@ -79,10 +105,11 @@ func NewChecker(fr *primitives.FunctionResult, errorCollector report.Reporter, c
 		errorCollector:        errorCollector,
 		commentFilter:         cf,
 		typesInfo:             typesInfo,
-		receiverMethods:       buildReceiverMethodMap(files),
-		functions:             collectFunctionDecls(files),
+		receiverMethods:       scope.receiverMethods,
+		functions:             scope.functions,
 		termination:           term,
-		explicitTransferCache: make(map[*ast.BlockStmt]map[token.Pos]struct{}),
+		explicitTransferCache: scope.explicitTransferCache,
+		lifecycleScanCache:    scope.scanCache,
 	}
 	c.loopCarry = newLoopCarryAnalyzer(c.mutexNames, c.rwMutexNames, cf, errorCollector, term)
 	return c
@@ -91,10 +118,10 @@ func NewChecker(fr *primitives.FunctionResult, errorCollector report.Reporter, c
 func (c *Checker) AnalyzeFunction(fn *ast.FuncDecl) {
 	c.funcAnalysis = newFuncAnalysis(fn)
 	c.tryLock = newTryLockTracker(c.mutexNames, c.rwMutexNames, c.commentFilter, c.errorCollector)
-	c.wrapper = newWrapperResolver(c.receiverMethods, c.function, c.rawBodyEffects)
-	c.lifecycle = newLifecycleResolver(c.receiverMethods, c.functions, c.typesInfo, c.explicitTransferCache, c.function)
+	c.wrapper = newWrapperResolver(c.receiverMethods, c.function, c.rawBodyEffects, c.typesInfo)
+	c.lifecycle = newLifecycleResolver(c.receiverMethods, c.functions, c.typesInfo, c.explicitTransferCache, c.lifecycleScanCache, c.function)
 	c.panicDetector = newLockedPanicDetector(c.mutexNames, c.rwMutexNames, c.typesInfo, c.errorCollector, c.rawBodyEffects)
-	c.flagGuardedMutexes = c.detectFlagGuardedReleases(fn)
+	c.flagGuardedFlags = c.detectFlagGuardedReleaseFlags(fn)
 	c.stats = initialStats(c.mutexNames, c.rwMutexNames)
 	lockOrder := newLockOrderDetector(c.mutexNames, c.rwMutexNames, c.commentFilter, c.typesInfo, c.errorCollector)
 	lockOrder.check(fn.Body)
@@ -195,6 +222,14 @@ func (c *Checker) varRootIsFunctionParameter(varName string) bool {
 	return false
 }
 
+// maxSimulationDepth caps how deep the lifecycle simulation recurses through
+// chained method/function calls. The simulationStack already breaks exact
+// cycles, but a wide call graph (e.g. a struct-with-mutex threaded through many
+// helpers) can still fan out into a very large simulation tree. Beyond this
+// depth we assume no net effect, which keeps analysis time bounded on large
+// real-world packages.
+const maxSimulationDepth = 24
+
 func (c *Checker) simulateMethodEffect(fn *ast.FuncDecl, varName string, isRWMutex bool, initial *Stats) *Stats {
 	if fn == nil || fn.Body == nil {
 		return nil
@@ -204,6 +239,9 @@ func (c *Checker) simulateMethodEffect(fn *ast.FuncDecl, varName string, isRWMut
 	if stack == nil {
 		stack = make(map[methodSimulationKey]bool)
 		c.simulationStack = stack
+	}
+	if len(stack) >= maxSimulationDepth {
+		return cloneStats(initial)
 	}
 
 	key := methodSimulationKey{fn: fn, varName: varName, isRWMutex: isRWMutex}
@@ -357,32 +395,34 @@ func (c *Checker) applyLocalMethodLifecycleEffects(call *ast.CallExpr, stats map
 
 	for mutexName := range c.mutexNames {
 		relativePath, ok := relativeMutexPath(mutexName, baseVar)
-		if !ok {
-			continue
+		if ok {
+			simulated := c.simulateMethodEffect(callee, calleeReceiver+"."+relativePath, false, stats[mutexName])
+			if simulated != nil {
+				stats[mutexName] = simulated
+				changed = true
+				continue
+			}
 		}
 
-		simulated := c.simulateMethodEffect(callee, calleeReceiver+"."+relativePath, false, stats[mutexName])
-		if simulated == nil {
-			continue
+		if c.applyArgumentReleaseEffect(call, callee, mutexName, false, stats) {
+			changed = true
 		}
-
-		stats[mutexName] = simulated
-		changed = true
 	}
 
 	for rwMutexName := range c.rwMutexNames {
 		relativePath, ok := relativeMutexPath(rwMutexName, baseVar)
-		if !ok {
-			continue
+		if ok {
+			simulated := c.simulateMethodEffect(callee, calleeReceiver+"."+relativePath, true, stats[rwMutexName])
+			if simulated != nil {
+				stats[rwMutexName] = simulated
+				changed = true
+				continue
+			}
 		}
 
-		simulated := c.simulateMethodEffect(callee, calleeReceiver+"."+relativePath, true, stats[rwMutexName])
-		if simulated == nil {
-			continue
+		if c.applyArgumentReleaseEffect(call, callee, rwMutexName, true, stats) {
+			changed = true
 		}
-
-		stats[rwMutexName] = simulated
-		changed = true
 	}
 
 	return changed
@@ -419,6 +459,12 @@ func (c *Checker) applyLocalFunctionCallLifecycleEffects(call *ast.CallExpr, sta
 	return changed
 }
 
+// argumentReleaseMethods are the unlock calls that make simulating a callee
+// worthwhile in applyArgumentReleaseEffect: if the callee never unlocks the
+// passed-in lock, simulating it cannot turn an unbalanced lock into a balanced
+// one, so the (recursive, expensive) simulation is skipped.
+var argumentReleaseMethods = []string{"Unlock", "RUnlock"}
+
 // applyArgumentReleaseEffect simulates the callee's effect on a single mutex that
 // the caller passes in as an argument, remapping the caller's variable to the
 // matching parameter name inside the callee.
@@ -433,7 +479,16 @@ func (c *Checker) applyArgumentReleaseEffect(call *ast.CallExpr, callee *ast.Fun
 		return false
 	}
 
-	simulated := c.simulateMethodEffect(callee, paramName+"."+suffix, isRWMutex, stats[mutexName])
+	// Cheap pre-filter before the recursive simulation: only callees that
+	// actually unlock the passed-in lock can balance it. This keeps analysis
+	// time bounded on packages that thread a struct-with-mutex through many
+	// helpers, where most callees never touch the lock.
+	releaseTarget := paramName + "." + suffix
+	if !functionBodyContainsFieldCall(callee.Body, releaseTarget, argumentReleaseMethods) {
+		return false
+	}
+
+	simulated := c.simulateMethodEffect(callee, releaseTarget, isRWMutex, stats[mutexName])
 	if simulated == nil {
 		return false
 	}
@@ -445,12 +500,7 @@ func (c *Checker) applyArgumentReleaseEffect(call *ast.CallExpr, callee *ast.Fun
 // topLevelFunctionNamed returns the package-level (non-method) function with the
 // given name, or nil when there is none.
 func (c *Checker) topLevelFunctionNamed(name string) *ast.FuncDecl {
-	for _, fn := range c.functions {
-		if fn != nil && fn.Recv == nil && fn.Name != nil && fn.Name.Name == name {
-			return fn
-		}
-	}
-	return nil
+	return topLevelFunctionNamed(c.functions, name)
 }
 
 // calleeParamNameForArg returns the callee parameter name that receives the

--- a/pkg/analyzer/internal/mutex/defer.go
+++ b/pkg/analyzer/internal/mutex/defer.go
@@ -133,7 +133,7 @@ func (c *Checker) handleDeferFunctionLiteral(fnlit *ast.FuncLit, pos token.Pos, 
 	// Check for mutex unlocks in function literal
 	for mutexName := range c.mutexNames {
 		if guard.containsUnlock(fnlit.Body, mutexName) && !guard.containsLock(fnlit.Body, mutexName) {
-			if c.flagGuardedMutexes[mutexName] {
+			if c.isFlagGuarded(mutexName) {
 				continue
 			}
 			if stats[mutexName].lock == 0 && guard.unlocksOnlyInRecoverGuard(fnlit.Body, mutexName, "Unlock") {
@@ -146,7 +146,7 @@ func (c *Checker) handleDeferFunctionLiteral(fnlit *ast.FuncLit, pos token.Pos, 
 	// Check for rwmutex unlocks in function literal
 	for rwMutexName := range c.rwMutexNames {
 		if guard.containsUnlock(fnlit.Body, rwMutexName) && !guard.containsLock(fnlit.Body, rwMutexName) {
-			if c.flagGuardedMutexes[rwMutexName] {
+			if c.isFlagGuarded(rwMutexName) {
 				continue
 			}
 			if stats[rwMutexName].lock == 0 && guard.unlocksOnlyInRecoverGuard(fnlit.Body, rwMutexName, "Unlock") {

--- a/pkg/analyzer/internal/mutex/flagguard.go
+++ b/pkg/analyzer/internal/mutex/flagguard.go
@@ -2,12 +2,14 @@ package mutex
 
 import (
 	"go/ast"
+	"go/token"
 
 	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/internal/common"
 )
 
-// detectFlagGuardedReleases returns the set of mutex/rwmutex names whose lock is
-// released by a deferred, flag-guarded unlock. The pattern is:
+// detectFlagGuardedReleaseFlags maps each mutex/rwmutex name whose lock is
+// released by a deferred, flag-guarded unlock to its guard flag's name. The
+// pattern is:
 //
 //	held := false
 //	defer func() { if held { mu.Unlock() } }()
@@ -21,12 +23,12 @@ import (
 // To stay sound, a mutex only qualifies when every Lock is immediately followed
 // by `flag = true`: a Lock that does not set the flag is not covered by the
 // deferred release and must still be reported.
-func (c *Checker) detectFlagGuardedReleases(fn *ast.FuncDecl) map[string]bool {
+func (c *Checker) detectFlagGuardedReleaseFlags(fn *ast.FuncDecl) map[string]string {
 	if fn == nil || fn.Body == nil {
 		return nil
 	}
 
-	var result map[string]bool
+	var result map[string]string
 	consider := func(names map[string]bool) {
 		for name := range names {
 			flag, ok := deferredFlagGuardedUnlock(fn.Body, name, "Unlock")
@@ -34,9 +36,9 @@ func (c *Checker) detectFlagGuardedReleases(fn *ast.FuncDecl) map[string]bool {
 				continue
 			}
 			if result == nil {
-				result = make(map[string]bool)
+				result = make(map[string]string)
 			}
-			result[name] = true
+			result[name] = flag
 		}
 	}
 
@@ -45,38 +47,174 @@ func (c *Checker) detectFlagGuardedReleases(fn *ast.FuncDecl) map[string]bool {
 	return result
 }
 
+// isFlagGuarded reports whether mutexName's lock is released by a deferred,
+// flag-guarded unlock (see detectFlagGuardedReleaseFlags).
+func (c *Checker) isFlagGuarded(mutexName string) bool {
+	_, ok := c.flagGuardedFlags[mutexName]
+	return ok
+}
+
+func (c *Checker) unlockIsGuardedByFlag(mutexName string, pos token.Pos) bool {
+	flag := c.flagGuardedFlags[mutexName]
+	return flag != "" && positionInsideFlagGuard(c.function, pos, flag)
+}
+
+func positionInsideFlagGuard(fn *ast.FuncDecl, pos token.Pos, flag string) bool {
+	if fn == nil || fn.Body == nil || !pos.IsValid() || flag == "" {
+		return false
+	}
+
+	found := false
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		if found {
+			return false
+		}
+		ifStmt, ok := n.(*ast.IfStmt)
+		if !ok || ifStmt.Body == nil {
+			return true
+		}
+		if !exprMentionsIdent(ifStmt.Cond, flag) {
+			return true
+		}
+		if ifStmt.Body.Pos() <= pos && pos <= ifStmt.Body.End() {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
+}
+
+func exprMentionsIdent(expr ast.Expr, name string) bool {
+	found := false
+	ast.Inspect(expr, func(n ast.Node) bool {
+		if found {
+			return false
+		}
+		ident, ok := n.(*ast.Ident)
+		if ok && ident.Name == name {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
+}
+
 // deferredFlagGuardedUnlock finds a deferred closure in body whose unlocks of
 // mutexName (via unlockMethod) all sit inside a single `if <flag> { ... }`, and
 // returns the guard flag name.
 func deferredFlagGuardedUnlock(body *ast.BlockStmt, mutexName, unlockMethod string) (string, bool) {
-	for _, stmt := range body.List {
-		deferStmt, ok := stmt.(*ast.DeferStmt)
+	return deferredFlagGuardedUnlockInStatements(body.List, mutexName, unlockMethod)
+}
+
+func deferredFlagGuardedUnlockInStatements(stmts []ast.Stmt, mutexName, unlockMethod string) (string, bool) {
+	for _, stmt := range stmts {
+		switch s := stmt.(type) {
+		case *ast.DeferStmt:
+			if flag, ok := flagFromGuardedDefer(s, mutexName, unlockMethod); ok {
+				return flag, true
+			}
+		case *ast.BlockStmt:
+			if flag, ok := deferredFlagGuardedUnlockInStatements(s.List, mutexName, unlockMethod); ok {
+				return flag, true
+			}
+		case *ast.IfStmt:
+			if flag, ok := deferredFlagGuardedUnlockInStatements(s.Body.List, mutexName, unlockMethod); ok {
+				return flag, true
+			}
+			if flag, ok := deferredFlagGuardedUnlockInElse(s.Else, mutexName, unlockMethod); ok {
+				return flag, true
+			}
+		case *ast.ForStmt:
+			if flag, ok := deferredFlagGuardedUnlockInStatements(s.Body.List, mutexName, unlockMethod); ok {
+				return flag, true
+			}
+		case *ast.RangeStmt:
+			if flag, ok := deferredFlagGuardedUnlockInStatements(s.Body.List, mutexName, unlockMethod); ok {
+				return flag, true
+			}
+		case *ast.SwitchStmt:
+			if flag, ok := deferredFlagGuardedUnlockInCaseClauses(s.Body.List, mutexName, unlockMethod); ok {
+				return flag, true
+			}
+		case *ast.TypeSwitchStmt:
+			if flag, ok := deferredFlagGuardedUnlockInCaseClauses(s.Body.List, mutexName, unlockMethod); ok {
+				return flag, true
+			}
+		case *ast.SelectStmt:
+			if flag, ok := deferredFlagGuardedUnlockInCommClauses(s.Body.List, mutexName, unlockMethod); ok {
+				return flag, true
+			}
+		case *ast.LabeledStmt:
+			if flag, ok := deferredFlagGuardedUnlockInStatements([]ast.Stmt{s.Stmt}, mutexName, unlockMethod); ok {
+				return flag, true
+			}
+		}
+	}
+	return "", false
+}
+
+func deferredFlagGuardedUnlockInElse(stmt ast.Stmt, mutexName, unlockMethod string) (string, bool) {
+	switch s := stmt.(type) {
+	case *ast.BlockStmt:
+		return deferredFlagGuardedUnlockInStatements(s.List, mutexName, unlockMethod)
+	case *ast.IfStmt:
+		return deferredFlagGuardedUnlockInStatements([]ast.Stmt{s}, mutexName, unlockMethod)
+	default:
+		return "", false
+	}
+}
+
+func deferredFlagGuardedUnlockInCaseClauses(stmts []ast.Stmt, mutexName, unlockMethod string) (string, bool) {
+	for _, stmt := range stmts {
+		cc, ok := stmt.(*ast.CaseClause)
 		if !ok {
 			continue
 		}
-		fnlit, ok := deferStmt.Call.Fun.(*ast.FuncLit)
-		if !ok || fnlit.Body == nil {
+		if flag, ok := deferredFlagGuardedUnlockInStatements(cc.Body, mutexName, unlockMethod); ok {
+			return flag, true
+		}
+	}
+	return "", false
+}
+
+func deferredFlagGuardedUnlockInCommClauses(stmts []ast.Stmt, mutexName, unlockMethod string) (string, bool) {
+	for _, stmt := range stmts {
+		cc, ok := stmt.(*ast.CommClause)
+		if !ok {
 			continue
 		}
+		if flag, ok := deferredFlagGuardedUnlockInStatements(cc.Body, mutexName, unlockMethod); ok {
+			return flag, true
+		}
+	}
+	return "", false
+}
 
-		total := countMutexMethodCalls(fnlit.Body, mutexName, unlockMethod)
-		if total == 0 {
+func flagFromGuardedDefer(deferStmt *ast.DeferStmt, mutexName, unlockMethod string) (string, bool) {
+	fnlit, ok := deferStmt.Call.Fun.(*ast.FuncLit)
+	if !ok || fnlit.Body == nil {
+		return "", false
+	}
+
+	total := countMutexMethodCalls(fnlit.Body, mutexName, unlockMethod)
+	if total == 0 {
+		return "", false
+	}
+
+	for _, inner := range fnlit.Body.List {
+		ifStmt, ok := inner.(*ast.IfStmt)
+		if !ok || ifStmt.Init != nil {
 			continue
 		}
-
-		for _, inner := range fnlit.Body.List {
-			ifStmt, ok := inner.(*ast.IfStmt)
-			if !ok || ifStmt.Init != nil {
-				continue
-			}
-			flagIdent, ok := ifStmt.Cond.(*ast.Ident)
-			if !ok {
-				continue
-			}
-			// Every unlock in the closure must be under this single flag guard.
-			if countMutexMethodCalls(ifStmt.Body, mutexName, unlockMethod) == total {
-				return flagIdent.Name, true
-			}
+		flagIdent, ok := ifStmt.Cond.(*ast.Ident)
+		if !ok {
+			continue
+		}
+		// Every unlock in the closure must be under this single flag guard.
+		if countMutexMethodCalls(ifStmt.Body, mutexName, unlockMethod) == total {
+			return flagIdent.Name, true
 		}
 	}
 	return "", false
@@ -91,6 +229,7 @@ func everyLockPairsWithSetFlag(body *ast.BlockStmt, mutexName, lockMethod, flag 
 	paired := true
 
 	var visit func(stmts []ast.Stmt)
+	var visitCallbackExprs func(ast.Expr)
 	visit = func(stmts []ast.Stmt) {
 		for i, stmt := range stmts {
 			if isMutexMethodCallStmt(stmt, mutexName, lockMethod) {
@@ -104,7 +243,20 @@ func everyLockPairsWithSetFlag(body *ast.BlockStmt, mutexName, lockMethod, flag 
 			switch s := stmt.(type) {
 			case *ast.BlockStmt:
 				visit(s.List)
+			case *ast.AssignStmt:
+				for _, rhs := range s.Rhs {
+					visitCallbackExprs(rhs)
+				}
+			case *ast.ExprStmt:
+				visitCallbackExprs(s.X)
+			case *ast.ReturnStmt:
+				for _, result := range s.Results {
+					visitCallbackExprs(result)
+				}
 			case *ast.IfStmt:
+				if s.Init != nil {
+					visit([]ast.Stmt{s.Init})
+				}
 				if s.Body != nil {
 					visit(s.Body.List)
 				}
@@ -138,6 +290,20 @@ func everyLockPairsWithSetFlag(body *ast.BlockStmt, mutexName, lockMethod, flag 
 			case *ast.LabeledStmt:
 				visit([]ast.Stmt{s.Stmt})
 			}
+		}
+	}
+
+	visitCallbackExprs = func(expr ast.Expr) {
+		call, ok := expr.(*ast.CallExpr)
+		if !ok {
+			return
+		}
+		for _, arg := range call.Args {
+			fnlit, ok := arg.(*ast.FuncLit)
+			if !ok || fnlit.Body == nil {
+				continue
+			}
+			visit(fnlit.Body.List)
 		}
 	}
 

--- a/pkg/analyzer/internal/mutex/flagguard_test.go
+++ b/pkg/analyzer/internal/mutex/flagguard_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 // flagGuardFuncDecl parses src with the typed lifecycle helper and returns the
-// top-level function named name, ready to feed to detectFlagGuardedReleases.
+// top-level function named name, ready to feed to detectFlagGuardedReleaseFlags.
 func flagGuardFuncDecl(t *testing.T, src, name string) *ast.FuncDecl {
 	t.Helper()
 	file, _ := parseTypedLifecycleFile(t, src)
@@ -153,9 +153,9 @@ func f(c bool) {
 			fn := flagGuardFuncDecl(t, tc.src, "f")
 			c := &Checker{mutexNames: tc.mutex, rwMutexNames: tc.rwMutex}
 
-			got := c.detectFlagGuardedReleases(fn)
-			if got[tc.varName] != tc.want {
-				t.Errorf("detectFlagGuardedReleases()[%q] = %v, want %v", tc.varName, got[tc.varName], tc.want)
+			got := c.detectFlagGuardedReleaseFlags(fn)
+			if (got[tc.varName] != "") != tc.want {
+				t.Errorf("detectFlagGuardedReleaseFlags()[%q] present = %v, want %v", tc.varName, got[tc.varName] != "", tc.want)
 			}
 		})
 	}
@@ -163,8 +163,8 @@ func f(c bool) {
 
 func TestDetectFlagGuardedReleases_NilFunc(t *testing.T) {
 	c := &Checker{mutexNames: map[string]bool{"mu": true}}
-	if got := c.detectFlagGuardedReleases(nil); got != nil {
-		t.Errorf("detectFlagGuardedReleases(nil) = %v, want nil", got)
+	if got := c.detectFlagGuardedReleaseFlags(nil); got != nil {
+		t.Errorf("detectFlagGuardedReleaseFlags(nil) = %v, want nil", got)
 	}
 }
 

--- a/pkg/analyzer/internal/mutex/funcanalysis.go
+++ b/pkg/analyzer/internal/mutex/funcanalysis.go
@@ -22,9 +22,10 @@ type funcAnalysis struct {
 	simulationStack        map[methodSimulationKey]bool
 	localFuncStack         map[*ast.FuncLit]bool
 
-	// flagGuardedMutexes holds mutexes released by a deferred, flag-guarded unlock
-	// (see detectFlagGuardedReleases). Populated once per real function.
-	flagGuardedMutexes map[string]bool
+	// flagGuardedFlags maps mutexes released by a deferred, flag-guarded unlock
+	// (see detectFlagGuardedReleaseFlags) to their guard flag name. Populated once
+	// per real function.
+	flagGuardedFlags map[string]string
 }
 
 func newFuncAnalysis(fn *ast.FuncDecl) *funcAnalysis {
@@ -73,14 +74,15 @@ func (c *Checker) forkForSimulation(fa *funcAnalysis, mutexNames, rwMutexNames m
 		termination:           c.termination,
 		loopCarry:             c.loopCarry,
 		explicitTransferCache: c.explicitTransferCache,
+		lifecycleScanCache:    c.lifecycleScanCache,
 		funcAnalysis:          fa,
 	}
 	// Wire the per-function collaborators against the fork's own names and
 	// (isolated) collector so simulation diagnostics never leak into the parent
 	// run. fa.rawBodyEffects is true here, so the wrapper resolver stays inert.
 	sim.tryLock = newTryLockTracker(sim.mutexNames, sim.rwMutexNames, sim.commentFilter, sim.errorCollector)
-	sim.wrapper = newWrapperResolver(sim.receiverMethods, fa.function, fa.rawBodyEffects)
-	sim.lifecycle = newLifecycleResolver(sim.receiverMethods, sim.functions, sim.typesInfo, sim.explicitTransferCache, fa.function)
+	sim.wrapper = newWrapperResolver(sim.receiverMethods, fa.function, fa.rawBodyEffects, sim.typesInfo)
+	sim.lifecycle = newLifecycleResolver(sim.receiverMethods, sim.functions, sim.typesInfo, sim.explicitTransferCache, sim.lifecycleScanCache, fa.function)
 	sim.panicDetector = newLockedPanicDetector(sim.mutexNames, sim.rwMutexNames, sim.typesInfo, sim.errorCollector, fa.rawBodyEffects)
 	return sim
 }

--- a/pkg/analyzer/internal/mutex/lifecycle.go
+++ b/pkg/analyzer/internal/mutex/lifecycle.go
@@ -9,6 +9,29 @@ import (
 	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/internal/common"
 )
 
+// returnedIdent pairs an identifier appearing in a return statement's results
+// with its enclosing return statement.
+type returnedIdent struct {
+	ident *ast.Ident
+	ret   *ast.ReturnStmt
+}
+
+// lifecycleScanCache memoizes per-function AST scans that the lifecycle checks
+// repeat for every function in the package on each unbalanced lock/unlock. It is
+// shared package-wide (like explicitTransferCache) so each function body is
+// scanned at most once instead of O(functions) times.
+type lifecycleScanCache struct {
+	returnedIdents        map[*ast.FuncDecl][]returnedIdent
+	returnedCompositeLits map[*ast.FuncDecl][]*ast.CompositeLit
+}
+
+func newLifecycleScanCache() *lifecycleScanCache {
+	return &lifecycleScanCache{
+		returnedIdents:        make(map[*ast.FuncDecl][]returnedIdent),
+		returnedCompositeLits: make(map[*ast.FuncDecl][]*ast.CompositeLit),
+	}
+}
+
 // lifecycleResolver recognizes ownership-transfer patterns where a lock is
 // acquired in one function but intentionally released by a returned handle or
 // by a caller that owns the acquire/release protocol.
@@ -17,6 +40,7 @@ type lifecycleResolver struct {
 	functions             []*ast.FuncDecl
 	typesInfo             *types.Info
 	explicitTransferCache map[*ast.BlockStmt]map[token.Pos]struct{}
+	scanCache             *lifecycleScanCache
 	function              *ast.FuncDecl
 	callerManagedCache    map[callerManagedKey]bool
 }
@@ -31,10 +55,14 @@ func newLifecycleResolver(
 	functions []*ast.FuncDecl,
 	typesInfo *types.Info,
 	explicitTransferCache map[*ast.BlockStmt]map[token.Pos]struct{},
+	scanCache *lifecycleScanCache,
 	function *ast.FuncDecl,
 ) *lifecycleResolver {
 	if explicitTransferCache == nil {
 		explicitTransferCache = make(map[*ast.BlockStmt]map[token.Pos]struct{})
+	}
+	if scanCache == nil {
+		scanCache = newLifecycleScanCache()
 	}
 
 	return &lifecycleResolver{
@@ -42,6 +70,7 @@ func newLifecycleResolver(
 		functions:             functions,
 		typesInfo:             typesInfo,
 		explicitTransferCache: explicitTransferCache,
+		scanCache:             scanCache,
 		function:              function,
 		callerManagedCache:    make(map[callerManagedKey]bool),
 	}
@@ -86,11 +115,14 @@ func (l *lifecycleResolver) returnsHandleFor(mutexName string, methodNames []str
 		}
 	}
 
-	return false
+	return l.returnsVariableWithReleaseFor(baseVar, suffix, methodNames)
 }
 
 func (l *lifecycleResolver) isReleaseFor(mutexName string, methodNames []string) bool {
-	if l.function == nil || l.function.Name == nil || !methodNameMatchesAnyHint(l.function.Name.Name, []string{"Close", "Unlock", "Release"}) {
+	if l.function == nil || l.function.Name == nil || l.function.Body == nil {
+		return false
+	}
+	if !functionBodyContainsFieldCall(l.function.Body, mutexName, matchingUnlockMethods(methodNames)) {
 		return false
 	}
 
@@ -137,6 +169,84 @@ func (l *lifecycleResolver) isReleaseFor(mutexName string, methodNames []string)
 
 			targetVar := sourceVar + "." + suffix
 			if functionBodyContainsFieldCall(fn.Body, targetVar, methodNames) {
+				return true
+			}
+		}
+
+		if l.functionReturningCurrentReceiverAfterAcquire(fn, currentType, path, methodNames) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (l *lifecycleResolver) returnsVariableWithReleaseFor(baseVar, suffix string, methodNames []string) bool {
+	if l.function == nil || l.function.Body == nil || l.typesInfo == nil {
+		return false
+	}
+
+	for _, ident := range l.returnedIdentsNamed(l.function, baseVar) {
+		returnedType := baseTypeNameFromType(l.typesInfo.TypeOf(ident))
+		if returnedType == "" {
+			continue
+		}
+		if l.releaseMethodUnlocks(returnedType, "", suffix, methodNames) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (l *lifecycleResolver) functionReturningCurrentReceiverAfterAcquire(fn *ast.FuncDecl, currentType, path string, acquireMethods []string) bool {
+	if l.typesInfo == nil {
+		return false
+	}
+
+	for _, ri := range l.returnedIdents(fn) {
+		if baseTypeNameFromType(l.typesInfo.TypeOf(ri.ident)) != currentType {
+			continue
+		}
+		if functionBodyContainsFieldCallBefore(fn.Body, ri.ident.Name+"."+path, acquireMethods, ri.ret.Pos()) {
+			return true
+		}
+	}
+	return false
+}
+
+func (l *lifecycleResolver) returnsFuncFor(mutexName string, methodNames []string) bool {
+	if l.function == nil || l.function.Body == nil {
+		return false
+	}
+
+	for _, name := range l.returnedFunctionNames(l.function) {
+		fn := topLevelFunctionNamed(l.functions, name)
+		if fn != nil && functionBodyContainsFieldCall(fn.Body, mutexName, methodNames) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (l *lifecycleResolver) isReturnedFuncReleaseFor(mutexName string, acquireMethods []string) bool {
+	if l.function == nil || l.function.Name == nil || l.function.Body == nil {
+		return false
+	}
+	if !functionBodyContainsFieldCall(l.function.Body, mutexName, matchingUnlockMethods(acquireMethods)) {
+		return false
+	}
+
+	for _, fn := range l.functions {
+		if fn == nil || fn.Body == nil || fn == l.function {
+			continue
+		}
+		for _, ret := range l.returnedFunctionNames(fn) {
+			if ret != l.function.Name.Name {
+				continue
+			}
+			if functionBodyContainsFieldCallBefore(fn.Body, mutexName, acquireMethods, l.functionReturnPos(fn, ret)) {
 				return true
 			}
 		}
@@ -216,8 +326,8 @@ func (l *lifecycleResolver) releaseMethodUnlocks(returnedType, fieldName, suffix
 		return false
 	}
 
-	for methodName, fn := range methods {
-		if fn == nil || fn.Body == nil || !methodNameMatchesAnyHint(methodName, []string{"Close", "Unlock", "Release"}) {
+	for _, fn := range methods {
+		if fn == nil || fn.Body == nil {
 			continue
 		}
 
@@ -241,6 +351,9 @@ func (l *lifecycleResolver) releaseMethodUnlocks(returnedType, fieldName, suffix
 func (l *lifecycleResolver) returnedCompositeLiterals(fn *ast.FuncDecl) []*ast.CompositeLit {
 	if fn == nil || fn.Body == nil {
 		return nil
+	}
+	if cached, ok := l.scanCache.returnedCompositeLits[fn]; ok {
+		return cached
 	}
 
 	localValues := make(map[string]ast.Expr)
@@ -283,6 +396,7 @@ func (l *lifecycleResolver) returnedCompositeLiterals(fn *ast.FuncDecl) []*ast.C
 		return true
 	})
 
+	l.scanCache.returnedCompositeLits[fn] = returned
 	return returned
 }
 
@@ -361,6 +475,9 @@ func (l *lifecycleResolver) explicitTransferCallPositions(body *ast.BlockStmt) m
 			}
 		case *ast.GoStmt:
 			recordCall(s.Call)
+			if fnlit, ok := s.Call.Fun.(*ast.FuncLit); ok && fnlit.Body != nil {
+				visitStmtList(fnlit.Body.List)
+			}
 		case *ast.IfStmt:
 			visitStmtList(s.Body.List)
 			if s.Else != nil {
@@ -486,4 +603,83 @@ func compositeLiteralUnkeyedVarNames(lit *ast.CompositeLit) []string {
 	}
 
 	return names
+}
+
+func matchingUnlockMethods(acquireMethods []string) []string {
+	var methods []string
+	for _, acquire := range acquireMethods {
+		if release := matchingUnlockMethod(acquire); release != "" {
+			methods = append(methods, release)
+		}
+	}
+	return methods
+}
+
+func topLevelFunctionNamed(functions []*ast.FuncDecl, name string) *ast.FuncDecl {
+	for _, fn := range functions {
+		if fn != nil && fn.Recv == nil && fn.Name != nil && fn.Name.Name == name {
+			return fn
+		}
+	}
+	return nil
+}
+
+// returnedIdents returns every identifier appearing in fn's return statements
+// paired with its enclosing return. The scan is memoized per function (shared
+// package-wide) because the lifecycle checks re-scan every package function for
+// many lock/unlock pairs; without the cache this is the dominant cost on large
+// packages.
+func (l *lifecycleResolver) returnedIdents(fn *ast.FuncDecl) []returnedIdent {
+	if fn == nil || fn.Body == nil {
+		return nil
+	}
+	if cached, ok := l.scanCache.returnedIdents[fn]; ok {
+		return cached
+	}
+
+	var result []returnedIdent
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		ret, ok := n.(*ast.ReturnStmt)
+		if !ok {
+			return true
+		}
+		for _, res := range ret.Results {
+			if ident, ok := res.(*ast.Ident); ok {
+				result = append(result, returnedIdent{ident: ident, ret: ret})
+			}
+		}
+		return true
+	})
+
+	l.scanCache.returnedIdents[fn] = result
+	return result
+}
+
+func (l *lifecycleResolver) returnedFunctionNames(fn *ast.FuncDecl) []string {
+	var names []string
+	for _, ri := range l.returnedIdents(fn) {
+		if ri.ident.Name != "" && ri.ident.Name != "nil" {
+			names = append(names, ri.ident.Name)
+		}
+	}
+	return names
+}
+
+func (l *lifecycleResolver) returnedIdentsNamed(fn *ast.FuncDecl, name string) []*ast.Ident {
+	var idents []*ast.Ident
+	for _, ri := range l.returnedIdents(fn) {
+		if ri.ident.Name == name {
+			idents = append(idents, ri.ident)
+		}
+	}
+	return idents
+}
+
+func (l *lifecycleResolver) functionReturnPos(fn *ast.FuncDecl, returnedName string) token.Pos {
+	for _, ri := range l.returnedIdents(fn) {
+		if ri.ident.Name == returnedName {
+			return ri.ret.Pos()
+		}
+	}
+	return token.NoPos
 }

--- a/pkg/analyzer/internal/mutex/lifecycle_test.go
+++ b/pkg/analyzer/internal/mutex/lifecycle_test.go
@@ -17,7 +17,7 @@ func buildLifecycleResolver(t *testing.T, src, receiverType, methodName string) 
 	if fn == nil {
 		t.Fatalf("method %s.%s not found in receiver map", receiverType, methodName)
 	}
-	return newLifecycleResolver(rm, collectFunctionDecls([]*ast.File{file}), info, nil, fn)
+	return newLifecycleResolver(rm, collectFunctionDecls([]*ast.File{file}), info, nil, nil, fn)
 }
 
 func parseTypedLifecycleFile(t *testing.T, src string) (*ast.File, *types.Info) {

--- a/pkg/analyzer/internal/mutex/lockstate.go
+++ b/pkg/analyzer/internal/mutex/lockstate.go
@@ -103,6 +103,9 @@ func (c *Checker) handleMutexCall(varName, methodName string, pos token.Pos, sta
 		stats[varName].lockPos = append(stats[varName].lockPos, pos)
 	case "Unlock":
 		if stats[varName].lock == 0 {
+			if c.unlockIsGuardedByFlag(varName, pos) {
+				return
+			}
 			if c.loopCarry.isCarriedLoopUnlock(varName, pos, c.function, WriteLockPattern) {
 				return
 			}
@@ -120,7 +123,7 @@ func (c *Checker) handleMutexCall(varName, methodName string, pos token.Pos, sta
 // detectFlagGuardedReleases): the acquisition is balanced like
 // `mu.Lock(); defer mu.Unlock()`.
 func (c *Checker) creditFlagGuardedRelease(varName string, stats map[string]*Stats) {
-	if c.flagGuardedMutexes[varName] {
+	if c.isFlagGuarded(varName) {
 		stats[varName].deferUnlock++
 	}
 }
@@ -162,6 +165,9 @@ func (c *Checker) handleRWMutexCall(varName, methodName string, pos token.Pos, s
 			return
 		}
 		if stats[varName].lock == 0 {
+			if c.unlockIsGuardedByFlag(varName, pos) {
+				return
+			}
 			if c.loopCarry.isCarriedLoopUnlock(varName, pos, c.function, WriteLockPattern) {
 				return
 			}

--- a/pkg/analyzer/internal/mutex/report_unmatched.go
+++ b/pkg/analyzer/internal/mutex/report_unmatched.go
@@ -86,6 +86,7 @@ func (c *Checker) reportBranchDelta(mutexName string, initial, final *Stats, isR
 // current lock/unlock pair.
 func (c *Checker) unlockDiagnosticSuppressed(mutexName string, acquireMethods []string) bool {
 	return c.lifecycle.isReleaseFor(mutexName, acquireMethods) ||
+		c.lifecycle.isReturnedFuncReleaseFor(mutexName, acquireMethods) ||
 		c.lifecycle.isCallerManagedReleaseFor(mutexName, acquireMethods) ||
 		c.functionIsParameterUnlockHelper(mutexName, acquireMethods)
 }
@@ -119,7 +120,9 @@ func (c *Checker) reportUnmatchedMutexLocksWithContext(mutexName string, stats *
 		rlockMessage = "rwmutex '" + mutexName + "' is rlocked but not runlocked in " + branchType
 	}
 
-	suppressFunctionLevelLock := branchType == "" && c.lifecycle.returnsHandleFor(mutexName, WriteLockPattern.UnlockMethods)
+	suppressFunctionLevelLock := branchType == "" &&
+		(c.lifecycle.returnsHandleFor(mutexName, WriteLockPattern.UnlockMethods) ||
+			c.lifecycle.returnsFuncFor(mutexName, WriteLockPattern.UnlockMethods))
 	for _, pos := range trailingPositions(stats.lockPos, remainingLockCount(stats.lock, stats.deferUnlock)) {
 		if suppressFunctionLevelLock {
 			continue
@@ -136,7 +139,9 @@ func (c *Checker) reportUnmatchedMutexLocksWithContext(mutexName string, stats *
 	}
 
 	if isRWMutex {
-		suppressFunctionLevelRLock := branchType == "" && c.lifecycle.returnsHandleFor(mutexName, ReadLockPattern.UnlockMethods)
+		suppressFunctionLevelRLock := branchType == "" &&
+			(c.lifecycle.returnsHandleFor(mutexName, ReadLockPattern.UnlockMethods) ||
+				c.lifecycle.returnsFuncFor(mutexName, ReadLockPattern.UnlockMethods))
 		for _, pos := range trailingPositions(stats.rlockPos, remainingLockCount(stats.rlock, stats.deferRUnlock)) {
 			if suppressFunctionLevelRLock {
 				continue

--- a/pkg/analyzer/internal/mutex/sub_analyzer.go
+++ b/pkg/analyzer/internal/mutex/sub_analyzer.go
@@ -26,10 +26,18 @@ var SubAnalyzer = &analysis.Analyzer{
 }
 
 func run(pass *analysis.Pass) (any, error) {
+	// scope is built once on first use and shared across every function in the
+	// pass, so the package-wide indexes and lifecycle caches are not rebuilt per
+	// function. driver.Run visits functions sequentially, so the lazy init needs
+	// no synchronization.
+	var scope *packageScope
 	return driver.Run(pass, driver.Config[*Checker]{
 		Guard: primitives.HasMutexes,
 		NewChecker: func(fr *primitives.FunctionResult, ec report.Reporter, cf *commentfilter.CommentFilter, pass *analysis.Pass) *Checker {
-			return NewChecker(fr, ec, cf, pass.TypesInfo, pass.Files)
+			if scope == nil {
+				scope = newPackageScope(pass.Files)
+			}
+			return NewChecker(fr, ec, cf, pass.TypesInfo, scope)
 		},
 	})
 }

--- a/pkg/analyzer/internal/mutex/wrapper.go
+++ b/pkg/analyzer/internal/mutex/wrapper.go
@@ -2,6 +2,7 @@ package mutex
 
 import (
 	"go/ast"
+	"go/types"
 	"slices"
 	"strings"
 
@@ -23,13 +24,15 @@ type wrapperResolver struct {
 	receiverMethods map[string]map[string]*ast.FuncDecl
 	function        *ast.FuncDecl
 	rawBodyEffects  bool
+	typesInfo       *types.Info
 }
 
-func newWrapperResolver(receiverMethods map[string]map[string]*ast.FuncDecl, function *ast.FuncDecl, rawBodyEffects bool) *wrapperResolver {
+func newWrapperResolver(receiverMethods map[string]map[string]*ast.FuncDecl, function *ast.FuncDecl, rawBodyEffects bool, typesInfo *types.Info) *wrapperResolver {
 	return &wrapperResolver{
 		receiverMethods: receiverMethods,
 		function:        function,
 		rawBodyEffects:  rawBodyEffects,
+		typesInfo:       typesInfo,
 	}
 }
 
@@ -52,6 +55,14 @@ func (w *wrapperResolver) resolve(varName, methodName string) bool {
 	oppositeMethods := oppositeMutexMethods(methodName)
 	if len(oppositeMethods) == 0 || w.currentMethodContainsFieldCall(varName, oppositeMethods) {
 		return false
+	}
+
+	if methodName == "RLock" && w.isOneWayReadLatch(varName) {
+		return true
+	}
+
+	if (methodName == "Lock" || methodName == "Unlock") && w.isOneWayWriteBarrier(varName, methodName) {
+		return true
 	}
 
 	// A single-statement Lock/Unlock split across sibling methods is an
@@ -81,6 +92,76 @@ func (w *wrapperResolver) resolve(varName, methodName string) bool {
 	}
 
 	return w.anySiblingMethodContainsFieldCall(suffix, w.function.Name.Name, oppositeMethods, oppositeMethods)
+}
+
+// isOneWayReadLatch recognizes a read lock used as a one-way "start gate": a
+// waiter/worker method RLocks and intentionally never RUnlocks because the read
+// lock is released elsewhere (e.g. a Broadcast/Release method on the same type
+// unlocks the field). This is a name-hint heuristic and only fires when BOTH the
+// current method's name looks like a waiter AND a sibling method that actually
+// releases the same field exists. The sibling requirement is the safety net:
+// a genuinely leaked latch with no releasing sibling is still reported (see
+// lonelyOneWayLatch in testdata). Trade-off: the hints are broad, so this favors
+// fewer false positives at the cost of an occasional false negative.
+func (w *wrapperResolver) isOneWayReadLatch(varName string) bool {
+	baseVar, fieldSuffix, ok := splitBaseAndSuffix(varName)
+	if !ok {
+		return false
+	}
+	if !methodNameMatchesAnyHint(w.function.Name.Name, []string{"Wait", "Loop", "Worker", "Barrier", "Gate", "Latch"}) {
+		return false
+	}
+	if functionBodyContainsFieldCall(w.function.Body, varName, []string{"RUnlock"}) {
+		return false
+	}
+	if w.anySiblingMethodContainsFieldSuffix(fieldSuffix, w.function.Name.Name, []string{"Unlock"}, []string{"Unlock", "Release", "Broadcast", "Run"}) {
+		return true
+	}
+	if receiverType := w.typeNameForBaseVar(baseVar); receiverType != "" {
+		return w.anyMethodOnTypeContainsFieldSuffix(receiverType, "", fieldSuffix, []string{"Unlock"}, []string{"Unlock", "Release", "Broadcast", "Run"})
+	}
+	return false
+}
+
+// isOneWayWriteBarrier recognizes a write Lock/Unlock split across sibling
+// methods as a deliberate cross-method barrier: e.g. Start/Open Locks and
+// Stop/Close/Release Unlocks the same field. Like isOneWayReadLatch it is a
+// name-hint heuristic guarded by the requirement that a sibling method really
+// performs the opposite operation on the field, so an unmatched Lock with no
+// releasing sibling is still reported. Trade-off: the hints (Start/Open/Run/
+// Stop...) are broad, trading a possible false negative for fewer false
+// positives on legitimate barrier pairs.
+func (w *wrapperResolver) isOneWayWriteBarrier(varName, methodName string) bool {
+	baseVar, fieldSuffix, ok := splitBaseAndSuffix(varName)
+	if !ok {
+		return false
+	}
+
+	var currentHints, siblingHints, siblingMethods []string
+	switch methodName {
+	case "Lock":
+		currentHints = []string{"Create", "Start", "Prepare", "Open"}
+		siblingHints = []string{"Unlock", "Release", "Broadcast", "Run", "Close", "Stop"}
+		siblingMethods = []string{"Unlock"}
+	case "Unlock":
+		currentHints = []string{"Unlock", "Release", "Broadcast", "Run", "Close", "Stop"}
+		siblingHints = []string{"Create", "Start", "Prepare", "Open"}
+		siblingMethods = []string{"Lock"}
+	default:
+		return false
+	}
+
+	if !methodNameMatchesAnyHint(w.function.Name.Name, currentHints) {
+		return false
+	}
+
+	if w.anySiblingMethodContainsFieldSuffix(fieldSuffix, w.function.Name.Name, siblingMethods, siblingHints) {
+		return true
+	}
+	if receiverType := w.typeNameForBaseVar(baseVar); receiverType != "" {
+		return w.anyMethodOnTypeContainsFieldSuffix(receiverType, w.function.Name.Name, fieldSuffix, siblingMethods, siblingHints)
+	}
+	return false
 }
 
 func (w *wrapperResolver) currentMethodContainsFieldCall(varName string, methodNames []string) bool {
@@ -156,7 +237,10 @@ func (w *wrapperResolver) anySiblingMethodContainsFieldSuffix(fieldSuffix, exclu
 	if receiverType == "" {
 		return false
 	}
+	return w.anyMethodOnTypeContainsFieldSuffix(receiverType, excludeMethod, fieldSuffix, fieldMethods, nameHints)
+}
 
+func (w *wrapperResolver) anyMethodOnTypeContainsFieldSuffix(receiverType, excludeMethod, fieldSuffix string, fieldMethods, nameHints []string) bool {
 	methods := w.receiverMethods[receiverType]
 	if len(methods) == 0 {
 		return false
@@ -175,6 +259,32 @@ func (w *wrapperResolver) anySiblingMethodContainsFieldSuffix(fieldSuffix, exclu
 	}
 
 	return false
+}
+
+func (w *wrapperResolver) typeNameForBaseVar(baseVar string) string {
+	if baseVar == "" {
+		return ""
+	}
+	if baseVar == common.ReceiverName(w.function) {
+		return receiverTypeName(w.function)
+	}
+	if w.function == nil || w.function.Body == nil || w.typesInfo == nil {
+		return ""
+	}
+
+	found := ""
+	ast.Inspect(w.function.Body, func(n ast.Node) bool {
+		if found != "" {
+			return false
+		}
+		ident, ok := n.(*ast.Ident)
+		if !ok || ident.Name != baseVar {
+			return true
+		}
+		found = baseTypeNameFromType(w.typesInfo.TypeOf(ident))
+		return found == ""
+	})
+	return found
 }
 
 func methodNameLooksLikeWrapper(fnName, syncMethod string) bool {

--- a/pkg/analyzer/internal/mutex/wrapper_test.go
+++ b/pkg/analyzer/internal/mutex/wrapper_test.go
@@ -16,7 +16,7 @@ func buildResolver(t *testing.T, src, receiverType, methodName string, rawBodyEf
 	if fn == nil {
 		t.Fatalf("method %s.%s not found in receiver map", receiverType, methodName)
 	}
-	return newWrapperResolver(rm, fn, rawBodyEffects)
+	return newWrapperResolver(rm, fn, rawBodyEffects, nil)
 }
 
 func TestWrapperResolver_RecognizesWrapperPair(t *testing.T) {

--- a/pkg/analyzer/internal/waitgroup/analyzer.go
+++ b/pkg/analyzer/internal/waitgroup/analyzer.go
@@ -309,7 +309,21 @@ func (c *Checker) relatedWaitGroupForCall(call *ast.CallExpr, wgName string) (*a
 			if strings.HasPrefix(wgName, prefix) {
 				if calleeReceiverName := common.ReceiverName(fn); calleeReceiverName != "" {
 					suffix := strings.TrimPrefix(wgName, receiverExprName)
-					return fn, calleeReceiverName + suffix, true
+					calleeWGName := calleeReceiverName + suffix
+					if functionBodyUsesWaitGroupName(fn.Body, calleeWGName) {
+						return fn, calleeWGName, true
+					}
+				}
+			}
+		}
+		if rootName := rootVarName(sel.X); rootName != "" {
+			prefix := rootName + "."
+			if strings.HasPrefix(wgName, prefix) {
+				if calleeReceiverName := common.ReceiverName(fn); calleeReceiverName != "" {
+					suffix := strings.TrimPrefix(wgName, rootName)
+					if calleeWGName := calleeWaitGroupNameForReceiverAlias(fn, calleeReceiverName, suffix); calleeWGName != "" {
+						return fn, calleeWGName, true
+					}
 				}
 			}
 		}
@@ -353,6 +367,91 @@ func (c *Checker) relatedWaitGroupForCall(call *ast.CallExpr, wgName string) (*a
 	}
 
 	return nil, "", false
+}
+
+func rootVarName(expr ast.Expr) string {
+	switch e := expr.(type) {
+	case *ast.Ident:
+		return e.Name
+	case *ast.SelectorExpr:
+		return rootVarName(e.X)
+	case *ast.IndexExpr:
+		return rootVarName(e.X)
+	case *ast.IndexListExpr:
+		return rootVarName(e.X)
+	case *ast.ParenExpr:
+		return rootVarName(e.X)
+	case *ast.StarExpr:
+		return rootVarName(e.X)
+	}
+	return ""
+}
+
+func calleeWaitGroupNameForReceiverAlias(fn *ast.FuncDecl, receiverName, suffix string) string {
+	if fn == nil || fn.Body == nil || suffix == "" {
+		return ""
+	}
+
+	candidates := map[string]bool{receiverName + suffix: true}
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		switch node := n.(type) {
+		case *ast.AssignStmt:
+			for i, lhs := range node.Lhs {
+				if i >= len(node.Rhs) {
+					continue
+				}
+				ident, ok := lhs.(*ast.Ident)
+				if !ok || ident.Name == "_" {
+					continue
+				}
+				rhsName := common.GetVarName(node.Rhs[i])
+				if strings.HasPrefix(rhsName, receiverName+".") {
+					candidates[ident.Name+suffix] = true
+				}
+			}
+		case *ast.ValueSpec:
+			for i, ident := range node.Names {
+				if i >= len(node.Values) || ident == nil || ident.Name == "_" {
+					continue
+				}
+				rhsName := common.GetVarName(node.Values[i])
+				if strings.HasPrefix(rhsName, receiverName+".") {
+					candidates[ident.Name+suffix] = true
+				}
+			}
+		}
+		return true
+	})
+
+	for candidate := range candidates {
+		if functionBodyUsesWaitGroupName(fn.Body, candidate) {
+			return candidate
+		}
+	}
+	return ""
+}
+
+func functionBodyUsesWaitGroupName(body *ast.BlockStmt, wgName string) bool {
+	found := false
+	ast.Inspect(body, func(n ast.Node) bool {
+		if found {
+			return false
+		}
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		if common.GetVarName(sel.X) == wgName && (sel.Sel.Name == "Add" || sel.Sel.Name == "Done" || sel.Sel.Name == "Wait" || sel.Sel.Name == "Go") {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
 }
 
 func calleeWaitGroupNameForArg(arg ast.Expr, wgName string, field *ast.Field, fieldIndex int) (string, bool) {

--- a/pkg/analyzer/internal/waitgroup/balance.go
+++ b/pkg/analyzer/internal/waitgroup/balance.go
@@ -307,7 +307,61 @@ func (b *balanceValidator) addCoveredByVariableDoneLoop(addPos token.Pos, wgName
 		}
 		return true
 	})
+	if found {
+		return true
+	}
+	found = b.addLoopCoveredByFollowingVariableDoneWorker(b.function.Body.List, addPos, wgName)
 	return found
+}
+
+func (b *balanceValidator) addLoopCoveredByFollowingVariableDoneWorker(stmts []ast.Stmt, addPos token.Pos, wgName string) bool {
+	for i, stmt := range stmts {
+		switch s := stmt.(type) {
+		case *ast.ForStmt:
+			if nodeContainsPos(s.Body, addPos) {
+				return b.laterStatementsHaveVariableDoneWorker(stmts[i+1:], wgName)
+			}
+			if b.addLoopCoveredByFollowingVariableDoneWorker(s.Body.List, addPos, wgName) {
+				return true
+			}
+		case *ast.RangeStmt:
+			if nodeContainsPos(s.Body, addPos) {
+				return b.laterStatementsHaveVariableDoneWorker(stmts[i+1:], wgName)
+			}
+			if b.addLoopCoveredByFollowingVariableDoneWorker(s.Body.List, addPos, wgName) {
+				return true
+			}
+		case *ast.BlockStmt:
+			if b.addLoopCoveredByFollowingVariableDoneWorker(s.List, addPos, wgName) {
+				return true
+			}
+		case *ast.IfStmt:
+			if b.addLoopCoveredByFollowingVariableDoneWorker(s.Body.List, addPos, wgName) {
+				return true
+			}
+			if block, ok := s.Else.(*ast.BlockStmt); ok && b.addLoopCoveredByFollowingVariableDoneWorker(block.List, addPos, wgName) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (b *balanceValidator) laterStatementsHaveVariableDoneWorker(stmts []ast.Stmt, wgName string) bool {
+	for _, stmt := range stmts {
+		goStmt, ok := stmt.(*ast.GoStmt)
+		if !ok {
+			continue
+		}
+		fnLit, ok := goStmt.Call.Fun.(*ast.FuncLit)
+		if !ok || fnLit.Body == nil {
+			continue
+		}
+		if b.blockHasVariableDoneLoop(fnLit.Body, wgName) {
+			return true
+		}
+	}
+	return false
 }
 
 func (b *balanceValidator) loopBodyHasVariableDoneWorker(body *ast.BlockStmt, after token.Pos, wgName string) bool {

--- a/pkg/analyzer/internal/waitgroup/iteration.go
+++ b/pkg/analyzer/internal/waitgroup/iteration.go
@@ -182,6 +182,9 @@ func (e *iterationEstimator) collectCollectionLengthsBefore(stmts []ast.Stmt, be
 		case *ast.ForStmt:
 			iterations, ok := e.estimateForIterationsKnown(s)
 			if !ok || s.Body == nil {
+				if s.Body != nil {
+					e.invalidateIndexedCollectionLengthsInStatements(s.Body.List, lengths, known)
+				}
 				continue
 			}
 			if !e.collectCollectionLengthsBefore(s.Body.List, before, multiplier*iterations, lengths, known) {
@@ -190,6 +193,9 @@ func (e *iterationEstimator) collectCollectionLengthsBefore(stmts []ast.Stmt, be
 		case *ast.RangeStmt:
 			iterations, ok := e.estimateRangeIterationsKnown(s)
 			if !ok || s.Body == nil {
+				if s.Body != nil {
+					e.invalidateIndexedCollectionLengthsInStatements(s.Body.List, lengths, known)
+				}
 				continue
 			}
 			if !e.collectCollectionLengthsBefore(s.Body.List, before, multiplier*iterations, lengths, known) {
@@ -231,10 +237,29 @@ func (e *iterationEstimator) recordCollectionDeclLengths(stmt *ast.DeclStmt, len
 	}
 }
 
+func (e *iterationEstimator) invalidateIndexedCollectionLengthsInStatements(stmts []ast.Stmt, lengths map[string]int, known map[string]bool) {
+	for _, stmt := range stmts {
+		ast.Inspect(stmt, func(n ast.Node) bool {
+			assign, ok := n.(*ast.AssignStmt)
+			if !ok {
+				return true
+			}
+			for _, lhs := range assign.Lhs {
+				e.invalidateIndexedCollectionLength(lhs, lengths, known)
+			}
+			return true
+		})
+	}
+}
+
 func (e *iterationEstimator) recordCollectionAssignLengths(stmt *ast.AssignStmt, multiplier int, lengths map[string]int, known map[string]bool) {
 	for i, lhs := range stmt.Lhs {
 		ident, ok := lhs.(*ast.Ident)
-		if !ok || i >= len(stmt.Rhs) {
+		if !ok {
+			e.invalidateIndexedCollectionLength(lhs, lengths, known)
+			continue
+		}
+		if i >= len(stmt.Rhs) {
 			continue
 		}
 		if e.recordAppendLength(ident.Name, stmt.Rhs[i], multiplier, lengths, known) {
@@ -242,6 +267,25 @@ func (e *iterationEstimator) recordCollectionAssignLengths(stmt *ast.AssignStmt,
 		}
 		e.setCollectionLength(ident.Name, stmt.Rhs[i], lengths, known)
 	}
+}
+
+func (e *iterationEstimator) invalidateIndexedCollectionLength(lhs ast.Expr, lengths map[string]int, known map[string]bool) {
+	var target ast.Expr
+	switch expr := lhs.(type) {
+	case *ast.IndexExpr:
+		target = expr.X
+	case *ast.IndexListExpr:
+		target = expr.X
+	default:
+		return
+	}
+
+	ident, ok := target.(*ast.Ident)
+	if !ok {
+		return
+	}
+	delete(lengths, ident.Name)
+	delete(known, ident.Name)
 }
 
 func (e *iterationEstimator) setCollectionLength(name string, expr ast.Expr, lengths map[string]int, known map[string]bool) {

--- a/pkg/analyzer/testdata/src/mutex/mutex_extended_cases.go
+++ b/pkg/analyzer/testdata/src/mutex/mutex_extended_cases.go
@@ -1494,6 +1494,176 @@ func (e *closeLockedEngine) closeLocked() {
 	e.mu.Unlock()
 }
 
+type closeLockedEngineWithStopper struct {
+	mu         sync.Mutex
+	stopper    closeLockedStopper
+	historian  closeLockedCloseable
+	conns      closeLockedCloseable
+	tables     map[string]int
+	notifiers  map[string]int
+	lastChange int
+	isOpen     bool
+}
+
+type closeLockedStopper struct{}
+type closeLockedCloseable struct{}
+
+func (closeLockedStopper) Stop()    {}
+func (closeLockedCloseable) Close() {}
+
+func (e *closeLockedEngineWithStopper) GoodCloseTransfersUnlockToCloseLockedWithWorker() {
+	e.mu.Lock()
+	if !e.isOpen {
+		e.mu.Unlock()
+		return
+	}
+
+	e.closeLockedWithWorker()
+}
+
+func (e *closeLockedEngineWithStopper) closeLockedWithWorker() {
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		e.stopper.Stop()
+	})
+	e.historian.Close()
+	e.conns.Close()
+
+	e.tables = make(map[string]int)
+	e.lastChange = 0
+	e.notifiers = make(map[string]int)
+	e.isOpen = false
+	e.mu.Unlock()
+	wg.Wait()
+}
+
+func GoodCloseLockedCalledInsideGoroutineAfterLock(e *closeLockedEngineWithStopper, finished chan bool) {
+	go func() {
+		e.mu.Lock()
+		waitForCloseTick()
+		e.closeLockedWithWorker()
+		finished <- true
+	}()
+}
+
+func waitForCloseTick() {}
+
+type conditionalLockHeldStream struct {
+	mu      sync.Mutex
+	enabled bool
+	limit   int
+}
+
+func (s *conditionalLockHeldStream) GoodConditionalFlagGuardedUnlock(events []int) {
+	lockHeld := false
+	inTransaction := false
+	accumulatedSize := 0
+
+	defer func() {
+		if lockHeld {
+			s.mu.Unlock()
+			lockHeld = false
+		}
+	}()
+
+	for _, event := range events {
+		if event == 0 {
+			inTransaction = false
+			accumulatedSize = 0
+			if s.enabled && lockHeld {
+				s.mu.Unlock()
+				lockHeld = false
+			}
+			continue
+		}
+
+		inTransaction = true
+		accumulatedSize += event
+		if s.enabled && inTransaction && !lockHeld && accumulatedSize > s.limit {
+			s.mu.Lock()
+			lockHeld = true
+		}
+	}
+}
+
+type conditionalStreamRunner struct{}
+
+func (conditionalStreamRunner) Stream(callback func([]int) error) error {
+	return callback([]int{1, 2, 0})
+}
+
+func (s *conditionalLockHeldStream) GoodConditionalFlagGuardedUnlockInCallback(runner conditionalStreamRunner) error {
+	for {
+		lockHeld := false
+		inTransaction := false
+		accumulatedSize := 0
+
+		defer func() {
+			if lockHeld {
+				s.mu.Unlock()
+				lockHeld = false
+			}
+		}()
+
+		if err := runner.Stream(func(events []int) error {
+			for _, event := range events {
+				if event == 0 {
+					inTransaction = false
+					accumulatedSize = 0
+					if s.enabled && lockHeld {
+						s.mu.Unlock()
+						lockHeld = false
+					}
+					continue
+				}
+
+				inTransaction = true
+				accumulatedSize += event
+				if s.enabled && inTransaction && !lockHeld && accumulatedSize > s.limit {
+					s.mu.Lock()
+					lockHeld = true
+					handleConditionalChunk()
+				}
+				if s.enabled && lockHeld && !inTransaction {
+					s.mu.Unlock()
+					lockHeld = false
+				}
+			}
+			return nil
+		}); err != nil {
+			return err
+		}
+		return nil
+	}
+}
+
+func handleConditionalChunk() {}
+
+var setupReturnedCleanupMu sync.Mutex
+
+func cleanupReturnedFromSetup() {
+	setupReturnedCleanupMu.Unlock()
+}
+
+func setupReturnsCleanup(ok bool) (func(), int) {
+	if !ok {
+		return nil, 1
+	}
+
+	setupReturnedCleanupMu.Lock()
+	return cleanupReturnedFromSetup, 0
+}
+
+func GoodSetupReturnsCleanupFunction(ok bool) int {
+	cleanup, ret := setupReturnsCleanup(ok)
+	if ret > 0 {
+		return ret
+	}
+
+	defer cleanup()
+	return 0
+}
+
 func decodeFP() error   { return nil }
 func mustPanicFP() bool { return false }
 

--- a/pkg/analyzer/testdata/src/mutex/rwmutex_cases.go
+++ b/pkg/analyzer/testdata/src/mutex/rwmutex_cases.go
@@ -303,6 +303,44 @@ func GoodRWMutexCorrectWriteAPI() {
 	mu.Unlock()
 }
 
+type delegatedRWUnlockShard struct {
+	mu    sync.RWMutex
+	qlen  int
+	qsize int
+}
+
+type delegatedRWUnlockStore struct{}
+
+func (s *delegatedRWUnlockStore) setEntry(shard *delegatedRWUnlockShard, cost int) {
+	if cost > shard.qsize {
+		shard.mu.Unlock()
+		return
+	}
+
+	shard.qlen += cost
+	s.processDeque(shard)
+}
+
+func (s *delegatedRWUnlockStore) processDeque(shard *delegatedRWUnlockShard) {
+	if shard.qlen <= shard.qsize {
+		shard.mu.Unlock()
+		return
+	}
+
+	shard.qlen = shard.qsize
+	shard.mu.Unlock()
+}
+
+func (s *delegatedRWUnlockStore) GoodRWMutexWriteUnlockDelegatedThroughHelpers(shard *delegatedRWUnlockShard, exists bool, cost int) {
+	shard.mu.Lock()
+	if exists {
+		shard.mu.Unlock()
+		return
+	}
+
+	s.setEntry(shard, cost)
+}
+
 type oneWayLatchPendingResult struct {
 	executing sync.RWMutex
 }
@@ -315,25 +353,106 @@ func (r *oneWayLatchPendingResult) GoodBroadcastUnlocksCreateLock() {
 	r.executing.Unlock()
 }
 
-func (r *oneWayLatchPendingResult) BadWaitUsesReadLockAsOneWayLatch() {
-	r.executing.RLock() // want "rwmutex 'r.executing' is rlocked but not runlocked"
+func (r *oneWayLatchPendingResult) GoodWaitUsesReadLockAsOneWayLatch() {
+	r.executing.RLock()
+}
+
+// Boundary cases: the one-way latch/barrier heuristics must only suppress when a
+// sibling method on the same type actually releases the field. A method whose
+// name merely matches the hints, with no releasing sibling, must still report.
+type lonelyOneWayLatch struct {
+	gate    sync.RWMutex
+	barrier sync.Mutex
+}
+
+func (l *lonelyOneWayLatch) WorkerLoopNeverRunlocks() {
+	l.gate.RLock() // want "rwmutex 'l.gate' is rlocked but not runlocked"
+}
+
+func (l *lonelyOneWayLatch) StartProcessingNeverUnlocks() {
+	l.barrier.Lock() // want "mutex 'l.barrier' is locked but not unlocked"
+}
+
+type nonTrivialConsolidator struct {
+	mu      sync.Mutex
+	queries map[string]*nonTrivialPendingResult
+}
+
+type nonTrivialPendingResult struct {
+	executing    sync.RWMutex
+	consolidator *nonTrivialConsolidator
+	query        string
+}
+
+func (co *nonTrivialConsolidator) GoodCreateLocksPendingResultUntilBroadcast(query string) (*nonTrivialPendingResult, bool) {
+	co.mu.Lock()
+	defer co.mu.Unlock()
+
+	if r, ok := co.queries[query]; ok {
+		return r, false
+	}
+
+	r := &nonTrivialPendingResult{consolidator: co, query: query}
+	r.executing.Lock()
+	co.queries[query] = r
+	return r, true
+}
+
+func (r *nonTrivialPendingResult) GoodBroadcastUnlocksPendingResult() {
+	r.consolidator.mu.Lock()
+	defer r.consolidator.mu.Unlock()
+
+	delete(r.consolidator.queries, r.query)
+	r.executing.Unlock()
 }
 
 type crossMethodBarrier struct {
-	lock sync.RWMutex
+	lock    sync.RWMutex
+	wg      sync.WaitGroup
+	threads []crossMethodBarrierThread
+	count   int
+}
+
+type crossMethodBarrierThread struct {
+	parent *crossMethodBarrier
+	index  int
 }
 
 func (b *crossMethodBarrier) GoodCreateThreadsHoldsBarrier() {
 	b.lock.Lock()
+
+	logBarrierEvent("starting")
+	for i := range b.threads {
+		b.wg.Add(1)
+		go b.threads[i].GoodClientLoopUsesReadLockAsOneWayStartGate()
+	}
+
+	logBarrierEvent("waiting")
+	b.wg.Wait()
+	b.wg.Add(len(b.threads))
 }
 
 func (b *crossMethodBarrier) GoodRunTestReleasesBarrier() {
+	logBarrierEvent("running")
 	b.lock.Unlock()
+
+	b.wg.Wait()
 }
 
-func (b *crossMethodBarrier) BadWorkerNeverReleasesReadBarrier() {
-	b.lock.RLock() // want "rwmutex 'b.lock' is rlocked but not runlocked"
+func (bt *crossMethodBarrierThread) GoodClientLoopUsesReadLockAsOneWayStartGate() {
+	b := bt.parent
+
+	b.wg.Done()
+	logBarrierEvent("waiting for barrier")
+	b.lock.RLock()
+	logBarrierEvent("started")
+
+	for i := 0; i < b.count; i++ {
+		_ = i + bt.index
+	}
 }
+
+func logBarrierEvent(string) {}
 
 // Double unlocks (runlock twice)
 func BadRWDoubleRUnlock() {

--- a/pkg/analyzer/testdata/src/waitgroup/waitgroup_extended_cases.go
+++ b/pkg/analyzer/testdata/src/waitgroup/waitgroup_extended_cases.go
@@ -598,6 +598,41 @@ func (h *HandlerLike) Start() {
 	h.startWG.Done()
 }
 
+type workerSliceLifecycle struct {
+	wg      sync.WaitGroup
+	started chan struct{}
+	workers []workerSliceLifecycleThread
+}
+
+type workerSliceLifecycleThread struct {
+	parent *workerSliceLifecycle
+}
+
+func (b *workerSliceLifecycle) GoodAddInLoopDoneInIndexedWorkerMethod() {
+	b.started = make(chan struct{})
+
+	for i := range b.workers {
+		b.wg.Add(1)
+		go b.workers[i].run()
+	}
+
+	b.wg.Wait()
+	b.wg.Add(len(b.workers))
+}
+
+func (b *workerSliceLifecycle) GoodReleaseWorkersAndWaitForSecondPhase() {
+	close(b.started)
+	b.wg.Wait()
+}
+
+func (w *workerSliceLifecycleThread) run() {
+	parent := w.parent
+
+	parent.wg.Done()
+	<-parent.started
+	parent.wg.Done()
+}
+
 // Good: a WaitGroup field whose lifecycle is balanced through returned closers.
 func GoodWaitGroupLifecycleManagedByCloser() {
 	var owner readerLifecycleOwner

--- a/pkg/analyzer/testdata/src/waitgroup/waitgroup_goroutine_cases.go
+++ b/pkg/analyzer/testdata/src/waitgroup/waitgroup_goroutine_cases.go
@@ -681,6 +681,177 @@ func GoodAddDonePairedInsideRangeOverAssignedSlice(items []int, err error) {
 	wg.Wait()
 }
 
+type deferredClosureBenchmark struct {
+	wg         sync.WaitGroup
+	concurrent deferredClosureAtomic
+	trace      []int
+}
+
+type deferredClosureAtomic struct{}
+
+func (deferredClosureAtomic) Add(delta int) int {
+	return delta
+}
+
+func (b *deferredClosureBenchmark) displayProgress(done <-chan struct{}, total int) {
+	select {
+	case <-done:
+		return
+	default:
+		_ = total
+		return
+	}
+}
+
+func (b *deferredClosureBenchmark) GoodAddLenDoneInDeferredWorkerClosure(fallback []int) {
+	trace := b.trace
+	if len(trace) == 0 {
+		trace = fallback
+	}
+
+	done := make(chan struct{})
+	go b.displayProgress(done, len(trace))
+
+	b.wg.Add(len(trace))
+
+	for _, req := range trace {
+		go func(req int) {
+			b.concurrent.Add(1)
+			defer func() {
+				b.concurrent.Add(-1)
+				b.wg.Done()
+			}()
+
+			_ = req
+		}(req)
+	}
+
+	b.wg.Wait()
+	close(done)
+}
+
+type keyspaceSetLike map[string]bool
+
+func newKeyspaceSetLike(values ...string) keyspaceSetLike {
+	set := keyspaceSetLike{}
+	for _, value := range values {
+		set[value] = true
+	}
+	return set
+}
+
+func (s keyspaceSetLike) Insert(value string) {
+	s[value] = true
+}
+
+func (s keyspaceSetLike) Len() int {
+	return len(s)
+}
+
+func (s keyspaceSetLike) Intersection(other keyspaceSetLike) keyspaceSetLike {
+	result := keyspaceSetLike{}
+	for value := range s {
+		if other[value] {
+			result[value] = true
+		}
+	}
+	return result
+}
+
+type keyspaceClusterLike struct {
+	missing bool
+}
+
+type keyspaceInfoLike struct {
+	Shards []keyspaceShardLike
+}
+
+type keyspaceShardLike struct {
+	Name string
+}
+
+func (c *keyspaceClusterLike) GetKeyspace(name string) (*keyspaceInfoLike, error) {
+	if c.missing && name == "" {
+		return nil, context.Canceled
+	}
+	return &keyspaceInfoLike{Shards: []keyspaceShardLike{{Name: name}}}, nil
+}
+
+type keyspaceErrorRecorderLike struct{}
+
+func (keyspaceErrorRecorderLike) RecordError(error) {}
+
+func GoodLoopAddsWorkersWithDeferredDoneAndMapLock(cluster *keyspaceClusterLike, results map[string]keyspaceSetLike) {
+	var (
+		mu  sync.Mutex
+		wg  sync.WaitGroup
+		rec keyspaceErrorRecorderLike
+	)
+
+	mu.Lock()
+	for key, values := range results {
+		wg.Add(1)
+
+		go func(key string, values keyspaceSetLike) {
+			defer wg.Done()
+
+			keyspace, err := cluster.GetKeyspace(key)
+			if err != nil {
+				if key == "" {
+					mu.Lock()
+					defer mu.Unlock()
+					delete(results, key)
+					return
+				}
+				rec.RecordError(err)
+				return
+			}
+
+			fullSet := newKeyspaceSetLike()
+			for _, shard := range keyspace.Shards {
+				fullSet.Insert(shard.Name)
+			}
+
+			if values.Len() == 0 {
+				mu.Lock()
+				defer mu.Unlock()
+				results[key] = fullSet
+				return
+			}
+
+			overlap := values.Intersection(fullSet)
+			mu.Lock()
+			defer mu.Unlock()
+			results[key] = overlap
+		}(key, values)
+	}
+	mu.Unlock()
+
+	wg.Wait()
+}
+
+func GoodLoopAddsWorkersAfterMapIndexPopulation(keys []string) {
+	results := map[string]keyspaceSetLike{}
+	for _, key := range keys {
+		if _, ok := results[key]; !ok {
+			results[key] = newKeyspaceSetLike("primary")
+			continue
+		}
+		results[key].Insert("replica")
+	}
+
+	var wg sync.WaitGroup
+	for key, values := range results {
+		wg.Add(1)
+		go func(key string, values keyspaceSetLike) {
+			defer wg.Done()
+			_ = values.Len()
+			_ = key
+		}(key, values)
+	}
+	wg.Wait()
+}
+
 // Cancellation via close() of a local channel: `case <-chClose` drains when
 // the channel is closed, equivalent to `<-ctx.Done()` for context cancellation.
 func GoodWorkerDoneOnCloseOfLocalChannel() {


### PR DESCRIPTION
…terns

Recognize one-way read latches / write barriers, conditional flag-guarded unlocks, unlocks delegated through helpers, cleanup funcs returned to the caller, and Add-in-loop/Done-in-worker waitgroup patterns over slices.

perf: build package-wide state (receiver index, function list, lifecycle caches) once per pass instead of per function, and memoize per-function AST scans, fixing an O(F^2) blowup that timed out on large packages.