### PR TITLE
feat: detect sync.Once misuse (re-entrant Do, Do(nil))

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -23,6 +23,7 @@ analyzer.Analyzer  ── umbrella: owns no logic, re-emits child diagnostics
         │ Requires
         ├─ mutex.SubAnalyzer      ─┐
         ├─ waitgroup.SubAnalyzer  ─┤  each returns []analysis.Diagnostic as its Result
+        ├─ once.SubAnalyzer       ─┤
         └─ copycheck.Analyzer     ─┘
                                    │  and depends on shared "foundation" analyzers
         foundation (run once per package, shared via pass.ResultOf):
@@ -38,9 +39,10 @@ Why this shape:
   every check would otherwise repeat. Declaring them in `Requires` means
   `go/analysis` runs each one *once per package* and hands the cached `Result` to
   every consumer. That is DRY enforced by the framework.
-- **Each check is an independent sub-analyzer.** `mutex`, `waitgroup` and
-  `copycheck` know nothing about each other. Adding a fourth primitive later
-  (`sync.Once`, `errgroup`…) is a new sibling, not a patch to existing code.
+- **Each check is an independent sub-analyzer.** `mutex`, `waitgroup`, `once`
+  and `copycheck` know nothing about each other. Adding the next primitive
+  (`errgroup`, `atomic`…) is a new sibling, not a patch to existing code —
+  `once` landed exactly this way.
 - **Only the umbrella reports.** Sub-analyzers return their diagnostics as a
   `Result` ([]analysis.Diagnostic) instead of calling `pass.Report`. The umbrella
   collects those slices and re-emits them. This keeps the whole graph observable
@@ -50,9 +52,10 @@ Why this shape:
 
 | Analyzer | Requires | Result |
 |---|---|---|
-| `analyzer.Analyzer` (umbrella) | `mutex`, `waitgroup`, `copycheck` | — (calls `pass.Report`) |
+| `analyzer.Analyzer` (umbrella) | `mutex`, `waitgroup`, `once`, `copycheck` | — (calls `pass.Report`) |
 | `mutex.SubAnalyzer` | `inspect`, `primitives`, `filesetup` | `[]analysis.Diagnostic` |
 | `waitgroup.SubAnalyzer` | `inspect`, `primitives`, `filesetup` | `[]analysis.Diagnostic` |
+| `once.SubAnalyzer` | `inspect`, `primitives`, `filesetup` | `[]analysis.Diagnostic` |
 | `copycheck.Analyzer` | `inspect`, `filesetup` | `[]analysis.Diagnostic` |
 | `primitives.Analyzer` | — (reads `pass.Pkg.Scope()`) | `*primitives.Result` |
 | `filesetup.Analyzer` | — (reads `pass.Files`) | `*filesetup.Result` |
@@ -102,8 +105,9 @@ Tracing `lock-without-unlock` for `mu.Lock()` with no matching `Unlock()`:
    `pass.ResultOf[mutex.SubAnalyzer]` and re-emits each diagnostic via
    `pass.Report`.
 
-`waitgroup` follows the exact same steps 1–4 and 8–9. Only the engine in step 5–7
-differs (see below).
+`waitgroup` and `once` follow the exact same steps 1–4 and 8–9. Only the engine
+in step 5–7 differs (see below); `once` is the smallest of the three — a single
+walk that resolves each `Do` argument and scans it for re-entrant calls.
 
 ### Direct path — `copycheck`
 
@@ -171,6 +175,7 @@ come from?" friction.
 | [`internal/filesetup`](pkg/analyzer/internal/filesetup) | Generated-file detection + per-file comment filters |
 | [`internal/mutex`](pkg/analyzer/internal/mutex) | Mutex / RWMutex engine + collaborators |
 | [`internal/waitgroup`](pkg/analyzer/internal/waitgroup) | WaitGroup engine + collaborators |
+| [`internal/once`](pkg/analyzer/internal/once) | sync.Once checks (re-entrant Do, Do(nil)) |
 | [`internal/copycheck`](pkg/analyzer/internal/copycheck) | Copy-by-value detection |
 | [`internal/common`](pkg/analyzer/internal/common) | Shared AST/type helpers (`IsMutex`, `GetVarName`…) |
 | [`internal/common/category`](pkg/analyzer/internal/common/category) | Stable category IDs (one per check) |

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 </p>
 
 <p align="center">
-  <b>A static analyzer for Go that catches common concurrency mistakes around <code>sync.Mutex</code>, <code>sync.RWMutex</code>, and <code>sync.WaitGroup</code> — before they reach production.</b>
+  <b>A static analyzer for Go that catches common concurrency mistakes around <code>sync.Mutex</code>, <code>sync.RWMutex</code>, <code>sync.WaitGroup</code>, and <code>sync.Once</code> — before they reach production.</b>
 </p>
 
 ---
@@ -111,7 +111,9 @@ Because the tool is a standard `go/analysis` single-checker, it accepts the usua
 | `defer-unlock-in-loop` | `sync.Mutex`, `sync.RWMutex` | `defer mu.Unlock()` lives inside a loop body, so the unlock only runs at function return. |
 | `double-lock` | `sync.Mutex`, `sync.RWMutex` | A second `Lock()` is taken while the first is still held (or a write `Lock()` while a read lock is held). |
 | `lock-order-cycle` | `sync.Mutex`, `sync.RWMutex` | Two functions acquire the same pair of mutexes in opposite orders — classic deadlock pattern. |
-| `sync-primitive-copy` | all | A `sync.Mutex`, `sync.RWMutex` or `sync.WaitGroup` (or a struct embedding one) is copied by value. |
+| `once-do-deadlock` | `sync.Once` | `once.Do(f)` where `f` calls `Do` on the same `Once` again — `sync.Once.Do` is not reentrant, so this deadlocks. |
+| `once-do-nil` | `sync.Once` | `once.Do(nil)` panics when the function is invoked. |
+| `sync-primitive-copy` | all | A `sync.Mutex`, `sync.RWMutex`, `sync.WaitGroup` or `sync.Once` (or a struct embedding one) is copied by value. |
 
 All checks above also fire on package-scoped primitives declared in any file of the same package — there is no separate ID for that case; the diagnostic carries the same category as the in-function variant.
 
@@ -200,14 +202,15 @@ More representative cases live under [`pkg/analyzer/testdata/src`](pkg/analyzer/
 
 ## How It Works
 
-`goconcurrencylint` is an umbrella `go/analysis` analyzer composed of three
+`goconcurrencylint` is an umbrella `go/analysis` analyzer composed of four
 independent sub-analyzers, wired together through the standard `Requires` graph:
 
 - **Mutex analyzer** — tracks `lock`, `rlock`, `borrowed lock`, and `defer unlock` counters per function, visiting each control-flow node and reconciling state at join points. Final state is validated at function exit.
 - **WaitGroup analyzer** — collects every `Add`, `Done`, `Wait`, and `Go` call with its position, builds a reachability map for calls inside goroutines, and validates the balance along every path. Calls that escape the function scope are intentionally excluded to minimize false positives.
-- **Copy analyzer** — flags any `sync.Mutex`, `sync.RWMutex` or `sync.WaitGroup` (or a struct embedding one) copied by value.
+- **Once analyzer** — resolves the function passed to `once.Do` (literal, named function, or method value) and reports re-entrant `Do` calls that deadlock, plus `Do(nil)` calls that panic.
+- **Copy analyzer** — flags any `sync.Mutex`, `sync.RWMutex`, `sync.WaitGroup` or `sync.Once` (or a struct embedding one) copied by value.
 
-Two foundation analyzers run once per package and share their results with the sub-analyzers: one discovers `sync` primitive declarations, the other identifies generated files and builds the comment filters behind `// goconcurrencylint:ignore`. All checks also share helpers for type detection (`IsMutex`, `IsRWMutex`, `IsWaitGroup`) and deterministic, deduplicated error reporting.
+Two foundation analyzers run once per package and share their results with the sub-analyzers: one discovers `sync` primitive declarations, the other identifies generated files and builds the comment filters behind `// goconcurrencylint:ignore`. All checks also share helpers for type detection (`IsMutex`, `IsRWMutex`, `IsWaitGroup`, `IsOnce`) and deterministic, deduplicated error reporting.
 
 For a contributor-level map of the analyzer graph and the journey of a single diagnostic, see [ARCHITECTURE.md](ARCHITECTURE.md).
 

--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -12,8 +12,8 @@
 //	│
 //	├── mutex.SubAnalyzer ──────┐
 //	├── waitgroup.SubAnalyzer ──┤── requires primitives.Analyzer ─┐
-//	└── copycheck.Analyzer ─────┴── requires filesetup.Analyzer   │
-//	                                                              └── requires inspect.Analyzer
+//	├── once.SubAnalyzer ───────┤── requires filesetup.Analyzer   │
+//	└── copycheck.Analyzer ─────┘                                 └── requires inspect.Analyzer
 //
 // "A requires B" means B runs first and exposes its Result through
 // pass.ResultOf[B]. Each sub-analyzer returns its diagnostic slice as a
@@ -25,17 +25,19 @@ package analyzer
 import (
 	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/internal/copycheck"
 	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/internal/mutex"
+	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/internal/once"
 	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/internal/waitgroup"
 	"golang.org/x/tools/go/analysis"
 )
 
 var Analyzer = &analysis.Analyzer{
 	Name: "goconcurrencylint",
-	Doc:  "Detects misuse of sync.Mutex, sync.RWMutex and sync.WaitGroup, plus copy-by-value of sync primitives.",
+	Doc:  "Detects misuse of sync.Mutex, sync.RWMutex, sync.WaitGroup and sync.Once, plus copy-by-value of sync primitives.",
 	Run:  run,
 	Requires: []*analysis.Analyzer{
 		mutex.SubAnalyzer,
 		waitgroup.SubAnalyzer,
+		once.SubAnalyzer,
 		copycheck.Analyzer,
 	},
 }
@@ -44,6 +46,7 @@ func run(pass *analysis.Pass) (any, error) {
 	subs := []*analysis.Analyzer{
 		mutex.SubAnalyzer,
 		waitgroup.SubAnalyzer,
+		once.SubAnalyzer,
 		copycheck.Analyzer,
 	}
 	for _, sub := range subs {

--- a/pkg/analyzer/analyzer_integration_test.go
+++ b/pkg/analyzer/analyzer_integration_test.go
@@ -12,6 +12,7 @@ func TestAnalyzerFixtures(t *testing.T) {
 	}{
 		{name: "mutex", packages: []string{"mutex"}},
 		{name: "waitgroup", packages: []string{"waitgroup"}},
+		{name: "once", packages: []string{"once"}},
 		{name: "packagelevel", packages: []string{"packagelevel"}},
 		{name: "ignoredirective", packages: []string{"ignoredirective"}},
 		{name: "generated", packages: []string{"generated"}},

--- a/pkg/analyzer/internal/common/category/category.go
+++ b/pkg/analyzer/internal/common/category/category.go
@@ -45,6 +45,10 @@ const (
 	DoneOutsideGoroutine    Category = "done-outside-goroutine"
 	GoPanic                 Category = "go-panic"
 	SyncPrimitiveCopy       Category = "sync-primitive-copy"
+
+	// sync.Once checks.
+	OnceDoDeadlock Category = "once-do-deadlock"
+	OnceDoNil      Category = "once-do-nil"
 )
 
 // All returns every known check category. Order is not significant.
@@ -78,6 +82,8 @@ func All() []Category {
 		DoneOutsideGoroutine,
 		GoPanic,
 		SyncPrimitiveCopy,
+		OnceDoDeadlock,
+		OnceDoNil,
 	}
 }
 

--- a/pkg/analyzer/internal/common/common.go
+++ b/pkg/analyzer/internal/common/common.go
@@ -51,6 +51,12 @@ func IsWaitGroup(typ types.Type) bool {
 	return MatchesPkgAndName(typ, "sync", "WaitGroup")
 }
 
+// IsOnce returns true if the given type is sync.Once or *sync.Once.
+func IsOnce(typ types.Type) bool {
+	typ = DerefOnce(typ)
+	return MatchesPkgAndName(typ, "sync", "Once")
+}
+
 // MatchesPkgAndName reports whether typ is a named type declared in pkg
 // whose name matches any of names.
 //

--- a/pkg/analyzer/internal/common/typeresolve.go
+++ b/pkg/analyzer/internal/common/typeresolve.go
@@ -1,0 +1,86 @@
+package common
+
+import (
+	"go/ast"
+	"go/types"
+)
+
+// BuildReceiverMethodMap indexes every method declaration in files by receiver
+// type name and then method name, so callers can resolve a method value
+// (x.method) to its *ast.FuncDecl.
+//
+// Generated files are indexed too, so sibling-method lookups that cross the
+// generated boundary (e.g. wrapper Lock/Unlock pairs) still resolve.
+func BuildReceiverMethodMap(files []*ast.File) map[string]map[string]*ast.FuncDecl {
+	methods := make(map[string]map[string]*ast.FuncDecl)
+
+	for _, file := range files {
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Body == nil || fn.Recv == nil {
+				continue
+			}
+
+			receiverType := ReceiverTypeName(fn)
+			if receiverType == "" {
+				continue
+			}
+
+			if methods[receiverType] == nil {
+				methods[receiverType] = make(map[string]*ast.FuncDecl)
+			}
+			methods[receiverType][fn.Name.Name] = fn
+		}
+	}
+
+	return methods
+}
+
+// ReceiverTypeName returns the base type name of fn's receiver (e.g. "Foo" for
+// both "func (s Foo)" and "func (s *Foo[T])"), or "" when fn has no receiver.
+func ReceiverTypeName(fn *ast.FuncDecl) string {
+	if fn == nil || fn.Recv == nil || len(fn.Recv.List) == 0 {
+		return ""
+	}
+
+	return BaseTypeName(fn.Recv.List[0].Type)
+}
+
+// BaseTypeName reduces a type expression to its underlying type name, peeling
+// pointers and generic instantiation brackets. Returns "" for expressions that
+// do not name a type.
+func BaseTypeName(expr ast.Expr) string {
+	switch e := expr.(type) {
+	case *ast.Ident:
+		return e.Name
+	case *ast.StarExpr:
+		return BaseTypeName(e.X)
+	case *ast.IndexExpr:
+		return BaseTypeName(e.X)
+	case *ast.IndexListExpr:
+		return BaseTypeName(e.X)
+	case *ast.SelectorExpr:
+		return e.Sel.Name
+	default:
+		return ""
+	}
+}
+
+// BaseTypeNameFromType reduces a resolved type to its named-type name, peeling
+// pointers and aliases. Returns "" when typ is not (a pointer to) a named type.
+func BaseTypeNameFromType(typ types.Type) string {
+	if typ == nil {
+		return ""
+	}
+
+	switch t := types.Unalias(typ).(type) {
+	case *types.Pointer:
+		return BaseTypeNameFromType(t.Elem())
+	case *types.Named:
+		if obj := t.Obj(); obj != nil {
+			return obj.Name()
+		}
+	}
+
+	return ""
+}

--- a/pkg/analyzer/internal/copycheck/copycheck.go
+++ b/pkg/analyzer/internal/copycheck/copycheck.go
@@ -181,7 +181,7 @@ func valueKind(typ types.Type) string {
 
 func directValueKind(typ types.Type) string {
 	typ = types.Unalias(typ)
-	if match, ok := common.MatchPkgAndName(typ, "sync", "Mutex", "RWMutex", "WaitGroup"); ok {
+	if match, ok := common.MatchPkgAndName(typ, "sync", "Mutex", "RWMutex", "WaitGroup", "Once"); ok {
 		switch match {
 		case "Mutex":
 			return "mutex"
@@ -189,6 +189,8 @@ func directValueKind(typ types.Type) string {
 			return "rwmutex"
 		case "WaitGroup":
 			return "waitgroup"
+		case "Once":
+			return "once"
 		}
 	}
 	return ""

--- a/pkg/analyzer/internal/mutex/analyzer.go
+++ b/pkg/analyzer/internal/mutex/analyzer.go
@@ -87,7 +87,7 @@ type packageScope struct {
 
 func newPackageScope(files []*ast.File) *packageScope {
 	return &packageScope{
-		receiverMethods:       buildReceiverMethodMap(files),
+		receiverMethods:       common.BuildReceiverMethodMap(files),
 		functions:             collectFunctionDecls(files),
 		explicitTransferCache: make(map[*ast.BlockStmt]map[token.Pos]struct{}),
 		scanCache:             newLifecycleScanCache(),
@@ -376,7 +376,7 @@ func (c *Checker) applyLocalMethodLifecycleEffects(call *ast.CallExpr, stats map
 		return false
 	}
 
-	receiverType := baseTypeNameFromType(c.typesInfo.TypeOf(sel.X))
+	receiverType := common.BaseTypeNameFromType(c.typesInfo.TypeOf(sel.X))
 	if receiverType == "" {
 		return false
 	}

--- a/pkg/analyzer/internal/mutex/lifecycle.go
+++ b/pkg/analyzer/internal/mutex/lifecycle.go
@@ -152,7 +152,7 @@ func (l *lifecycleResolver) isReleaseFor(mutexName string, methodNames []string)
 	}
 
 	currentReceiver := common.ReceiverName(l.function)
-	currentType := receiverTypeName(l.function)
+	currentType := common.ReceiverTypeName(l.function)
 	if currentReceiver == "" || currentType == "" {
 		return false
 	}
@@ -212,7 +212,7 @@ func (l *lifecycleResolver) returnsVariableWithReleaseFor(baseVar, suffix string
 	}
 
 	for _, ident := range l.returnedIdentsNamed(l.function, baseVar) {
-		returnedType := baseTypeNameFromType(l.typesInfo.TypeOf(ident))
+		returnedType := common.BaseTypeNameFromType(l.typesInfo.TypeOf(ident))
 		if returnedType == "" {
 			continue
 		}
@@ -230,7 +230,7 @@ func (l *lifecycleResolver) functionReturningCurrentReceiverAfterAcquire(fn *ast
 	}
 
 	for _, ri := range l.returnedIdents(fn) {
-		if baseTypeNameFromType(l.typesInfo.TypeOf(ri.ident)) != currentType {
+		if common.BaseTypeNameFromType(l.typesInfo.TypeOf(ri.ident)) != currentType {
 			continue
 		}
 		if functionBodyContainsFieldCallBefore(fn.Body, ri.ident.Name+"."+path, acquireMethods, ri.ret.Pos()) {
@@ -336,7 +336,7 @@ func (l *lifecycleResolver) functionsReturningType(typeName string) []*ast.FuncD
 			}
 			if l.typesInfo != nil {
 				for _, ri := range l.returnedIdents(fn) {
-					record(baseTypeNameFromType(l.typesInfo.TypeOf(ri.ident)))
+					record(common.BaseTypeNameFromType(l.typesInfo.TypeOf(ri.ident)))
 				}
 			}
 		}
@@ -387,7 +387,7 @@ func (l *lifecycleResolver) isCallerManagedReleaseFor(mutexName string, methodNa
 
 func (l *lifecycleResolver) computeCallerManagedReleaseFor(mutexName string, methodNames []string) bool {
 	currentReceiver := common.ReceiverName(l.function)
-	currentType := receiverTypeName(l.function)
+	currentType := common.ReceiverTypeName(l.function)
 	if currentReceiver == "" || currentType == "" {
 		return false
 	}
@@ -511,7 +511,7 @@ func (l *lifecycleResolver) callTargetsCurrentMethod(call *ast.CallExpr, receive
 		return "", false
 	}
 
-	if baseTypeNameFromType(l.typesInfo.TypeOf(sel.X)) != receiverType {
+	if common.BaseTypeNameFromType(l.typesInfo.TypeOf(sel.X)) != receiverType {
 		return "", false
 	}
 
@@ -660,7 +660,7 @@ func compositeLiteralTypeName(lit *ast.CompositeLit) string {
 	if lit == nil {
 		return ""
 	}
-	return baseTypeName(lit.Type)
+	return common.BaseTypeName(lit.Type)
 }
 
 func compositeLiteralFieldVarName(lit *ast.CompositeLit, fieldName string) string {

--- a/pkg/analyzer/internal/mutex/lifecycle_test.go
+++ b/pkg/analyzer/internal/mutex/lifecycle_test.go
@@ -7,12 +7,14 @@ import (
 	"go/token"
 	"go/types"
 	"testing"
+
+	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/internal/common"
 )
 
 func buildLifecycleResolver(t *testing.T, src, receiverType, methodName string) *lifecycleResolver {
 	t.Helper()
 	file, info := parseTypedLifecycleFile(t, src)
-	rm := buildReceiverMethodMap([]*ast.File{file})
+	rm := common.BuildReceiverMethodMap([]*ast.File{file})
 	fn := rm[receiverType][methodName]
 	if fn == nil {
 		t.Fatalf("method %s.%s not found in receiver map", receiverType, methodName)

--- a/pkg/analyzer/internal/mutex/typeresolve.go
+++ b/pkg/analyzer/internal/mutex/typeresolve.go
@@ -2,39 +2,11 @@ package mutex
 
 import (
 	"go/ast"
-	"go/types"
 	"slices"
 	"strings"
 
 	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/internal/common"
 )
-
-// Indexes generated files too so sibling-method lookups (e.g. wrapper
-// Lock/Unlock pairs split across the boundary) resolve.
-func buildReceiverMethodMap(files []*ast.File) map[string]map[string]*ast.FuncDecl {
-	methods := make(map[string]map[string]*ast.FuncDecl)
-
-	for _, file := range files {
-		for _, decl := range file.Decls {
-			fn, ok := decl.(*ast.FuncDecl)
-			if !ok || fn.Body == nil || fn.Recv == nil {
-				continue
-			}
-
-			receiverType := receiverTypeName(fn)
-			if receiverType == "" {
-				continue
-			}
-
-			if methods[receiverType] == nil {
-				methods[receiverType] = make(map[string]*ast.FuncDecl)
-			}
-			methods[receiverType][fn.Name.Name] = fn
-		}
-	}
-
-	return methods
-}
 
 // Includes generated files so functionIsCallerManagedReleaseFor sees every
 // call site of the current method.
@@ -52,48 +24,6 @@ func collectFunctionDecls(files []*ast.File) []*ast.FuncDecl {
 	}
 
 	return functions
-}
-
-func receiverTypeName(fn *ast.FuncDecl) string {
-	if fn == nil || fn.Recv == nil || len(fn.Recv.List) == 0 {
-		return ""
-	}
-
-	return baseTypeName(fn.Recv.List[0].Type)
-}
-
-func baseTypeName(expr ast.Expr) string {
-	switch e := expr.(type) {
-	case *ast.Ident:
-		return e.Name
-	case *ast.StarExpr:
-		return baseTypeName(e.X)
-	case *ast.IndexExpr:
-		return baseTypeName(e.X)
-	case *ast.IndexListExpr:
-		return baseTypeName(e.X)
-	case *ast.SelectorExpr:
-		return e.Sel.Name
-	default:
-		return ""
-	}
-}
-
-func baseTypeNameFromType(typ types.Type) string {
-	if typ == nil {
-		return ""
-	}
-
-	switch t := types.Unalias(typ).(type) {
-	case *types.Pointer:
-		return baseTypeNameFromType(t.Elem())
-	case *types.Named:
-		if obj := t.Obj(); obj != nil {
-			return obj.Name()
-		}
-	}
-
-	return ""
 }
 
 func methodNameMatchesAnyHint(fnName string, hints []string) bool {

--- a/pkg/analyzer/internal/mutex/wrapper.go
+++ b/pkg/analyzer/internal/mutex/wrapper.go
@@ -169,7 +169,7 @@ func (w *wrapperResolver) currentMethodContainsFieldCall(varName string, methodN
 }
 
 func (w *wrapperResolver) siblingMethodContainsFieldCall(fieldSuffix string, siblingMethods, fieldMethods []string) bool {
-	receiverType := receiverTypeName(w.function)
+	receiverType := common.ReceiverTypeName(w.function)
 	if receiverType == "" {
 		return false
 	}
@@ -200,7 +200,7 @@ func (w *wrapperResolver) siblingMethodContainsFieldCall(fieldSuffix string, sib
 }
 
 func (w *wrapperResolver) anySiblingMethodContainsFieldCall(fieldSuffix, excludeMethod string, fieldMethods, nameHints []string) bool {
-	receiverType := receiverTypeName(w.function)
+	receiverType := common.ReceiverTypeName(w.function)
 	if receiverType == "" {
 		return false
 	}
@@ -233,7 +233,7 @@ func (w *wrapperResolver) anySiblingMethodContainsFieldCall(fieldSuffix, exclude
 }
 
 func (w *wrapperResolver) anySiblingMethodContainsFieldSuffix(fieldSuffix, excludeMethod string, fieldMethods, nameHints []string) bool {
-	receiverType := receiverTypeName(w.function)
+	receiverType := common.ReceiverTypeName(w.function)
 	if receiverType == "" {
 		return false
 	}
@@ -266,7 +266,7 @@ func (w *wrapperResolver) typeNameForBaseVar(baseVar string) string {
 		return ""
 	}
 	if baseVar == common.ReceiverName(w.function) {
-		return receiverTypeName(w.function)
+		return common.ReceiverTypeName(w.function)
 	}
 	if w.function == nil || w.function.Body == nil || w.typesInfo == nil {
 		return ""
@@ -281,7 +281,7 @@ func (w *wrapperResolver) typeNameForBaseVar(baseVar string) string {
 		if !ok || ident.Name != baseVar {
 			return true
 		}
-		found = baseTypeNameFromType(w.typesInfo.TypeOf(ident))
+		found = common.BaseTypeNameFromType(w.typesInfo.TypeOf(ident))
 		return found == ""
 	})
 	return found
@@ -308,7 +308,7 @@ func (w *wrapperResolver) isBarrierPairHalf(varName, methodName string, opposite
 }
 
 func (w *wrapperResolver) anySiblingBodyIsSingleFieldSuffixCall(fieldSuffix, excludeMethod string, methodNames []string) bool {
-	receiverType := receiverTypeName(w.function)
+	receiverType := common.ReceiverTypeName(w.function)
 	if receiverType == "" {
 		return false
 	}

--- a/pkg/analyzer/internal/mutex/wrapper_test.go
+++ b/pkg/analyzer/internal/mutex/wrapper_test.go
@@ -3,15 +3,17 @@ package mutex
 import (
 	"go/ast"
 	"testing"
+
+	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/internal/common"
 )
 
 // buildResolver parses src, indexes its receiver methods the same way the real
-// analyzer does (buildReceiverMethodMap), and returns a resolver bound to the
-// method named methodName on type receiverType.
+// analyzer does (common.BuildReceiverMethodMap), and returns a resolver bound
+// to the method named methodName on type receiverType.
 func buildResolver(t *testing.T, src, receiverType, methodName string, rawBodyEffects bool) *wrapperResolver {
 	t.Helper()
 	file, _ := parseFile(t, src)
-	rm := buildReceiverMethodMap([]*ast.File{file})
+	rm := common.BuildReceiverMethodMap([]*ast.File{file})
 	fn := rm[receiverType][methodName]
 	if fn == nil {
 		t.Fatalf("method %s.%s not found in receiver map", receiverType, methodName)

--- a/pkg/analyzer/internal/once/analyzer.go
+++ b/pkg/analyzer/internal/once/analyzer.go
@@ -1,0 +1,413 @@
+// Package once detects misuse of sync.Once.
+package once
+
+import (
+	"go/ast"
+	"go/token"
+	"go/types"
+	"strings"
+
+	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/internal/common"
+	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/internal/common/category"
+	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/internal/common/report"
+	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/internal/primitives"
+)
+
+// packageScope holds the package-wide indexes shared by every function in a
+// pass: named top-level functions and methods grouped by receiver type, used
+// to resolve the function passed to Do.
+type packageScope struct {
+	topLevelFuncs   map[string]*ast.FuncDecl
+	receiverMethods map[string]map[string]*ast.FuncDecl
+}
+
+func newPackageScope(files []*ast.File) *packageScope {
+	scope := &packageScope{
+		topLevelFuncs:   make(map[string]*ast.FuncDecl),
+		receiverMethods: common.BuildReceiverMethodMap(files),
+	}
+
+	// Only the top-level (receiverless) functions are gathered here; the
+	// receiver-method index is shared with mutex via common.
+	for _, file := range files {
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Body == nil || fn.Name == nil || fn.Recv != nil {
+				continue
+			}
+			scope.topLevelFuncs[fn.Name.Name] = fn
+		}
+	}
+
+	return scope
+}
+
+// Checker analyzes sync.Once usage within one function.
+type Checker struct {
+	pkgOnces       map[string]bool
+	errorCollector report.Reporter
+	typesInfo      *types.Info
+	scope          *packageScope
+	function       *ast.FuncDecl
+}
+
+// NewChecker creates a sync.Once checker. pkg supplies the package-scope Once
+// names: a named top-level function passed to Do can only reach those, never
+// the caller's locals.
+func NewChecker(errorCollector report.Reporter, pkg *primitives.Result, typesInfo *types.Info, scope *packageScope) *Checker {
+	return &Checker{
+		pkgOnces:       pkg.Onces,
+		errorCollector: errorCollector,
+		typesInfo:      typesInfo,
+		scope:          scope,
+	}
+}
+
+func (c *Checker) AnalyzeFunction(fn *ast.FuncDecl) {
+	c.function = fn
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || sel.Sel.Name != "Do" || len(call.Args) != 1 {
+			return true
+		}
+		// The type check keeps http.Client.Do and friends out, including
+		// when a name collides with a tracked Once.
+		if !common.IsOnce(c.typesInfo.TypeOf(sel.X)) {
+			return true
+		}
+		onceName := common.GetVarName(sel.X)
+		if onceName == "" || onceName == "?" {
+			return true
+		}
+		c.checkDoCall(call, onceName)
+		return true
+	})
+}
+
+func (c *Checker) checkDoCall(call *ast.CallExpr, onceName string) {
+	arg := common.UnwrapParenExpr(call.Args[0])
+
+	if ident, ok := arg.(*ast.Ident); ok && ident.Name == "nil" {
+		c.errorCollector.AddError(call.Pos(), category.OnceDoNil,
+			"once '"+onceName+"' Do called with nil function (panics at runtime)")
+		return
+	}
+
+	body, target := c.resolveDoArg(arg, onceName)
+	if body == nil {
+		return
+	}
+	if pos, ok := c.blockReachesDo(body, target); ok {
+		c.errorCollector.AddError(pos, category.OnceDoDeadlock,
+			"once '"+onceName+"' Do called inside its own Do function (sync.Once.Do is not reentrant and deadlocks)")
+	}
+}
+
+// resolveDoArg resolves the function passed to Do to a body to scan, together
+// with the name the same Once goes by inside that body. It returns a nil body
+// when the argument cannot be resolved within the package.
+func (c *Checker) resolveDoArg(arg ast.Expr, onceName string) (*ast.BlockStmt, string) {
+	switch fn := arg.(type) {
+	case *ast.FuncLit:
+		// A literal closes over the caller's scope: same name, same Once.
+		return fn.Body, onceName
+
+	case *ast.Ident:
+		// A local `f := func() {...}` also closes over the caller's scope.
+		if lit := c.localFunctionLiteral(fn.Name); lit != nil {
+			return lit.Body, onceName
+		}
+		// A named top-level function can only reach package-level Onces.
+		if c.pkgOnces[onceName] {
+			if decl := c.scope.topLevelFuncs[fn.Name]; decl != nil {
+				return decl.Body, onceName
+			}
+		}
+
+	case *ast.SelectorExpr:
+		// Method value, e.g. s.once.Do(s.init): resolve init on s's type and
+		// rewrite the Once path from the caller's variable to the method
+		// receiver (s.once -> r.once).
+		decl := c.methodDecl(fn)
+		if decl == nil {
+			return nil, ""
+		}
+		// Rewriting s.once -> r.once needs both a usable caller path and a
+		// named receiver; reaching a package-level Once needs neither.
+		base := common.GetVarName(fn.X)
+		if recv := common.ReceiverName(decl); recv != "" && base != "" && base != "?" {
+			if path, ok := strings.CutPrefix(onceName, base+"."); ok {
+				return decl.Body, recv + "." + path
+			}
+		}
+		if c.pkgOnces[onceName] {
+			return decl.Body, onceName
+		}
+	}
+
+	return nil, ""
+}
+
+// methodDecl resolves a method value expression (x.name) to the package
+// method declaration on x's type, or nil.
+func (c *Checker) methodDecl(sel *ast.SelectorExpr) *ast.FuncDecl {
+	typeName := common.BaseTypeNameFromType(c.typesInfo.TypeOf(sel.X))
+	if typeName == "" {
+		return nil
+	}
+	return c.scope.receiverMethods[typeName][sel.Sel.Name]
+}
+
+// localFunctionLiteral finds `name := func() {...}` (or var name = func...)
+// in the current function body.
+func (c *Checker) localFunctionLiteral(name string) *ast.FuncLit {
+	if c.function == nil || c.function.Body == nil {
+		return nil
+	}
+
+	var found *ast.FuncLit
+	ast.Inspect(c.function.Body, func(n ast.Node) bool {
+		switch node := n.(type) {
+		case *ast.AssignStmt:
+			for i, lhs := range node.Lhs {
+				ident, ok := lhs.(*ast.Ident)
+				if !ok || ident.Name != name || i >= len(node.Rhs) {
+					continue
+				}
+				if lit, ok := node.Rhs[i].(*ast.FuncLit); ok {
+					found = lit
+				}
+			}
+		case *ast.ValueSpec:
+			for i, ident := range node.Names {
+				if ident.Name != name || i >= len(node.Values) {
+					continue
+				}
+				if lit, ok := node.Values[i].(*ast.FuncLit); ok {
+					found = lit
+				}
+			}
+		}
+		return true
+	})
+
+	return found
+}
+
+// blockReachesDo reports whether executing block synchronously reaches a
+// <target>.Do(...) call, returning the position of that inner call.
+func (c *Checker) blockReachesDo(block *ast.BlockStmt, target string) (token.Pos, bool) {
+	if block == nil {
+		return token.NoPos, false
+	}
+	for _, stmt := range block.List {
+		if pos, ok := c.stmtReachesDo(stmt, target); ok {
+			return pos, true
+		}
+	}
+	return token.NoPos, false
+}
+
+func (c *Checker) stmtReachesDo(stmt ast.Stmt, target string) (token.Pos, bool) {
+	switch s := stmt.(type) {
+	case *ast.GoStmt:
+		// A goroutine launched inside f runs after the outer Do completes:
+		// its Do call blocks until then but does not deadlock the outer Do.
+		return token.NoPos, false
+
+	case *ast.ExprStmt:
+		return c.exprReachesDo(s.X, target)
+
+	case *ast.DeferStmt:
+		// Deferred calls run while the outer Do is still in flight.
+		if pos, ok := c.callReachesDo(s.Call, target); ok {
+			return pos, true
+		}
+		return token.NoPos, false
+
+	case *ast.AssignStmt:
+		for _, rhs := range s.Rhs {
+			if pos, ok := c.exprReachesDo(rhs, target); ok {
+				return pos, true
+			}
+		}
+
+	case *ast.DeclStmt:
+		if gen, ok := s.Decl.(*ast.GenDecl); ok {
+			for _, spec := range gen.Specs {
+				vs, ok := spec.(*ast.ValueSpec)
+				if !ok {
+					continue
+				}
+				for _, value := range vs.Values {
+					if pos, ok := c.exprReachesDo(value, target); ok {
+						return pos, true
+					}
+				}
+			}
+		}
+
+	case *ast.ReturnStmt:
+		for _, result := range s.Results {
+			if pos, ok := c.exprReachesDo(result, target); ok {
+				return pos, true
+			}
+		}
+
+	case *ast.IfStmt:
+		if s.Init != nil {
+			if pos, ok := c.stmtReachesDo(s.Init, target); ok {
+				return pos, true
+			}
+		}
+		if pos, ok := c.exprReachesDo(s.Cond, target); ok {
+			return pos, true
+		}
+		if pos, ok := c.blockReachesDo(s.Body, target); ok {
+			return pos, true
+		}
+		if s.Else != nil {
+			if pos, ok := c.stmtReachesDo(s.Else, target); ok {
+				return pos, true
+			}
+		}
+
+	case *ast.ForStmt:
+		if s.Init != nil {
+			if pos, ok := c.stmtReachesDo(s.Init, target); ok {
+				return pos, true
+			}
+		}
+		if s.Cond != nil {
+			if pos, ok := c.exprReachesDo(s.Cond, target); ok {
+				return pos, true
+			}
+		}
+		if pos, ok := c.blockReachesDo(s.Body, target); ok {
+			return pos, true
+		}
+
+	case *ast.RangeStmt:
+		if pos, ok := c.exprReachesDo(s.X, target); ok {
+			return pos, true
+		}
+		if pos, ok := c.blockReachesDo(s.Body, target); ok {
+			return pos, true
+		}
+
+	case *ast.SwitchStmt:
+		if s.Init != nil {
+			if pos, ok := c.stmtReachesDo(s.Init, target); ok {
+				return pos, true
+			}
+		}
+		if s.Tag != nil {
+			if pos, ok := c.exprReachesDo(s.Tag, target); ok {
+				return pos, true
+			}
+		}
+		return c.caseClausesReachDo(s.Body, target)
+
+	case *ast.TypeSwitchStmt:
+		if s.Init != nil {
+			if pos, ok := c.stmtReachesDo(s.Init, target); ok {
+				return pos, true
+			}
+		}
+		return c.caseClausesReachDo(s.Body, target)
+
+	case *ast.SelectStmt:
+		for _, clause := range s.Body.List {
+			cc, ok := clause.(*ast.CommClause)
+			if !ok {
+				continue
+			}
+			for _, st := range cc.Body {
+				if pos, ok := c.stmtReachesDo(st, target); ok {
+					return pos, true
+				}
+			}
+		}
+
+	case *ast.BlockStmt:
+		return c.blockReachesDo(s, target)
+
+	case *ast.LabeledStmt:
+		return c.stmtReachesDo(s.Stmt, target)
+	}
+
+	return token.NoPos, false
+}
+
+func (c *Checker) caseClausesReachDo(body *ast.BlockStmt, target string) (token.Pos, bool) {
+	for _, clause := range body.List {
+		cc, ok := clause.(*ast.CaseClause)
+		if !ok {
+			continue
+		}
+		for _, st := range cc.Body {
+			if pos, ok := c.stmtReachesDo(st, target); ok {
+				return pos, true
+			}
+		}
+	}
+	return token.NoPos, false
+}
+
+// exprReachesDo scans an expression for Do calls on target. Function literals
+// are only entered when they are invoked in place (IIFE); a literal that is
+// merely defined does not execute synchronously.
+func (c *Checker) exprReachesDo(expr ast.Expr, target string) (token.Pos, bool) {
+	if expr == nil {
+		return token.NoPos, false
+	}
+
+	var (
+		foundPos token.Pos
+		found    bool
+	)
+	ast.Inspect(expr, func(n ast.Node) bool {
+		if found {
+			return false
+		}
+		switch node := n.(type) {
+		case *ast.FuncLit:
+			// Entered explicitly via callReachesDo when invoked in place.
+			return false
+		case *ast.CallExpr:
+			if pos, ok := c.callReachesDo(node, target); ok {
+				foundPos, found = pos, true
+				return false
+			}
+		}
+		return true
+	})
+	return foundPos, found
+}
+
+// callReachesDo reports whether call is <target>.Do(...) itself or an
+// in-place invocation of a literal whose body reaches one.
+func (c *Checker) callReachesDo(call *ast.CallExpr, target string) (token.Pos, bool) {
+	if c.isDoCallOn(call, target) {
+		return call.Pos(), true
+	}
+	if lit, ok := common.UnwrapParenExpr(call.Fun).(*ast.FuncLit); ok {
+		return c.blockReachesDo(lit.Body, target)
+	}
+	return token.NoPos, false
+}
+
+func (c *Checker) isDoCallOn(call *ast.CallExpr, target string) bool {
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok || sel.Sel.Name != "Do" {
+		return false
+	}
+	if !common.IsOnce(c.typesInfo.TypeOf(sel.X)) {
+		return false
+	}
+	return common.GetVarName(sel.X) == target
+}

--- a/pkg/analyzer/internal/once/sub_analyzer.go
+++ b/pkg/analyzer/internal/once/sub_analyzer.go
@@ -1,0 +1,42 @@
+package once
+
+import (
+	"reflect"
+
+	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/internal/common/commentfilter"
+	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/internal/common/report"
+	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/internal/driver"
+	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/internal/filesetup"
+	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/internal/primitives"
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/inspect"
+)
+
+// SubAnalyzer drives the sync.Once misuse checks as an independent
+// analysis.Analyzer. It does not call pass.Report itself: it returns the
+// prepared diagnostic slice as Result so the umbrella Analyzer can re-emit
+// them (and so analysistest can observe them through the umbrella).
+var SubAnalyzer = &analysis.Analyzer{
+	Name:       "goconcurrencylint_once",
+	Doc:        "Detects misuse of sync.Once: re-entrant Do calls that deadlock and Do(nil) calls that panic.",
+	Run:        run,
+	Requires:   []*analysis.Analyzer{inspect.Analyzer, primitives.Analyzer, filesetup.Analyzer},
+	ResultType: reflect.TypeFor[[]analysis.Diagnostic](),
+}
+
+func run(pass *analysis.Pass) (any, error) {
+	// scope is built once on first use and shared across every function in
+	// the pass (driver.Run visits functions sequentially, so the lazy init
+	// needs no synchronization).
+	var scope *packageScope
+	return driver.Run(pass, driver.Config[*Checker]{
+		Guard: primitives.HasOnces,
+		NewChecker: func(_ *primitives.FunctionResult, ec report.Reporter, _ *commentfilter.CommentFilter, pass *analysis.Pass) *Checker {
+			if scope == nil {
+				scope = newPackageScope(pass.Files)
+			}
+			pkg := pass.ResultOf[primitives.Analyzer].(*primitives.Result)
+			return NewChecker(ec, pkg, pass.TypesInfo, scope)
+		},
+	})
+}

--- a/pkg/analyzer/internal/primitives/primitives.go
+++ b/pkg/analyzer/internal/primitives/primitives.go
@@ -27,6 +27,7 @@ type Result struct {
 	Mutexes    map[string]bool
 	RWMutexes  map[string]bool
 	WaitGroups map[string]bool
+	Onces      map[string]bool
 }
 
 // FunctionResult lists sync primitive names visible inside a function:
@@ -39,6 +40,7 @@ type FunctionResult struct {
 	Mutexes           map[string]bool
 	RWMutexes         map[string]bool
 	WaitGroups        map[string]bool
+	Onces             map[string]bool
 	LocalWaitGroups   map[string]bool
 	PackageWaitGroups map[string]bool
 }
@@ -48,7 +50,7 @@ type FunctionResult struct {
 // pass.ResultOf[primitives.Analyzer].
 var Analyzer = &analysis.Analyzer{
 	Name:       "goconcurrencylint_primitives",
-	Doc:        "Collects sync.Mutex/RWMutex/WaitGroup variable names declared at package scope.",
+	Doc:        "Collects sync.Mutex/RWMutex/WaitGroup/Once variable names declared at package scope.",
 	Run:        run,
 	ResultType: reflect.TypeFor[*Result](),
 }
@@ -58,6 +60,7 @@ func run(pass *analysis.Pass) (any, error) {
 		Mutexes:    map[string]bool{},
 		RWMutexes:  map[string]bool{},
 		WaitGroups: map[string]bool{},
+		Onces:      map[string]bool{},
 	}
 
 	scope := pass.Pkg.Scope()
@@ -70,10 +73,25 @@ func run(pass *analysis.Pass) (any, error) {
 		if varObj.Pkg() != pass.Pkg {
 			continue
 		}
-		classify(name, varObj.Type(), res.Mutexes, res.RWMutexes, res.WaitGroups)
+		classify(name, varObj.Type(), res.maps())
 	}
 
 	return res, nil
+}
+
+// maps bundles this Result's per-kind name maps for classify.
+func (r *Result) maps() primitiveMaps {
+	return primitiveMaps{mu: r.Mutexes, rw: r.RWMutexes, wg: r.WaitGroups, once: r.Onces}
+}
+
+func (fr *FunctionResult) maps() primitiveMaps {
+	return primitiveMaps{mu: fr.Mutexes, rw: fr.RWMutexes, wg: fr.WaitGroups, once: fr.Onces}
+}
+
+// primitiveMaps bundles the per-kind name maps so classify keeps a single
+// signature as new primitives are added.
+type primitiveMaps struct {
+	mu, rw, wg, once map[string]bool
 }
 
 // ForFunction returns the primitives visible inside fn, merging the
@@ -85,9 +103,10 @@ func ForFunction(fn *ast.FuncDecl, pass *analysis.Pass, pkg *Result) *FunctionRe
 		Mutexes:    map[string]bool{},
 		RWMutexes:  map[string]bool{},
 		WaitGroups: map[string]bool{},
+		Onces:      map[string]bool{},
 	}
 
-	// Function parameters: include mutex/rwmutex but intentionally not
+	// Function parameters: include mutex/rwmutex/once but intentionally not
 	// waitgroups (Done-only worker functions would produce false positives).
 	if fn.Type != nil && fn.Type.Params != nil {
 		for _, field := range fn.Type.Params.List {
@@ -101,6 +120,8 @@ func ForFunction(fn *ast.FuncDecl, pass *analysis.Pass, pkg *Result) *FunctionRe
 					fr.Mutexes[name.Name] = true
 				case common.IsRWMutex(typ):
 					fr.RWMutexes[name.Name] = true
+				case common.IsOnce(typ):
+					fr.Onces[name.Name] = true
 				}
 			}
 		}
@@ -115,6 +136,7 @@ func ForFunction(fn *ast.FuncDecl, pass *analysis.Pass, pkg *Result) *FunctionRe
 	maps.Copy(fr.Mutexes, pkg.Mutexes)
 	maps.Copy(fr.RWMutexes, pkg.RWMutexes)
 	maps.Copy(fr.WaitGroups, pkg.WaitGroups)
+	maps.Copy(fr.Onces, pkg.Onces)
 	fr.LocalWaitGroups = localWG
 	fr.PackageWaitGroups = pkg.WaitGroups
 
@@ -131,6 +153,11 @@ func HasWaitGroups(fr *FunctionResult) bool {
 	return len(fr.WaitGroups) > 0
 }
 
+// HasOnces reports whether any sync.Once name is in scope.
+func HasOnces(fr *FunctionResult) bool {
+	return len(fr.Onces) > 0
+}
+
 func scanBody(body *ast.BlockStmt, pass *analysis.Pass, fr *FunctionResult) {
 	if body == nil {
 		return
@@ -143,7 +170,7 @@ func scanBody(body *ast.BlockStmt, pass *analysis.Pass, fr *FunctionResult) {
 				if typ == nil {
 					continue
 				}
-				classify(name.Name, typ, fr.Mutexes, fr.RWMutexes, fr.WaitGroups)
+				classify(name.Name, typ, fr.maps())
 			}
 
 		case *ast.AssignStmt:
@@ -156,7 +183,7 @@ func scanBody(body *ast.BlockStmt, pass *analysis.Pass, fr *FunctionResult) {
 					continue
 				}
 				if typ := pass.TypesInfo.TypeOf(node.Rhs[i]); typ != nil {
-					classify(ident.Name, typ, fr.Mutexes, fr.RWMutexes, fr.WaitGroups)
+					classify(ident.Name, typ, fr.maps())
 				}
 			}
 
@@ -166,7 +193,7 @@ func scanBody(body *ast.BlockStmt, pass *analysis.Pass, fr *FunctionResult) {
 				parentName := common.GetVarName(node.X)
 				if parentName != "?" {
 					compoundName := parentName + "." + node.Sel.Name
-					classify(compoundName, fieldType, fr.Mutexes, fr.RWMutexes, fr.WaitGroups)
+					classify(compoundName, fieldType, fr.maps())
 				}
 			}
 		}
@@ -195,15 +222,17 @@ func variableType(vs *ast.ValueSpec, pass *analysis.Pass) types.Type {
 }
 
 // classify routes name into the matching primitive map. The caller supplies
-// the three target maps so the helper can serve both *Result (package
-// scope) and *FunctionResult (per-function) without duplication.
-func classify(name string, typ types.Type, mu, rw, wg map[string]bool) {
+// the target maps so the helper can serve both *Result (package scope) and
+// *FunctionResult (per-function) without duplication.
+func classify(name string, typ types.Type, into primitiveMaps) {
 	switch {
 	case common.IsMutex(typ):
-		mu[name] = true
+		into.mu[name] = true
 	case common.IsRWMutex(typ):
-		rw[name] = true
+		into.rw[name] = true
 	case common.IsWaitGroup(typ):
-		wg[name] = true
+		into.wg[name] = true
+	case common.IsOnce(typ):
+		into.once[name] = true
 	}
 }

--- a/pkg/analyzer/testdata/src/once/once_cases.go
+++ b/pkg/analyzer/testdata/src/once/once_cases.go
@@ -1,0 +1,338 @@
+package once
+
+import "sync"
+
+var globalOnce sync.Once
+
+type server struct {
+	once  sync.Once
+	other sync.Once
+}
+
+// ========== once-do-deadlock ==========
+
+// Bad: Do called again on the same Once inside its own Do literal.
+func BadReentrantDoLiteral() {
+	var once sync.Once
+	once.Do(func() {
+		once.Do(func() {}) // want "once 'once' Do called inside its own Do function"
+	})
+}
+
+// Bad: the re-entrant Do hides behind control flow inside the literal.
+func BadReentrantDoInsideIf(cond bool) {
+	var once sync.Once
+	once.Do(func() {
+		if cond {
+			once.Do(func() {}) // want "once 'once' Do called inside its own Do function"
+		}
+	})
+}
+
+// Bad: a deferred Do still runs while the outer Do is in flight.
+func BadReentrantDoInDefer() {
+	var once sync.Once
+	once.Do(func() {
+		defer once.Do(func() {}) // want "once 'once' Do called inside its own Do function"
+	})
+}
+
+// Bad: the function passed to Do is a named top-level function that calls
+// Do on the same package-level Once again.
+func BadReentrantDoNamedFunc() {
+	globalOnce.Do(reentrantSetup)
+}
+
+func reentrantSetup() {
+	globalOnce.Do(func() {}) // want "once 'globalOnce' Do called inside its own Do function"
+}
+
+// Bad: method value on the same receiver field.
+func (s *server) BadReentrantDoMethodValue() {
+	s.once.Do(s.setup)
+}
+
+func (s *server) setup() {
+	s.once.Do(func() {}) // want "once 's.once' Do called inside its own Do function"
+}
+
+// Bad: a local function literal closing over the same Once.
+func BadReentrantDoLocalLiteral() {
+	var once sync.Once
+	f := func() {
+		once.Do(func() {}) // want "once 'once' Do called inside its own Do function"
+	}
+	once.Do(f)
+}
+
+// Bad: an in-place invocation (IIFE) inside the Do function executes
+// synchronously.
+func BadReentrantDoIIFE() {
+	var once sync.Once
+	once.Do(func() {
+		func() {
+			once.Do(func() {}) // want "once 'once' Do called inside its own Do function"
+		}()
+	})
+}
+
+// ========== once-do-deadlock: control flow inside the Do body ==========
+
+// Bad: re-entrant Do inside a for loop.
+func BadReentrantDoInForLoop() {
+	var once sync.Once
+	once.Do(func() {
+		for i := 0; i < 1; i++ {
+			once.Do(func() {}) // want "once 'once' Do called inside its own Do function"
+		}
+	})
+}
+
+// Bad: re-entrant Do inside a range loop.
+func BadReentrantDoInRange() {
+	var once sync.Once
+	once.Do(func() {
+		for range []int{1} {
+			once.Do(func() {}) // want "once 'once' Do called inside its own Do function"
+		}
+	})
+}
+
+// Bad: re-entrant Do inside a switch case.
+func BadReentrantDoInSwitch(x int) {
+	var once sync.Once
+	once.Do(func() {
+		switch x {
+		case 1:
+			once.Do(func() {}) // want "once 'once' Do called inside its own Do function"
+		}
+	})
+}
+
+// Bad: re-entrant Do inside a type switch case.
+func BadReentrantDoInTypeSwitch(v any) {
+	var once sync.Once
+	once.Do(func() {
+		switch v.(type) {
+		case int:
+			once.Do(func() {}) // want "once 'once' Do called inside its own Do function"
+		}
+	})
+}
+
+// Bad: re-entrant Do inside a select communication clause.
+func BadReentrantDoInSelect(ch chan int) {
+	var once sync.Once
+	once.Do(func() {
+		select {
+		case <-ch:
+			once.Do(func() {}) // want "once 'once' Do called inside its own Do function"
+		}
+	})
+}
+
+// Bad: the re-entrant Do hides in the else branch.
+func BadReentrantDoInElse(cond bool) {
+	var once sync.Once
+	once.Do(func() {
+		if cond {
+			_ = cond
+		} else {
+			once.Do(func() {}) // want "once 'once' Do called inside its own Do function"
+		}
+	})
+}
+
+// Bad: re-entrant Do inside a bare nested block.
+func BadReentrantDoInBlock() {
+	var once sync.Once
+	once.Do(func() {
+		{
+			once.Do(func() {}) // want "once 'once' Do called inside its own Do function"
+		}
+	})
+}
+
+// Bad: re-entrant Do inside a labeled loop.
+func BadReentrantDoInLabeledLoop() {
+	var once sync.Once
+	once.Do(func() {
+	loop:
+		for {
+			once.Do(func() {}) // want "once 'once' Do called inside its own Do function"
+			break loop
+		}
+	})
+}
+
+// Bad: a var initializer that runs an IIFE re-entering Do.
+func BadReentrantDoInVarDecl() {
+	var once sync.Once
+	once.Do(func() {
+		x := func() int {
+			once.Do(func() {}) // want "once 'once' Do called inside its own Do function"
+			return 0
+		}()
+		_ = x
+	})
+}
+
+// ========== once-do-deadlock: function resolution variants ==========
+
+// Bad: method value whose declared receiver name (r) differs from the call
+// site (s). The Once path is rewritten s.once -> r.once to find the inner
+// call; the diagnostic still names it from the caller's perspective (s.once).
+func (s *server) BadReentrantDoMethodValueRenamedRecv() {
+	s.once.Do(s.setupRenamed)
+}
+
+func (r *server) setupRenamed() {
+	r.once.Do(func() {}) // want "once 's.once' Do called inside its own Do function"
+}
+
+// Bad: a method value that re-enters a package-level Once (not a receiver field).
+func (s *server) BadReentrantDoPkgOnceViaMethod() {
+	globalOnce.Do(s.touchGlobalOnce)
+}
+
+func (s *server) touchGlobalOnce() {
+	globalOnce.Do(func() {}) // want "once 'globalOnce' Do called inside its own Do function"
+}
+
+// Bad: same path but through an *unnamed* receiver. The Once is package-level,
+// not a receiver field, so resolution must not require a receiver name.
+func (s *server) BadReentrantDoPkgOnceViaUnnamedRecv() {
+	globalOnce.Do(s.touchGlobalUnnamed)
+}
+
+func (*server) touchGlobalUnnamed() {
+	globalOnce.Do(func() {}) // want "once 'globalOnce' Do called inside its own Do function"
+}
+
+// Bad: re-entrant Do through a *sync.Once parameter (pointer is dereferenced).
+func BadReentrantDoPointerParam(o *sync.Once) {
+	o.Do(func() {
+		o.Do(func() {}) // want "once 'o' Do called inside its own Do function"
+	})
+}
+
+// ========== once-do-nil ==========
+
+// Bad: Do(nil) panics when the function is invoked.
+func BadDoNil() {
+	var once sync.Once
+	once.Do(nil) // want "once 'once' Do called with nil function"
+}
+
+// ========== good cases ==========
+
+// Good: nesting two different Onces is fine.
+func GoodDifferentOnces() {
+	var a, b sync.Once
+	a.Do(func() {
+		b.Do(func() {})
+	})
+}
+
+// Good: different Once fields on the same receiver.
+func (s *server) GoodDifferentFields() {
+	s.once.Do(func() {
+		s.other.Do(func() {})
+	})
+}
+
+// Good: a goroutine launched inside Do runs after the outer Do completes,
+// so it blocks but does not deadlock.
+func GoodGoroutineInsideDo() {
+	var once sync.Once
+	once.Do(func() {
+		go func() {
+			once.Do(func() {})
+		}()
+	})
+}
+
+// Good: a literal that is defined but never invoked does not execute.
+func GoodUninvokedLiteral() {
+	var once sync.Once
+	once.Do(func() {
+		helper := func() { once.Do(func() {}) }
+		_ = helper
+	})
+}
+
+// Good: method values on different objects target different Onces.
+func GoodDifferentReceivers(s, t *server) {
+	s.once.Do(t.setup)
+}
+
+// Good: Do has a .Do method but is not a sync.Once.
+type httpishClient struct{}
+
+func (c *httpishClient) Do(req string) {}
+
+func GoodNonOnceDo() {
+	c := &httpishClient{}
+	c.Do("request")
+}
+
+// Good: calling Do repeatedly (idempotent init) is the intended use.
+func GoodRepeatedDo() {
+	var once sync.Once
+	for i := 0; i < 3; i++ {
+		once.Do(func() {})
+	}
+}
+
+// Good: method value where the method initializes without re-entering.
+func (s *server) initialize() {}
+
+func (s *server) GoodMethodValue() {
+	s.once.Do(s.initialize)
+}
+
+// Good: a named top-level function passed to Do that never re-enters.
+func GoodNamedFuncNoReentry() {
+	globalOnce.Do(safeSetup)
+}
+
+func safeSetup() {
+	_ = 1 + 1
+}
+
+// Good: a method value that touches a *different* Once field is not a deadlock.
+func (s *server) initOther() {
+	s.other.Do(func() {})
+}
+
+func (s *server) GoodMethodValueDifferentField() {
+	s.once.Do(s.initOther)
+}
+
+// Good: a deferred Do on a different Once does not deadlock the outer one.
+func GoodDeferDifferentOnce() {
+	var a, b sync.Once
+	a.Do(func() {
+		defer b.Do(func() {})
+	})
+}
+
+// Good: a goroutine launched from inside a branch still runs after Do returns.
+func GoodGoroutineInBranch(cond bool) {
+	var once sync.Once
+	once.Do(func() {
+		if cond {
+			go once.Do(func() {})
+		}
+	})
+}
+
+// ========== copy-by-value ==========
+
+func takesOnceByValue(o sync.Once) {} // want "once 'o' is copied by value"
+
+func BadCopyOnce() {
+	var once sync.Once
+	copied := once // want "once 'once' is copied by value"
+	_ = copied
+}


### PR DESCRIPTION
Add the once sub-analyzer: once-do-deadlock (Do called on the same Once from inside its own Do function — not reentrant, deadlocks) and once-do-nil (Do(nil) panics). Resolves the function passed to Do across literals, named functions and method values. Extends copy-by-value detection to sync.Once.