### PR TITLE
feat: add sync.Pool, once-constructor and rwmutex recursive-lock checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Each check has a stable code (e.g. `GCL1001`) shown in the diagnostic message an
 | [`GCL1010`](docs/checks/GCL1010.md) | `panic-before-unlock` | `sync.Mutex`, `sync.RWMutex` | A statically-known out-of-range index can panic between Lock() and a non-deferred unlock. |
 | [`GCL1011`](docs/checks/GCL1011.md) | `double-lock` | `sync.Mutex`, `sync.RWMutex` | A second Lock() is taken while the first is still held. |
 | [`GCL1012`](docs/checks/GCL1012.md) | `lock-order-cycle` | `sync.Mutex`, `sync.RWMutex` | Two functions acquire the same pair of mutexes in opposite orders — a classic deadlock pattern. |
+| [`GCL1013`](docs/checks/GCL1013.md) | `rwmutex-recursive-lock` | `sync.RWMutex` | A goroutine re-acquires an RWMutex it already holds in a conflicting mode (read then write, or write then read), which self-deadlocks. |
 | [`GCL2001`](docs/checks/GCL2001.md) | `add-without-done` | `sync.WaitGroup` | wg.Add(n) has fewer guaranteed Done()s than its count, so the counter can never reach zero. |
 | [`GCL2002`](docs/checks/GCL2002.md) | `done-without-add` | `sync.WaitGroup` | wg.Done() is called more times than wg.Add() allows, which panics at runtime. |
 | [`GCL2003`](docs/checks/GCL2003.md) | `add-after-wait` | `sync.WaitGroup` | wg.Add() is called after wg.Wait() returned with an empty counter — a classic reuse bug. |
@@ -118,8 +119,10 @@ Each check has a stable code (e.g. `GCL1001`) shown in the diagnostic message an
 | [`GCL2015`](docs/checks/GCL2015.md) | `go-panic` | `sync.WaitGroup` | A function passed to wg.Go() may panic and bring the program down. |
 | [`GCL3001`](docs/checks/GCL3001.md) | `once-do-deadlock` | `sync.Once` | once.Do(f) where f calls Do on the same Once again — Once.Do is not reentrant, so this deadlocks. |
 | [`GCL3002`](docs/checks/GCL3002.md) | `once-do-nil` | `sync.Once` | once.Do(nil) panics when the function is invoked. |
+| [`GCL3003`](docs/checks/GCL3003.md) | `once-constructor-nil` | `sync.Once` | sync.OnceFunc/OnceValue/OnceValues is called with a nil function, which panics when the memoized function first runs. |
 | [`GCL4001`](docs/checks/GCL4001.md) | `cond-new-nil-locker` | `sync.Cond` | sync.NewCond(nil) builds a Cond whose Locker is nil, so the first Wait panics at runtime. |
-| [`GCL9001`](docs/checks/GCL9001.md) | `sync-primitive-copy` | `sync.Mutex`, `sync.RWMutex`, `sync.WaitGroup`, `sync.Once` | A sync primitive (or a struct embedding one) is copied by value. |
+| [`GCL5001`](docs/checks/GCL5001.md) | `pool-non-pointer-value` | `sync.Pool` | A non-pointer value is placed in a sync.Pool (a Put argument or a New return), so every call boxes it into an interface and heap-allocates — defeating the pool. |
+| [`GCL9001`](docs/checks/GCL9001.md) | `sync-primitive-copy` | `sync.Mutex`, `sync.RWMutex`, `sync.WaitGroup`, `sync.Once`, `sync.Cond`, `sync.Pool`, `sync.Map` | A sync primitive (or a struct embedding one) is copied by value. |
 <!-- END GENERATED CHECKS TABLE -->
 
 All checks above also fire on package-scoped primitives declared in any file of the same package — there is no separate code for that case; the diagnostic carries the same category as the in-function variant.

--- a/docs/checks/GCL1013.md
+++ b/docs/checks/GCL1013.md
@@ -1,0 +1,49 @@
+# GCL1013 — rwmutex-recursive-lock
+
+> A goroutine re-acquires an RWMutex it already holds in a conflicting mode (read then write, or write then read), which self-deadlocks.
+
+|           |                              |
+|-----------|------------------------------|
+| Code      | `GCL1013` |
+| Slug      | `rwmutex-recursive-lock` |
+| Primitive | `sync.RWMutex` |
+
+## Why it matters
+
+Go's sync.RWMutex is neither recursive nor upgradable: Lock waits for the goroutine's own read lock to be released, and RLock waits for its own write lock — so the goroutine blocks on itself forever.
+
+## Examples
+
+The linter flags code like this:
+
+```go
+var mu sync.RWMutex
+mu.RLock()
+mu.Lock() // upgrading the read lock to a write lock on the same goroutine deadlocks
+mu.Unlock()
+mu.RUnlock()
+```
+
+Write it like this instead:
+
+```go
+var mu sync.RWMutex
+mu.RLock()
+_ = read()
+mu.RUnlock()
+mu.Lock() // take the write lock only after releasing the read lock
+mu.Unlock()
+```
+
+## Suppressing this check
+
+Add an inline directive on the offending line. Either the canonical code or the legacy slug is accepted:
+
+```go
+foo() // goconcurrencylint:ignore GCL1013
+foo() // goconcurrencylint:ignore rwmutex-recursive-lock
+```
+
+See the [check catalogue](README.md) for every check.
+
+<sub>Generated from the check registry by `scripts/gendocs` — do not edit by hand.</sub>

--- a/docs/checks/GCL3003.md
+++ b/docs/checks/GCL3003.md
@@ -1,0 +1,44 @@
+# GCL3003 — once-constructor-nil
+
+> sync.OnceFunc/OnceValue/OnceValues is called with a nil function, which panics when the memoized function first runs.
+
+|           |                              |
+|-----------|------------------------------|
+| Code      | `GCL3003` |
+| Slug      | `once-constructor-nil` |
+| Primitive | `sync.Once` |
+
+## Why it matters
+
+Each constructor wraps f in a Once and returns a function that invokes f; a nil f is a nil function call that panics the first time the returned function runs.
+
+## Examples
+
+The linter flags code like this:
+
+```go
+handle := sync.OnceFunc(nil) // calling handle later panics on the nil function
+handle()
+```
+
+Write it like this instead:
+
+```go
+handle := sync.OnceFunc(func() {
+	initialize()
+})
+handle()
+```
+
+## Suppressing this check
+
+Add an inline directive on the offending line. Either the canonical code or the legacy slug is accepted:
+
+```go
+foo() // goconcurrencylint:ignore GCL3003
+foo() // goconcurrencylint:ignore once-constructor-nil
+```
+
+See the [check catalogue](README.md) for every check.
+
+<sub>Generated from the check registry by `scripts/gendocs` — do not edit by hand.</sub>

--- a/docs/checks/GCL5001.md
+++ b/docs/checks/GCL5001.md
@@ -1,0 +1,44 @@
+# GCL5001 — pool-non-pointer-value
+
+> A non-pointer value is placed in a sync.Pool (a Put argument or a New return), so every call boxes it into an interface and heap-allocates — defeating the pool.
+
+|           |                              |
+|-----------|------------------------------|
+| Code      | `GCL5001` |
+| Slug      | `pool-non-pointer-value` |
+| Primitive | `sync.Pool` |
+
+## Why it matters
+
+A value that is not pointer-shaped cannot live in the pool's internal interface without a heap allocation, so pooling it allocates on every Put or New miss instead of reusing memory; storing a pointer avoids the boxing.
+
+## Examples
+
+The linter flags code like this:
+
+```go
+var pool sync.Pool
+buf := make([]byte, 1024)
+pool.Put(buf) // []byte is not pointer-shaped: this allocates on every Put
+```
+
+Write it like this instead:
+
+```go
+var pool sync.Pool
+buf := make([]byte, 1024)
+pool.Put(&buf) // store a pointer so nothing is boxed
+```
+
+## Suppressing this check
+
+Add an inline directive on the offending line. Either the canonical code or the legacy slug is accepted:
+
+```go
+foo() // goconcurrencylint:ignore GCL5001
+foo() // goconcurrencylint:ignore pool-non-pointer-value
+```
+
+See the [check catalogue](README.md) for every check.
+
+<sub>Generated from the check registry by `scripts/gendocs` — do not edit by hand.</sub>

--- a/docs/checks/GCL9001.md
+++ b/docs/checks/GCL9001.md
@@ -6,7 +6,7 @@
 |-----------|------------------------------|
 | Code      | `GCL9001` |
 | Slug      | `sync-primitive-copy` |
-| Primitive | `sync.Mutex`, `sync.RWMutex`, `sync.WaitGroup`, `sync.Once` |
+| Primitive | `sync.Mutex`, `sync.RWMutex`, `sync.WaitGroup`, `sync.Once`, `sync.Cond`, `sync.Pool`, `sync.Map` |
 
 ## Why it matters
 

--- a/docs/checks/README.md
+++ b/docs/checks/README.md
@@ -18,6 +18,7 @@ Every diagnostic `goconcurrencylint` can emit, with its stable code. The code is
 | [GCL1010](GCL1010.md) | `panic-before-unlock` | A statically-known out-of-range index can panic between Lock() and a non-deferred unlock. |
 | [GCL1011](GCL1011.md) | `double-lock` | A second Lock() is taken while the first is still held. |
 | [GCL1012](GCL1012.md) | `lock-order-cycle` | Two functions acquire the same pair of mutexes in opposite orders — a classic deadlock pattern. |
+| [GCL1013](GCL1013.md) | `rwmutex-recursive-lock` | A goroutine re-acquires an RWMutex it already holds in a conflicting mode (read then write, or write then read), which self-deadlocks. |
 
 ## sync.WaitGroup
 
@@ -45,12 +46,19 @@ Every diagnostic `goconcurrencylint` can emit, with its stable code. The code is
 |------|------|-------------|
 | [GCL3001](GCL3001.md) | `once-do-deadlock` | once.Do(f) where f calls Do on the same Once again — Once.Do is not reentrant, so this deadlocks. |
 | [GCL3002](GCL3002.md) | `once-do-nil` | once.Do(nil) panics when the function is invoked. |
+| [GCL3003](GCL3003.md) | `once-constructor-nil` | sync.OnceFunc/OnceValue/OnceValues is called with a nil function, which panics when the memoized function first runs. |
 
 ## sync.Cond
 
 | Code | Slug | Description |
 |------|------|-------------|
 | [GCL4001](GCL4001.md) | `cond-new-nil-locker` | sync.NewCond(nil) builds a Cond whose Locker is nil, so the first Wait panics at runtime. |
+
+## sync.Pool
+
+| Code | Slug | Description |
+|------|------|-------------|
+| [GCL5001](GCL5001.md) | `pool-non-pointer-value` | A non-pointer value is placed in a sync.Pool (a Put argument or a New return), so every call boxes it into an interface and heap-allocates — defeating the pool. |
 
 ## Cross-cutting
 

--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -15,6 +15,7 @@
 //	├── waitgroup.SubAnalyzer ──┤── requires primitives.Analyzer ─┐
 //	├── once.SubAnalyzer ───────┤── requires filesetup.Analyzer   │
 //	├── cond.SubAnalyzer ───────┤                                 │
+//	├── pool.SubAnalyzer ───────┤                                 │
 //	└── copycheck.Analyzer ─────┘                                 └── requires inspect.Analyzer
 //
 // "A requires B" means B runs first and exposes its Result through
@@ -29,19 +30,21 @@ import (
 	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/internal/copycheck"
 	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/internal/mutex"
 	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/internal/once"
+	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/internal/pool"
 	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/internal/waitgroup"
 	"golang.org/x/tools/go/analysis"
 )
 
 var Analyzer = &analysis.Analyzer{
 	Name: "goconcurrencylint",
-	Doc:  "Detects misuse of sync.Mutex, sync.RWMutex, sync.WaitGroup, sync.Once and sync.Cond, plus copy-by-value of sync primitives.",
+	Doc:  "Detects misuse of sync.Mutex, sync.RWMutex, sync.WaitGroup, sync.Once, sync.Cond and sync.Pool, plus copy-by-value of sync primitives.",
 	Run:  run,
 	Requires: []*analysis.Analyzer{
 		mutex.SubAnalyzer,
 		waitgroup.SubAnalyzer,
 		once.SubAnalyzer,
 		cond.SubAnalyzer,
+		pool.SubAnalyzer,
 		copycheck.Analyzer,
 	},
 }
@@ -52,6 +55,7 @@ func run(pass *analysis.Pass) (any, error) {
 		waitgroup.SubAnalyzer,
 		once.SubAnalyzer,
 		cond.SubAnalyzer,
+		pool.SubAnalyzer,
 		copycheck.Analyzer,
 	}
 	for _, sub := range subs {

--- a/pkg/analyzer/analyzer_integration_test.go
+++ b/pkg/analyzer/analyzer_integration_test.go
@@ -14,6 +14,8 @@ func TestAnalyzerFixtures(t *testing.T) {
 		{name: "waitgroup", packages: []string{"waitgroup"}},
 		{name: "once", packages: []string{"once"}},
 		{name: "cond", packages: []string{"cond"}},
+		{name: "pool", packages: []string{"pool"}},
+		{name: "synccopy", packages: []string{"synccopy"}},
 		{name: "packagelevel", packages: []string{"packagelevel"}},
 		{name: "ignoredirective", packages: []string{"ignoredirective"}},
 		{name: "generated", packages: []string{"generated"}},

--- a/pkg/analyzer/internal/callscan/callscan.go
+++ b/pkg/analyzer/internal/callscan/callscan.go
@@ -1,0 +1,77 @@
+// Package callscan provides the shared skeleton for sub-analyzers that flag
+// specific call expressions by callee name: walk every call in the package,
+// cheap-reject on the callee selector before any type lookup, skip generated
+// files, and hand the survivors to a checker. It mirrors driver.Run's shape
+// for the per-function skeleton (mutex, waitgroup, once), but for a
+// package-wide call-expression scan (cond's NewCond, once's OnceFunc family).
+package callscan
+
+import (
+	"go/ast"
+
+	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/internal/common/report"
+	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/internal/filesetup"
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/inspect"
+	"golang.org/x/tools/go/ast/inspector"
+)
+
+// Checker is the minimal interface a call-scan checker must satisfy. Check is
+// called once per call expression whose selector passes Config.Accept.
+type Checker interface {
+	Check(call *ast.CallExpr, sel *ast.SelectorExpr)
+}
+
+// Config parameterizes the shared call-scan skeleton.
+type Config[C Checker] struct {
+	// SelectorOf extracts the callee selector from a call's Fun expression,
+	// peeling any shape the sub-analyzer needs to see through (e.g. generic
+	// instantiations). A nil return means the call is not one this scan
+	// considers at all.
+	SelectorOf func(fun ast.Expr) *ast.SelectorExpr
+
+	// Accept is the cheap, name-only reject applied before any type lookup.
+	Accept func(name string) bool
+
+	// NewChecker constructs the checker once per pass, wired to the shared
+	// ErrorCollector so its diagnostics land in this scan's Result.
+	NewChecker func(ec report.Reporter, pass *analysis.Pass) C
+}
+
+// Run executes the shared call-scan skeleton described by cfg and returns the
+// collected diagnostics. It is intended to be used directly as the body of a
+// sub-analyzer's run function:
+//
+//	func run(pass *analysis.Pass) (any, error) {
+//	    return callscan.Run(pass, callscan.Config[*Checker]{...}), nil
+//	}
+func Run[C Checker](pass *analysis.Pass, cfg Config[C]) []analysis.Diagnostic {
+	insp := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
+	files := pass.ResultOf[filesetup.Analyzer].(*filesetup.Result)
+	ec := &report.ErrorCollector{}
+	checker := cfg.NewChecker(ec, pass)
+
+	insp.Preorder([]ast.Node{(*ast.CallExpr)(nil)}, func(n ast.Node) {
+		call := n.(*ast.CallExpr)
+		// Cheap reject first: filter on the selector name before any type
+		// lookup or file check, since most calls are not ones this scan cares
+		// about.
+		sel := cfg.SelectorOf(call.Fun)
+		if sel == nil || !cfg.Accept(sel.Sel.Name) {
+			return
+		}
+		if files.IsGenerated(pass.Fset.File(call.Pos())) {
+			return
+		}
+		checker.Check(call, sel)
+	})
+
+	return ec.Diagnostics(pass, files.IgnoreFunc())
+}
+
+// PlainSelector is the common SelectorOf for scans that only care about a
+// direct method/function selector (x.Name(...)), not generic instantiations.
+func PlainSelector(fun ast.Expr) *ast.SelectorExpr {
+	sel, _ := fun.(*ast.SelectorExpr)
+	return sel
+}

--- a/pkg/analyzer/internal/common/category/category.go
+++ b/pkg/analyzer/internal/common/category/category.go
@@ -6,6 +6,8 @@
 //	GCL1xxx  sync.Mutex / sync.RWMutex
 //	GCL2xxx  sync.WaitGroup
 //	GCL3xxx  sync.Once
+//	GCL4xxx  sync.Cond
+//	GCL5xxx  sync.Pool
 //	GCL9xxx  cross-cutting (applies to several primitives)
 //
 // Every check also keeps a legacy kebab-case slug (e.g. lock-without-unlock).
@@ -33,6 +35,7 @@ const (
 	PanicBeforeUnlock      Category = "GCL1010"
 	DoubleLock             Category = "GCL1011"
 	LockOrderCycle         Category = "GCL1012"
+	RWMutexRecursiveLock   Category = "GCL1013"
 
 	// WaitGroup checks (GCL2xxx).
 	AddWithoutDone          Category = "GCL2001"
@@ -52,11 +55,15 @@ const (
 	GoPanic                 Category = "GCL2015"
 
 	// sync.Once checks (GCL3xxx).
-	OnceDoDeadlock Category = "GCL3001"
-	OnceDoNil      Category = "GCL3002"
+	OnceDoDeadlock     Category = "GCL3001"
+	OnceDoNil          Category = "GCL3002"
+	OnceConstructorNil Category = "GCL3003"
 
 	// sync.Cond checks (GCL4xxx).
 	CondNewNilLocker Category = "GCL4001"
+
+	// sync.Pool checks (GCL5xxx).
+	PoolNonPointerValue Category = "GCL5001"
 
 	// Cross-cutting checks (GCL9xxx).
 	SyncPrimitiveCopy Category = "GCL9001"
@@ -69,7 +76,8 @@ const (
 	primWG    = "sync.WaitGroup"
 	primOnce  = "sync.Once"
 	primCond  = "sync.Cond"
-	primAll   = "sync.Mutex, sync.RWMutex, sync.WaitGroup, sync.Once"
+	primPool  = "sync.Pool"
+	primAll   = "sync.Mutex, sync.RWMutex, sync.WaitGroup, sync.Once, sync.Cond, sync.Pool, sync.Map"
 )
 
 // Check is the full, stable metadata for one diagnostic. The registry below
@@ -262,6 +270,22 @@ func g() { b.Lock(); a.Lock(); a.Unlock(); b.Unlock() } // opposite order`,
 // both functions take a before b
 func f() { a.Lock(); b.Lock(); b.Unlock(); a.Unlock() }
 func g() { a.Lock(); b.Lock(); a.Unlock(); b.Unlock() }`},
+	{RWMutexRecursiveLock, "rwmutex-recursive-lock", primRW,
+		"A goroutine re-acquires an RWMutex it already holds in a conflicting mode (read then write, or write then read), which self-deadlocks.",
+		"Go's sync.RWMutex is neither recursive nor upgradable: Lock waits for the goroutine's own read lock to be released, and RLock waits for its own write lock — so the goroutine blocks on itself forever.",
+		`
+var mu sync.RWMutex
+mu.RLock()
+mu.Lock() // upgrading the read lock to a write lock on the same goroutine deadlocks
+mu.Unlock()
+mu.RUnlock()`,
+		`
+var mu sync.RWMutex
+mu.RLock()
+_ = read()
+mu.RUnlock()
+mu.Lock() // take the write lock only after releasing the read lock
+mu.Unlock()`},
 
 	{AddWithoutDone, "add-without-done", primWG,
 		"wg.Add(n) has fewer guaranteed Done()s than its count, so the counter can never reach zero.",
@@ -509,6 +533,17 @@ var once sync.Once
 once.Do(func() {
 	initialize()
 })`},
+	{OnceConstructorNil, "once-constructor-nil", primOnce,
+		"sync.OnceFunc/OnceValue/OnceValues is called with a nil function, which panics when the memoized function first runs.",
+		"Each constructor wraps f in a Once and returns a function that invokes f; a nil f is a nil function call that panics the first time the returned function runs.",
+		`
+handle := sync.OnceFunc(nil) // calling handle later panics on the nil function
+handle()`,
+		`
+handle := sync.OnceFunc(func() {
+	initialize()
+})
+handle()`},
 
 	{CondNewNilLocker, "cond-new-nil-locker", primCond,
 		"sync.NewCond(nil) builds a Cond whose Locker is nil, so the first Wait panics at runtime.",
@@ -518,6 +553,18 @@ once.Do(func() {
 		`
 	var mu sync.Mutex
 	c := sync.NewCond(&mu) // pass a real Locker`},
+
+	{PoolNonPointerValue, "pool-non-pointer-value", primPool,
+		"A non-pointer value is placed in a sync.Pool (a Put argument or a New return), so every call boxes it into an interface and heap-allocates — defeating the pool.",
+		"A value that is not pointer-shaped cannot live in the pool's internal interface without a heap allocation, so pooling it allocates on every Put or New miss instead of reusing memory; storing a pointer avoids the boxing.",
+		`
+var pool sync.Pool
+buf := make([]byte, 1024)
+pool.Put(buf) // []byte is not pointer-shaped: this allocates on every Put`,
+		`
+var pool sync.Pool
+buf := make([]byte, 1024)
+pool.Put(&buf) // store a pointer so nothing is boxed`},
 
 	{SyncPrimitiveCopy, "sync-primitive-copy", primAll,
 		"A sync primitive (or a struct embedding one) is copied by value.",

--- a/pkg/analyzer/internal/common/common.go
+++ b/pkg/analyzer/internal/common/common.go
@@ -65,6 +65,14 @@ func IsCond(typ types.Type) bool {
 	return MatchesPkgAndName(typ, "sync", "Cond")
 }
 
+// IsPool returns true if the given type is sync.Pool or *sync.Pool. Pool
+// methods have pointer receivers, so a value is auto-addressed at the call
+// site; both the value and pointer forms appear in practice.
+func IsPool(typ types.Type) bool {
+	typ = DerefOnce(typ)
+	return MatchesPkgAndName(typ, "sync", "Pool")
+}
+
 // MatchesPkgAndName reports whether typ is a named type declared in pkg
 // whose name matches any of names.
 //

--- a/pkg/analyzer/internal/cond/analyzer.go
+++ b/pkg/analyzer/internal/cond/analyzer.go
@@ -32,12 +32,11 @@ func NewChecker(errorCollector report.Reporter, typesInfo *types.Info) *Checker 
 	}
 }
 
-// CheckCall flags sync.NewCond(nil) (GCL4001). Only the literal nil is flagged;
-// the object lookup confirms the callee is really sync.NewCond and not a
-// same-named helper.
-func (c *Checker) CheckCall(call *ast.CallExpr) {
-	sel, ok := call.Fun.(*ast.SelectorExpr)
-	if !ok || sel.Sel.Name != "NewCond" || len(call.Args) != 1 {
+// Check flags sync.NewCond(nil) (GCL4001). sel is the callee selector already
+// matched to the name "NewCond" by the call-scan skeleton; the object lookup
+// here confirms the callee is really sync.NewCond and not a same-named helper.
+func (c *Checker) Check(call *ast.CallExpr, sel *ast.SelectorExpr) {
+	if len(call.Args) != 1 {
 		return
 	}
 	fn, ok := c.typesInfo.ObjectOf(sel.Sel).(*types.Func)

--- a/pkg/analyzer/internal/cond/sub_analyzer.go
+++ b/pkg/analyzer/internal/cond/sub_analyzer.go
@@ -1,14 +1,13 @@
 package cond
 
 import (
-	"go/ast"
 	"reflect"
 
+	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/internal/callscan"
 	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/internal/common/report"
 	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/internal/filesetup"
 	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/analysis/passes/inspect"
-	"golang.org/x/tools/go/ast/inspector"
 )
 
 // SubAnalyzer drives the sync.Cond misuse checks as an independent
@@ -17,9 +16,10 @@ import (
 // them through the umbrella).
 //
 // The only check left is NewCond(nil), which is keyed off rare NewCond call
-// sites, so this sub-analyzer skips the per-function driver skeleton entirely:
-// it walks call expressions directly and cheap-rejects on the callee name
-// before touching type information. That keeps it near-free on large packages.
+// sites, so this sub-analyzer delegates to callscan.Run instead of the
+// per-function driver skeleton: it walks call expressions directly and
+// cheap-rejects on the callee name before touching type information, keeping
+// it near-free on large packages.
 var SubAnalyzer = &analysis.Analyzer{
 	Name:       "goconcurrencylint_cond",
 	Doc:        "Detects misuse of sync.Cond: NewCond(nil).",
@@ -29,24 +29,11 @@ var SubAnalyzer = &analysis.Analyzer{
 }
 
 func run(pass *analysis.Pass) (any, error) {
-	insp := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
-	files := pass.ResultOf[filesetup.Analyzer].(*filesetup.Result)
-	ec := &report.ErrorCollector{}
-	checker := NewChecker(ec, pass.TypesInfo)
-
-	insp.Preorder([]ast.Node{(*ast.CallExpr)(nil)}, func(n ast.Node) {
-		call := n.(*ast.CallExpr)
-		// Cheap reject first: the vast majority of calls are not NewCond, so
-		// filter on the selector name before any type lookup or file check.
-		sel, ok := call.Fun.(*ast.SelectorExpr)
-		if !ok || sel.Sel.Name != "NewCond" {
-			return
-		}
-		if files.IsGenerated(pass.Fset.File(call.Pos())) {
-			return
-		}
-		checker.CheckCall(call)
-	})
-
-	return ec.Diagnostics(pass, files.IgnoreFunc()), nil
+	return callscan.Run(pass, callscan.Config[*Checker]{
+		SelectorOf: callscan.PlainSelector,
+		Accept:     func(name string) bool { return name == "NewCond" },
+		NewChecker: func(ec report.Reporter, pass *analysis.Pass) *Checker {
+			return NewChecker(ec, pass.TypesInfo)
+		},
+	}), nil
 }

--- a/pkg/analyzer/internal/copycheck/copycheck.go
+++ b/pkg/analyzer/internal/copycheck/copycheck.go
@@ -1,6 +1,8 @@
-// Package copycheck detects copy-by-value of sync.Mutex, sync.RWMutex
-// and sync.WaitGroup. It is an independent sub-analyzer that reports
-// diagnostics directly through analysis.Pass.Report.
+// Package copycheck detects copy-by-value of the sync primitives that must
+// not be copied after first use: sync.Mutex, sync.RWMutex, sync.WaitGroup,
+// sync.Once, sync.Cond, sync.Pool and sync.Map (directly or via a containing
+// struct). It is an independent sub-analyzer that reports diagnostics directly
+// through analysis.Pass.Report.
 package copycheck
 
 import (
@@ -19,14 +21,15 @@ import (
 	"golang.org/x/tools/go/ast/inspector"
 )
 
-// Analyzer reports any copy of a sync.Mutex, sync.RWMutex or
-// sync.WaitGroup value (directly or via a containing struct). It does
-// not call pass.Report itself: it returns the prepared diagnostic slice
-// as ResultType so the umbrella analyzer can re-emit them. This is the
-// pattern that makes the dependency graph visible to analysistest.
+// Analyzer reports any copy of a sync.Mutex, sync.RWMutex, sync.WaitGroup,
+// sync.Once, sync.Cond, sync.Pool or sync.Map value (directly or via a
+// containing struct). It does not call pass.Report itself: it returns the
+// prepared diagnostic slice as ResultType so the umbrella analyzer can re-emit
+// them. This is the pattern that makes the dependency graph visible to
+// analysistest.
 var Analyzer = &analysis.Analyzer{
 	Name:       "goconcurrencylint_copy",
-	Doc:        "Detects copy-by-value of sync.Mutex, sync.RWMutex and sync.WaitGroup.",
+	Doc:        "Detects copy-by-value of sync.Mutex, sync.RWMutex, sync.WaitGroup, sync.Once, sync.Cond, sync.Pool and sync.Map.",
 	Run:        run,
 	Requires:   []*analysis.Analyzer{inspect.Analyzer, filesetup.Analyzer},
 	ResultType: reflect.TypeFor[[]analysis.Diagnostic](),
@@ -181,7 +184,8 @@ func valueKind(typ types.Type) string {
 
 func directValueKind(typ types.Type) string {
 	typ = types.Unalias(typ)
-	if match, ok := common.MatchPkgAndName(typ, "sync", "Mutex", "RWMutex", "WaitGroup", "Once"); ok {
+	if match, ok := common.MatchPkgAndName(typ, "sync",
+		"Mutex", "RWMutex", "WaitGroup", "Once", "Cond", "Pool", "Map"); ok {
 		switch match {
 		case "Mutex":
 			return "mutex"
@@ -191,6 +195,14 @@ func directValueKind(typ types.Type) string {
 			return "waitgroup"
 		case "Once":
 			return "once"
+		case "Cond":
+			return "cond"
+		case "Pool":
+			return "pool"
+		// Map keeps its qualified name: a bare "map" would read as the
+		// builtin type instead of sync.Map.
+		case "Map":
+			return "sync.Map"
 		}
 	}
 	return ""

--- a/pkg/analyzer/internal/mutex/lockstate.go
+++ b/pkg/analyzer/internal/mutex/lockstate.go
@@ -137,7 +137,10 @@ func (c *Checker) handleRWMutexCall(varName, methodName string, pos token.Pos, s
 	switch methodName {
 	case "Lock":
 		if stats[varName].rlock > 0 {
-			c.errorCollector.AddError(pos, category.DoubleLock, "rwmutex '"+varName+"' attempts write Lock while read lock is held")
+			// Read-to-write upgrade on the same goroutine: Lock blocks waiting
+			// for this goroutine's own read lock to be released. Guaranteed
+			// self-deadlock (RWMutex is not upgradable).
+			c.errorCollector.AddError(pos, category.RWMutexRecursiveLock, "rwmutex '"+varName+"' attempts write Lock while read lock is held")
 		}
 		if stats[varName].borrowedLock > 0 {
 			stats[varName].borrowedLock--
@@ -178,6 +181,13 @@ func (c *Checker) handleRWMutexCall(varName, methodName string, pos token.Pos, s
 			stats[varName].removeFirstLockPos()
 		}
 	case "RLock", "TryRLock":
+		// Write-to-read on the same goroutine: a blocking RLock waits for this
+		// goroutine's own write lock to be released. Guaranteed self-deadlock.
+		// TryRLock is excluded: it returns false instead of blocking, so it does
+		// not deadlock.
+		if methodName == "RLock" && stats[varName].lock > 0 {
+			c.errorCollector.AddError(pos, category.RWMutexRecursiveLock, "rwmutex '"+varName+"' attempts read RLock while write lock is held")
+		}
 		if stats[varName].borrowedRLock > 0 {
 			stats[varName].borrowedRLock--
 			stats[varName].removeFirstBorrowedRUnlockPos()

--- a/pkg/analyzer/internal/once/analyzer.go
+++ b/pkg/analyzer/internal/once/analyzer.go
@@ -411,3 +411,72 @@ func (c *Checker) isDoCallOn(call *ast.CallExpr, target string) bool {
 	}
 	return common.GetVarName(sel.X) == target
 }
+
+// onceConstructors are the sync package memoizing constructors (Go 1.21+).
+// Each wraps its function argument in a sync.Once and returns a function that
+// invokes it, so passing a nil literal panics when the returned function runs.
+var onceConstructors = map[string]struct{}{
+	"OnceFunc":   {},
+	"OnceValue":  {},
+	"OnceValues": {},
+}
+
+// ConstructorSelector extracts the callee selector from a call to a sync.Once
+// constructor, peeling the type-argument index of the generic OnceValue and
+// OnceValues instantiations (e.g. sync.OnceValue[int](nil)). It returns nil for
+// any other call shape.
+func ConstructorSelector(fun ast.Expr) *ast.SelectorExpr {
+	switch f := fun.(type) {
+	case *ast.SelectorExpr:
+		return f
+	case *ast.IndexExpr:
+		if sel, ok := f.X.(*ast.SelectorExpr); ok {
+			return sel
+		}
+	case *ast.IndexListExpr:
+		if sel, ok := f.X.(*ast.SelectorExpr); ok {
+			return sel
+		}
+	}
+	return nil
+}
+
+// IsOnceConstructorName reports whether name is one of OnceFunc, OnceValue or
+// OnceValues. It is the cheap selector-name reject used before any type lookup.
+func IsOnceConstructorName(name string) bool {
+	_, ok := onceConstructors[name]
+	return ok
+}
+
+// ConstructorChecker reports sync.OnceFunc/OnceValue/OnceValues(nil) (GCL3003)
+// for one pass. It satisfies callscan.Checker so the sub-analyzer can drive it
+// through the shared call-scan skeleton.
+type ConstructorChecker struct {
+	errorCollector report.Reporter
+	typesInfo      *types.Info
+}
+
+// NewConstructorChecker creates the OnceFunc/OnceValue/OnceValues(nil) checker.
+func NewConstructorChecker(errorCollector report.Reporter, typesInfo *types.Info) *ConstructorChecker {
+	return &ConstructorChecker{errorCollector: errorCollector, typesInfo: typesInfo}
+}
+
+// Check flags a nil argument to a sync.Once constructor. sel is the callee
+// selector already extracted by ConstructorSelector and matched to a known
+// constructor name by IsOnceConstructorName; the object lookup here confirms
+// the callee is really from package sync and not a same-named helper. Only a
+// literal nil is flagged: a nil-typed variable is not statically known to be
+// nil.
+func (c *ConstructorChecker) Check(call *ast.CallExpr, sel *ast.SelectorExpr) {
+	if len(call.Args) != 1 {
+		return
+	}
+	fn, ok := c.typesInfo.ObjectOf(sel.Sel).(*types.Func)
+	if !ok || fn.Pkg() == nil || fn.Pkg().Path() != "sync" {
+		return
+	}
+	if ident, ok := common.UnwrapParenExpr(call.Args[0]).(*ast.Ident); ok && ident.Name == "nil" {
+		c.errorCollector.AddError(call.Pos(), category.OnceConstructorNil,
+			"sync."+sel.Sel.Name+" called with nil function (panics when the returned function runs)")
+	}
+}

--- a/pkg/analyzer/internal/once/sub_analyzer.go
+++ b/pkg/analyzer/internal/once/sub_analyzer.go
@@ -3,6 +3,7 @@ package once
 import (
 	"reflect"
 
+	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/internal/callscan"
 	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/internal/common/commentfilter"
 	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/internal/common/report"
 	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/internal/driver"
@@ -18,7 +19,7 @@ import (
 // them (and so analysistest can observe them through the umbrella).
 var SubAnalyzer = &analysis.Analyzer{
 	Name:       "goconcurrencylint_once",
-	Doc:        "Detects misuse of sync.Once: re-entrant Do calls that deadlock and Do(nil) calls that panic.",
+	Doc:        "Detects misuse of sync.Once: re-entrant Do that deadlocks, Do(nil), and OnceFunc/OnceValue/OnceValues(nil) that panic.",
 	Run:        run,
 	Requires:   []*analysis.Analyzer{inspect.Analyzer, primitives.Analyzer, filesetup.Analyzer},
 	ResultType: reflect.TypeFor[[]analysis.Diagnostic](),
@@ -29,7 +30,7 @@ func run(pass *analysis.Pass) (any, error) {
 	// the pass (driver.Run visits functions sequentially, so the lazy init
 	// needs no synchronization).
 	var scope *packageScope
-	return driver.Run(pass, driver.Config[*Checker]{
+	result, err := driver.Run(pass, driver.Config[*Checker]{
 		Guard: primitives.HasOnces,
 		NewChecker: func(_ *primitives.FunctionResult, ec report.Reporter, _ *commentfilter.CommentFilter, pass *analysis.Pass) *Checker {
 			if scope == nil {
@@ -39,4 +40,20 @@ func run(pass *analysis.Pass) (any, error) {
 			return NewChecker(ec, pkg, pass.TypesInfo, scope)
 		},
 	})
+	if err != nil {
+		return nil, err
+	}
+
+	// The OnceFunc/OnceValue/OnceValues(nil) checks key off package-level sync
+	// constructors, not a sync.Once variable, so they run outside the
+	// per-function HasOnces guard above, via the shared call-scan skeleton.
+	diags := result.([]analysis.Diagnostic)
+	constructorDiags := callscan.Run(pass, callscan.Config[*ConstructorChecker]{
+		SelectorOf: ConstructorSelector,
+		Accept:     IsOnceConstructorName,
+		NewChecker: func(ec report.Reporter, pass *analysis.Pass) *ConstructorChecker {
+			return NewConstructorChecker(ec, pass.TypesInfo)
+		},
+	})
+	return append(diags, constructorDiags...), nil
 }

--- a/pkg/analyzer/internal/pool/analyzer.go
+++ b/pkg/analyzer/internal/pool/analyzer.go
@@ -1,0 +1,197 @@
+// Package pool detects misuse of sync.Pool.
+package pool
+
+import (
+	"go/ast"
+	"go/types"
+
+	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/internal/common"
+	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/internal/common/category"
+	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/internal/common/report"
+)
+
+// Checker reports non-pointer values placed in a sync.Pool: a Put whose
+// argument, or a New function whose return, is not pointer-shaped. Such a value
+// is boxed into the pool's internal interface, which heap-allocates on every
+// call and defeats the purpose of the pool. Storing a pointer (or any other
+// pointer-shaped value) is always the fix, so the check has no false positives.
+// The Put case is what staticcheck flags as SA6002; the New case extends the
+// same reasoning to the pool's constructor.
+type Checker struct {
+	errorCollector report.Reporter
+	typesInfo      *types.Info
+}
+
+// NewChecker creates a sync.Pool checker. typesInfo is the pass-wide type
+// information used to confirm a Put call is really on a sync.Pool and to
+// classify the argument's shape.
+func NewChecker(errorCollector report.Reporter, typesInfo *types.Info) *Checker {
+	return &Checker{
+		errorCollector: errorCollector,
+		typesInfo:      typesInfo,
+	}
+}
+
+// CheckCall flags p.Put(v) (GCL5001) when v's type is not pointer-shaped. The
+// type check confirms the receiver is a real sync.Pool and not a same-named
+// Put method on another type.
+func (c *Checker) CheckCall(call *ast.CallExpr) {
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok || sel.Sel.Name != "Put" || len(call.Args) != 1 {
+		return
+	}
+	if !common.IsPool(c.typesInfo.TypeOf(sel.X)) {
+		return
+	}
+
+	argType := c.typesInfo.TypeOf(call.Args[0])
+	if argType == nil {
+		return
+	}
+	// Put(nil) stores a nil interface, which does not allocate.
+	if basic, ok := argType.Underlying().(*types.Basic); ok && basic.Kind() == types.UntypedNil {
+		return
+	}
+	if isPointerShaped(argType) {
+		return
+	}
+
+	c.errorCollector.AddError(call.Args[0].Pos(), category.PoolNonPointerValue,
+		"sync.Pool.Put stores non-pointer value of type "+typeName(argType)+", which allocates on every call; store a pointer instead")
+}
+
+// CheckCompositeLit flags a sync.Pool{New: func() any { return v }} whose New
+// returns a non-pointer value: the returned value is boxed into the pool's
+// interface on every miss, exactly like a non-pointer Put.
+func (c *Checker) CheckCompositeLit(cl *ast.CompositeLit) {
+	// Cheap reject first, like CheckCall: most composite literals in a package
+	// have no "New" key at all, so look for one before paying for a type
+	// lookup on every literal.
+	fn := newFuncLitElt(cl)
+	if fn == nil {
+		return
+	}
+	if !common.IsPool(c.typesInfo.TypeOf(cl)) {
+		return
+	}
+	c.checkNewValue(fn)
+}
+
+// newFuncLitElt returns the function literal assigned to the "New" key in a
+// composite literal, or nil if there is no such key or its value is not a
+// literal.
+func newFuncLitElt(cl *ast.CompositeLit) *ast.FuncLit {
+	for _, elt := range cl.Elts {
+		kv, ok := elt.(*ast.KeyValueExpr)
+		if !ok {
+			continue
+		}
+		if key, ok := kv.Key.(*ast.Ident); ok && key.Name == "New" {
+			if fn, ok := kv.Value.(*ast.FuncLit); ok {
+				return fn
+			}
+		}
+	}
+	return nil
+}
+
+// CheckAssign flags p.New = func() any { return v } for the same reason as
+// CheckCompositeLit.
+func (c *Checker) CheckAssign(assign *ast.AssignStmt) {
+	for i, lhs := range assign.Lhs {
+		sel, ok := lhs.(*ast.SelectorExpr)
+		if !ok || sel.Sel.Name != "New" || i >= len(assign.Rhs) {
+			continue
+		}
+		if !common.IsPool(c.typesInfo.TypeOf(sel.X)) {
+			continue
+		}
+		if fn, ok := assign.Rhs[i].(*ast.FuncLit); ok {
+			c.checkNewValue(fn)
+		}
+	}
+}
+
+// checkNewValue reports a New function literal that returns a non-pointer value.
+// To stay conservative it only reasons about a single, unconditional return of
+// one value whose type is known; anything more complex (multiple returns,
+// unresolved types) is left alone.
+func (c *Checker) checkNewValue(fn *ast.FuncLit) {
+	expr, ok := singleReturnExpr(fn)
+	if !ok {
+		return
+	}
+	t := c.typesInfo.TypeOf(expr)
+	if t == nil {
+		return
+	}
+	if basic, ok := t.Underlying().(*types.Basic); ok && basic.Kind() == types.UntypedNil {
+		return
+	}
+	if isPointerShaped(t) {
+		return
+	}
+	c.errorCollector.AddError(expr.Pos(), category.PoolNonPointerValue,
+		"sync.Pool.New returns non-pointer value of type "+typeName(t)+", which allocates on every call; return a pointer instead")
+}
+
+// singleReturnExpr returns the single returned expression of fn when its body
+// has exactly one return statement of exactly one value, ignoring returns
+// inside nested function literals. The second result is false otherwise.
+func singleReturnExpr(fn *ast.FuncLit) (ast.Expr, bool) {
+	if fn.Body == nil {
+		return nil, false
+	}
+	var returns []*ast.ReturnStmt
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		switch node := n.(type) {
+		case *ast.FuncLit:
+			return false // a nested literal's returns are not fn's returns
+		case *ast.ReturnStmt:
+			returns = append(returns, node)
+		}
+		return true
+	})
+	if len(returns) != 1 || len(returns[0].Results) != 1 {
+		return nil, false
+	}
+	return returns[0].Results[0], true
+}
+
+// isPointerShaped reports whether a value of type t is stored directly in an
+// interface without a heap allocation. Two independent runtime rules make that
+// true: t is "direct interface" shaped (pointers, channels, maps, funcs,
+// unsafe.Pointer, interfaces, and single-field structs / single-element arrays
+// that are themselves pointer-shaped), or t is zero-size (empty struct, [0]T),
+// in which case every value shares runtime.zerobase and boxing never
+// allocates regardless of shape. Anything else — basic values, slices,
+// strings, multi-field structs — is boxed and allocates on every Put. Unknown
+// shapes (type parameters resolve to their interface constraint) fall into the
+// interface case and are treated as pointer-shaped, so the check never fires
+// on them.
+func isPointerShaped(t types.Type) bool {
+	switch u := t.Underlying().(type) {
+	case *types.Pointer, *types.Chan, *types.Map, *types.Signature, *types.Interface:
+		return true
+	case *types.Basic:
+		return u.Kind() == types.UnsafePointer
+	case *types.Struct:
+		if u.NumFields() == 0 {
+			return true // struct{}: zero-size, never allocates
+		}
+		return u.NumFields() == 1 && isPointerShaped(u.Field(0).Type())
+	case *types.Array:
+		if u.Len() == 0 {
+			return true // [0]T: zero-size, never allocates
+		}
+		return u.Len() == 1 && isPointerShaped(u.Elem())
+	default:
+		return false
+	}
+}
+
+// typeName renders t with package names (not full import paths) for a readable
+// diagnostic, e.g. "bytes.Buffer" rather than the fully qualified path.
+func typeName(t types.Type) string {
+	return types.TypeString(t, func(p *types.Package) string { return p.Name() })
+}

--- a/pkg/analyzer/internal/pool/sub_analyzer.go
+++ b/pkg/analyzer/internal/pool/sub_analyzer.go
@@ -1,0 +1,61 @@
+package pool
+
+import (
+	"go/ast"
+	"reflect"
+
+	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/internal/common/report"
+	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/internal/filesetup"
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/inspect"
+	"golang.org/x/tools/go/ast/inspector"
+)
+
+// SubAnalyzer drives the sync.Pool misuse checks as an independent
+// analysis.Analyzer. Like the other sub-analyzers it returns its diagnostics as
+// Result so the umbrella Analyzer re-emits them (and analysistest observes them
+// through the umbrella).
+//
+// The checks are keyed off Put call sites and Pool.New assignments, so this
+// sub-analyzer skips the per-function driver skeleton entirely: it walks the
+// relevant nodes directly and cheap-rejects before touching type information,
+// keeping it near-free on large packages.
+var SubAnalyzer = &analysis.Analyzer{
+	Name:       "goconcurrencylint_pool",
+	Doc:        "Detects non-pointer values placed in a sync.Pool (Put argument or New return), which box and allocate on every call.",
+	Run:        run,
+	Requires:   []*analysis.Analyzer{inspect.Analyzer, filesetup.Analyzer},
+	ResultType: reflect.TypeFor[[]analysis.Diagnostic](),
+}
+
+func run(pass *analysis.Pass) (any, error) {
+	insp := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
+	files := pass.ResultOf[filesetup.Analyzer].(*filesetup.Result)
+	ec := &report.ErrorCollector{}
+	checker := NewChecker(ec, pass.TypesInfo)
+
+	nodeFilter := []ast.Node{
+		(*ast.CallExpr)(nil),
+		(*ast.CompositeLit)(nil),
+		(*ast.AssignStmt)(nil),
+	}
+	insp.Preorder(nodeFilter, func(n ast.Node) {
+		if files.IsGenerated(pass.Fset.File(n.Pos())) {
+			return
+		}
+		switch node := n.(type) {
+		case *ast.CallExpr:
+			// Cheap reject on the selector name before any type lookup, since
+			// most calls are not Put.
+			if sel, ok := node.Fun.(*ast.SelectorExpr); ok && sel.Sel.Name == "Put" {
+				checker.CheckCall(node)
+			}
+		case *ast.CompositeLit:
+			checker.CheckCompositeLit(node)
+		case *ast.AssignStmt:
+			checker.CheckAssign(node)
+		}
+	})
+
+	return ec.Diagnostics(pass, files.IgnoreFunc()), nil
+}

--- a/pkg/analyzer/message_code_test.go
+++ b/pkg/analyzer/message_code_test.go
@@ -17,7 +17,7 @@ import (
 // prefix.
 func TestDiagnosticMessageCarriesCode(t *testing.T) {
 	results := analysistest.Run(t, analysistest.TestData(), Analyzer,
-		"mutex", "waitgroup", "once", "cond", "packagelevel", "ignoredirective", "generated")
+		"mutex", "waitgroup", "once", "cond", "pool", "synccopy", "packagelevel", "ignoredirective", "generated")
 
 	total := 0
 	for _, res := range results {

--- a/pkg/analyzer/rwmutex_recursive_lock_test.go
+++ b/pkg/analyzer/rwmutex_recursive_lock_test.go
@@ -1,0 +1,42 @@
+package analyzer
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/internal/common/category"
+	"golang.org/x/tools/go/analysis/analysistest"
+)
+
+// TestRWMutexRecursiveLockCategory pins the read/write self-deadlock
+// diagnostics to GCL1013 specifically. The `// want` markers on those fixtures
+// only match message text, which is also a substring of the GCL1011
+// double-lock messages; without this test, silently reverting the
+// reclassification back to GCL1011 (see lockstate.go) would not fail any
+// fixture.
+func TestRWMutexRecursiveLockCategory(t *testing.T) {
+	results := analysistest.Run(t, analysistest.TestData(), Analyzer, "mutex")
+
+	const (
+		readThenWrite = "attempts write Lock while read lock is held"
+		writeThenRead = "attempts read RLock while write lock is held"
+	)
+
+	found := 0
+	for _, res := range results {
+		for _, diag := range res.Diagnostics {
+			if !strings.Contains(diag.Message, readThenWrite) && !strings.Contains(diag.Message, writeThenRead) {
+				continue
+			}
+			found++
+			if diag.Category != string(category.RWMutexRecursiveLock) {
+				t.Errorf("diagnostic %q carries category %q, want %q",
+					diag.Message, diag.Category, category.RWMutexRecursiveLock)
+			}
+		}
+	}
+
+	if found == 0 {
+		t.Fatal("expected at least one rwmutex recursive-lock diagnostic in the mutex fixtures")
+	}
+}

--- a/pkg/analyzer/testdata/src/mutex/rwmutex_cases.go
+++ b/pkg/analyzer/testdata/src/mutex/rwmutex_cases.go
@@ -56,6 +56,57 @@ func BadRWMutexPromotionWithDeferredRUnlock() {
 	mu.Unlock()
 }
 
+// Acquiring a read lock while already holding the write lock deadlocks in the
+// same goroutine: the blocking RLock waits for the goroutine's own Unlock.
+func BadRWMutexWriteThenRead() {
+	var mu sync.RWMutex
+	mu.Lock()
+	mu.RLock() // want "rwmutex 'mu' attempts read RLock while write lock is held"
+	mu.RUnlock()
+	mu.Unlock()
+}
+
+// A deferred Unlock still leaves the write lock held when RLock is reached.
+func BadRWMutexWriteThenReadWithDeferredUnlock() {
+	var mu sync.RWMutex
+	mu.Lock()
+	defer mu.Unlock()
+	mu.RLock() // want "rwmutex 'mu' attempts read RLock while write lock is held"
+	mu.RUnlock()
+}
+
+// The read lock is fine once the write lock has been released first.
+func GoodRWMutexWriteThenReadAfterUnlock() {
+	var mu sync.RWMutex
+	mu.Lock()
+	mu.Unlock()
+	mu.RLock()
+	mu.RUnlock()
+}
+
+// The read lock is still held inside the branch, so the promotion deadlocks.
+func BadRWMutexPromotionInBranch(cond bool) {
+	var mu sync.RWMutex
+	mu.RLock()
+	if cond {
+		mu.Lock() // want "rwmutex 'mu' attempts write Lock while read lock is held"
+		mu.Unlock()
+	}
+	mu.RUnlock()
+}
+
+// The read lock is released before the branch, so the later write lock is safe
+// on every path and must not be flagged.
+func GoodRWMutexReleaseBeforeBranch(cond bool) {
+	var mu sync.RWMutex
+	mu.RLock()
+	mu.RUnlock()
+	if cond {
+		mu.Lock()
+		mu.Unlock()
+	}
+}
+
 // RLock without RUnlock
 func BadRLockWithoutRUnlock() {
 	var mu sync.RWMutex
@@ -272,11 +323,12 @@ func BadRWImbalancedRLockRUnlock() {
 	mu.RUnlock()
 }
 
-// Imbalanced: lock and rlock, only unlock
+// Imbalanced: lock and rlock, only unlock. The RLock while the write lock is
+// held is itself a self-deadlock (GCL1013), and the read lock is never released.
 func BadRWImbalancedMixed() {
 	var mu sync.RWMutex
 	mu.Lock()
-	mu.RLock() // want "rwmutex 'mu' is rlocked but not runlocked"
+	mu.RLock() // want "rwmutex 'mu' attempts read RLock while write lock is held" "rwmutex 'mu' is rlocked but not runlocked"
 	mu.Unlock()
 }
 

--- a/pkg/analyzer/testdata/src/once/once_constructor_cases.go
+++ b/pkg/analyzer/testdata/src/once/once_constructor_cases.go
@@ -1,0 +1,61 @@
+package once
+
+import "sync"
+
+// ========== once-constructor-nil (GCL3003) ==========
+
+// Bad: OnceFunc(nil) — the returned function invokes a nil func and panics.
+func BadOnceFuncNil() {
+	handle := sync.OnceFunc(nil) // want "sync.OnceFunc called with nil function"
+	handle()
+}
+
+// Bad: OnceValue[int](nil) — a generic instantiation (IndexExpr) still resolves
+// to sync.OnceValue.
+func BadOnceValueNil() {
+	get := sync.OnceValue[int](nil) // want "sync.OnceValue called with nil function"
+	_ = get()
+}
+
+// Bad: OnceValues[int, string](nil) — two type arguments (IndexListExpr).
+func BadOnceValuesNil() {
+	get := sync.OnceValues[int, string](nil) // want "sync.OnceValues called with nil function"
+	_, _ = get()
+}
+
+// Bad: the nil literal survives redundant parentheses.
+func BadOnceFuncNilParen() {
+	_ = sync.OnceFunc((nil)) // want "sync.OnceFunc called with nil function"
+}
+
+// Good: a real function is memoized.
+func GoodOnceFunc() {
+	handle := sync.OnceFunc(func() { initResource() })
+	handle()
+}
+
+// Good: OnceValue with a real function.
+func GoodOnceValue() {
+	get := sync.OnceValue(func() int { return 42 })
+	_ = get()
+}
+
+// Precision: a nil-typed variable is not the literal nil, so it is not flagged;
+// only the statically-known nil literal is reported.
+func OnceFuncNilVarNotFlagged() {
+	var f func()
+	_ = sync.OnceFunc(f)
+}
+
+// Precision: a same-named method on another type must not be flagged — only the
+// real sync constructors are.
+type fakeOnce struct{}
+
+func (fakeOnce) OnceFunc(f func()) func() { return f }
+
+func OnceFuncLookalikeNotFlagged() {
+	var x fakeOnce
+	_ = x.OnceFunc(nil)
+}
+
+func initResource() {}

--- a/pkg/analyzer/testdata/src/pool/pool_cases.go
+++ b/pkg/analyzer/testdata/src/pool/pool_cases.go
@@ -1,0 +1,218 @@
+package pool
+
+import (
+	"bytes"
+	"sync"
+	"unsafe"
+)
+
+// ========== pool-non-pointer-value (GCL5001) ==========
+//
+// sync.Pool.Put(v) stores v in the pool's internal interface. If v is not
+// pointer-shaped it is boxed with a heap allocation on every Put, defeating the
+// pool. The fix is always to store a pointer (or another pointer-shaped value).
+
+// --- Bad: non-pointer values box and allocate on every Put ---
+
+// A slice ([]byte) is the canonical case: store *[]byte instead.
+func BadPutSlice() {
+	var p sync.Pool
+	buf := make([]byte, 1024)
+	p.Put(buf) // want "sync.Pool.Put stores non-pointer value"
+}
+
+func BadPutString() {
+	var p sync.Pool
+	p.Put("value") // want "sync.Pool.Put stores non-pointer value"
+}
+
+func BadPutInt() {
+	var p sync.Pool
+	p.Put(42) // want "sync.Pool.Put stores non-pointer value"
+}
+
+// A multi-field struct value is not pointer-shaped.
+func BadPutStructValue() {
+	var p sync.Pool
+	var b bytes.Buffer
+	p.Put(b) // want "sync.Pool.Put stores non-pointer value"
+}
+
+// --- Good: pointer-shaped values are stored directly, no allocation ---
+
+func GoodPutPointerToSlice() {
+	var p sync.Pool
+	buf := make([]byte, 1024)
+	p.Put(&buf)
+}
+
+func GoodPutPointerToStruct() {
+	var p sync.Pool
+	p.Put(new(bytes.Buffer))
+}
+
+func GoodPutMap() {
+	var p sync.Pool
+	p.Put(make(map[string]int))
+}
+
+func GoodPutChan() {
+	var p sync.Pool
+	p.Put(make(chan int))
+}
+
+func GoodPutFunc() {
+	var p sync.Pool
+	p.Put(func() {})
+}
+
+// nil stores a nil interface; no allocation.
+func GoodPutNil() {
+	var p sync.Pool
+	p.Put(nil)
+}
+
+// An interface value is assigned to the any parameter without re-boxing.
+func GoodPutInterface(err error) {
+	var p sync.Pool
+	p.Put(err)
+}
+
+// --- Precision: a same-named Put on another type must not be flagged ---
+
+type fakePool struct{}
+
+func (fakePool) Put(v any) {}
+
+func PutLookalikeNotFlagged() {
+	var fp fakePool
+	fp.Put(42)
+}
+
+// A Pool reached through a struct field is still a sync.Pool.
+type server struct {
+	pool sync.Pool
+}
+
+func (s *server) BadPutViaField() {
+	buf := make([]byte, 8)
+	s.pool.Put(buf) // want "sync.Pool.Put stores non-pointer value"
+}
+
+// ========== pointer-shape classification (hardening) ==========
+
+// An array of more than one element is not pointer-shaped.
+func BadPutArray() {
+	var p sync.Pool
+	p.Put([2]int{1, 2}) // want "sync.Pool.Put stores non-pointer value"
+}
+
+// A single-element array of a pointer-shaped type is itself pointer-shaped.
+func GoodPutSingleElemPointerArray() {
+	var p sync.Pool
+	x := 1
+	p.Put([1]*int{&x})
+}
+
+type ptrBox struct{ p *int }
+
+// A single-field struct whose field is a pointer is pointer-shaped (Go's
+// runtime stores it directly in the interface).
+func GoodPutSingleFieldPointerStruct() {
+	var p sync.Pool
+	x := 1
+	p.Put(ptrBox{&x})
+}
+
+type intBox struct{ n int }
+
+// A single-field struct whose field is a value is not pointer-shaped.
+func BadPutSingleFieldValueStruct() {
+	var p sync.Pool
+	p.Put(intBox{1}) // want "sync.Pool.Put stores non-pointer value"
+}
+
+// unsafe.Pointer is pointer-shaped.
+func GoodPutUnsafePointer() {
+	var p sync.Pool
+	x := 1
+	p.Put(unsafe.Pointer(&x))
+}
+
+// A zero-size struct shares runtime.zerobase and never allocates, regardless
+// of boxing — the common semaphore-token idiom must not be flagged.
+func GoodPutEmptyStruct() {
+	var p sync.Pool
+	p.Put(struct{}{})
+}
+
+type token struct{}
+
+// A named zero-size struct is zero-size too.
+func GoodPutNamedEmptyStruct() {
+	var p sync.Pool
+	p.Put(token{})
+}
+
+// A zero-length array is zero-size for the same reason.
+func GoodPutZeroLengthArray() {
+	var p sync.Pool
+	p.Put([0]int{})
+}
+
+// ========== New returning a non-pointer value ==========
+
+// Bad: New returns a slice, boxed into the pool interface on every miss.
+func BadNewReturnsSlice() {
+	p := sync.Pool{New: func() any {
+		return make([]byte, 1024) // want "sync.Pool.New returns non-pointer value"
+	}}
+	_ = p
+}
+
+// Bad: the returned value flows through a local variable first.
+func BadNewReturnsVarSlice() {
+	p := sync.Pool{New: func() any {
+		b := make([]byte, 8)
+		return b // want "sync.Pool.New returns non-pointer value"
+	}}
+	_ = p
+}
+
+// Bad: New assigned as a field returns a struct value.
+func BadNewAssignReturnsStruct() {
+	var p sync.Pool
+	p.New = func() any {
+		return bytes.Buffer{} // want "sync.Pool.New returns non-pointer value"
+	}
+	_ = p.Get()
+}
+
+// Good: New returns a pointer.
+func GoodNewReturnsPointer() {
+	p := sync.Pool{New: func() any {
+		return new(bytes.Buffer)
+	}}
+	_ = p
+}
+
+// Good: New assigned as a field returns a pointer.
+func GoodNewAssignReturnsPointer() {
+	var p sync.Pool
+	p.New = func() any {
+		return &bytes.Buffer{}
+	}
+	_ = p.Get()
+}
+
+// Conservative: a New with more than one return path is left alone, even though
+// one branch returns a non-pointer — the intent is ambiguous.
+func NewMultiReturnNotFlagged(cond bool) {
+	p := sync.Pool{New: func() any {
+		if cond {
+			return new(bytes.Buffer)
+		}
+		return make([]byte, 8)
+	}}
+	_ = p
+}

--- a/pkg/analyzer/testdata/src/synccopy/copy_cases.go
+++ b/pkg/analyzer/testdata/src/synccopy/copy_cases.go
@@ -1,0 +1,76 @@
+package synccopy
+
+import "sync"
+
+// ========== sync-primitive-copy for sync.Cond / sync.Pool / sync.Map (GCL9001) ==========
+//
+// These primitives contain a noCopy / internal state that must not be duplicated
+// after first use. go vet's copylocks flags the same copies, so this is a
+// zero-false-positive extension of the copy check to the rest of the sync
+// package. A *pointer* to any of them may be shared and copied freely; only a
+// by-value copy is a bug.
+
+// --- sync.Cond ---
+
+func takesCondByValue(c sync.Cond) {} // want "cond 'c' is copied by value"
+
+func BadCopyCond() {
+	var c sync.Cond
+	cp := c // want "cond 'c' is copied by value"
+	_ = cp
+}
+
+// Good: a *sync.Cond pointer is passed around, never the value.
+func GoodCondPointer() {
+	var mu sync.Mutex
+	c := sync.NewCond(&mu)
+	usesCondPointer(c)
+}
+
+func usesCondPointer(c *sync.Cond) { _ = c }
+
+// --- sync.Pool ---
+
+func takesPoolByValue(p sync.Pool) {} // want "pool 'p' is copied by value"
+
+func BadCopyPool() {
+	var p sync.Pool
+	cp := p // want "pool 'p' is copied by value"
+	_ = cp
+}
+
+// Good: the pool is used in place; method calls do not copy it.
+func GoodPoolInPlace() {
+	var p sync.Pool
+	v := 1
+	p.Put(&v) // pointer-shaped: no GCL5001
+	_ = p.Get()
+}
+
+// --- sync.Map ---
+
+func takesMapByValue(m sync.Map) {} // want "sync.Map 'm' is copied by value"
+
+func BadCopyMap() {
+	var m sync.Map
+	cp := m // want "sync.Map 'm' is copied by value"
+	_ = cp
+}
+
+// Good: the map is used in place.
+func GoodMapInPlace() {
+	var m sync.Map
+	m.Store("k", 1)
+	_, _ = m.Load("k")
+}
+
+// --- a struct that holds one of them by value ---
+
+type resources struct {
+	pool sync.Pool
+}
+
+func takesResourcesByValue(r resources) {} // want "struct 'r' containing pool is copied by value"
+
+// Good: hold and pass the struct by pointer.
+func takesResourcesByPointer(r *resources) { _ = r }

--- a/scripts/gendocs/main.go
+++ b/scripts/gendocs/main.go
@@ -42,6 +42,7 @@ var groups = []group{
 	{'2', "sync.WaitGroup"},
 	{'3', "sync.Once"},
 	{'4', "sync.Cond"},
+	{'5', "sync.Pool"},
 	{'9', "Cross-cutting"},
 }
 


### PR DESCRIPTION
- GCL5001 pool-non-pointer-value: Put + New non-pointer detection
- GCL3003 once-constructor-nil: OnceFunc/OnceValue/OnceValues(nil)
- GCL1013 rwmutex-recursive-lock: read<->write self-deadlock (both directions)
- GCL9001 copy check extended to sync.Cond, sync.Pool, sync.Map
- extract internal/callscan shared skeleton (cond + once constructor scan)
- fix zero-size false positive in pool pointer-shape classification