### PR TITLE
feat: add channel misuse checks (GCL6001-6004)

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,10 @@ Each check has a stable code (e.g. `GCL1001`) shown in the diagnostic message an
 | [`GCL3003`](docs/checks/GCL3003.md) | `once-constructor-nil` | `sync.Once` | sync.OnceFunc/OnceValue/OnceValues is called with a nil function, which panics when the memoized function first runs. |
 | [`GCL4001`](docs/checks/GCL4001.md) | `cond-new-nil-locker` | `sync.Cond` | sync.NewCond(nil) builds a Cond whose Locker is nil, so the first Wait panics at runtime. |
 | [`GCL5001`](docs/checks/GCL5001.md) | `pool-non-pointer-value` | `sync.Pool` | A non-pointer value is placed in a sync.Pool (a Put argument or a New return), so every call boxes it into an interface and heap-allocates — defeating the pool. |
+| [`GCL6001`](docs/checks/GCL6001.md) | `close-of-nil-channel` | `channel` | close() is called on a channel that is nil on every path reaching the call, which panics at runtime. |
+| [`GCL6002`](docs/checks/GCL6002.md) | `close-of-closed-channel` | `channel` | close() is called on a channel that is already closed on every path reaching the call, which panics at runtime. |
+| [`GCL6003`](docs/checks/GCL6003.md) | `send-on-closed-channel` | `channel` | A value is sent on a channel that is already closed on every path reaching the send, which panics at runtime. |
+| [`GCL6004`](docs/checks/GCL6004.md) | `nil-channel-op` | `channel` | A send or receive is performed on a channel that is nil on every path reaching the operation, which blocks the goroutine forever. |
 | [`GCL9001`](docs/checks/GCL9001.md) | `sync-primitive-copy` | `sync.Mutex`, `sync.RWMutex`, `sync.WaitGroup`, `sync.Once`, `sync.Cond`, `sync.Pool`, `sync.Map` | A sync primitive (or a struct embedding one) is copied by value. |
 <!-- END GENERATED CHECKS TABLE -->
 

--- a/docs/checks/GCL6001.md
+++ b/docs/checks/GCL6001.md
@@ -1,0 +1,42 @@
+# GCL6001 — close-of-nil-channel
+
+> close() is called on a channel that is nil on every path reaching the call, which panics at runtime.
+
+|           |                              |
+|-----------|------------------------------|
+| Code      | `GCL6001` |
+| Slug      | `close-of-nil-channel` |
+| Primitive | `channel` |
+
+## Why it matters
+
+Closing a nil channel panics with "close of nil channel"; the variable was declared but never assigned a channel from make.
+
+## Examples
+
+The linter flags code like this:
+
+```go
+var ch chan int
+close(ch) // ch is nil: panics with "close of nil channel"
+```
+
+Write it like this instead:
+
+```go
+ch := make(chan int)
+close(ch)
+```
+
+## Suppressing this check
+
+Add an inline directive on the offending line. Either the canonical code or the legacy slug is accepted:
+
+```go
+foo() // goconcurrencylint:ignore GCL6001
+foo() // goconcurrencylint:ignore close-of-nil-channel
+```
+
+See the [check catalogue](README.md) for every check.
+
+<sub>Generated from the check registry by `scripts/gendocs` — do not edit by hand.</sub>

--- a/docs/checks/GCL6002.md
+++ b/docs/checks/GCL6002.md
@@ -1,0 +1,43 @@
+# GCL6002 — close-of-closed-channel
+
+> close() is called on a channel that is already closed on every path reaching the call, which panics at runtime.
+
+|           |                              |
+|-----------|------------------------------|
+| Code      | `GCL6002` |
+| Slug      | `close-of-closed-channel` |
+| Primitive | `channel` |
+
+## Why it matters
+
+Closing an already-closed channel panics with "close of closed channel"; a channel must be closed exactly once.
+
+## Examples
+
+The linter flags code like this:
+
+```go
+ch := make(chan int)
+close(ch)
+close(ch) // already closed: panics with "close of closed channel"
+```
+
+Write it like this instead:
+
+```go
+ch := make(chan int)
+close(ch)
+```
+
+## Suppressing this check
+
+Add an inline directive on the offending line. Either the canonical code or the legacy slug is accepted:
+
+```go
+foo() // goconcurrencylint:ignore GCL6002
+foo() // goconcurrencylint:ignore close-of-closed-channel
+```
+
+See the [check catalogue](README.md) for every check.
+
+<sub>Generated from the check registry by `scripts/gendocs` — do not edit by hand.</sub>

--- a/docs/checks/GCL6003.md
+++ b/docs/checks/GCL6003.md
@@ -1,0 +1,44 @@
+# GCL6003 — send-on-closed-channel
+
+> A value is sent on a channel that is already closed on every path reaching the send, which panics at runtime.
+
+|           |                              |
+|-----------|------------------------------|
+| Code      | `GCL6003` |
+| Slug      | `send-on-closed-channel` |
+| Primitive | `channel` |
+
+## Why it matters
+
+Sending on a closed channel panics with "send on closed channel"; closing signals that no more values will ever be sent.
+
+## Examples
+
+The linter flags code like this:
+
+```go
+ch := make(chan int, 1)
+close(ch)
+ch <- 1 // channel already closed: panics with "send on closed channel"
+```
+
+Write it like this instead:
+
+```go
+ch := make(chan int, 1)
+ch <- 1
+close(ch)
+```
+
+## Suppressing this check
+
+Add an inline directive on the offending line. Either the canonical code or the legacy slug is accepted:
+
+```go
+foo() // goconcurrencylint:ignore GCL6003
+foo() // goconcurrencylint:ignore send-on-closed-channel
+```
+
+See the [check catalogue](README.md) for every check.
+
+<sub>Generated from the check registry by `scripts/gendocs` — do not edit by hand.</sub>

--- a/docs/checks/GCL6004.md
+++ b/docs/checks/GCL6004.md
@@ -1,0 +1,42 @@
+# GCL6004 — nil-channel-op
+
+> A send or receive is performed on a channel that is nil on every path reaching the operation, which blocks the goroutine forever.
+
+|           |                              |
+|-----------|------------------------------|
+| Code      | `GCL6004` |
+| Slug      | `nil-channel-op` |
+| Primitive | `channel` |
+
+## Why it matters
+
+Send and receive on a nil channel block forever; the variable was declared but never assigned a channel from make. A nil channel inside a select is a legitimate way to disable a case and is not flagged.
+
+## Examples
+
+The linter flags code like this:
+
+```go
+var ch chan int
+ch <- 1 // ch is nil: this goroutine blocks forever
+```
+
+Write it like this instead:
+
+```go
+ch := make(chan int, 1)
+ch <- 1
+```
+
+## Suppressing this check
+
+Add an inline directive on the offending line. Either the canonical code or the legacy slug is accepted:
+
+```go
+foo() // goconcurrencylint:ignore GCL6004
+foo() // goconcurrencylint:ignore nil-channel-op
+```
+
+See the [check catalogue](README.md) for every check.
+
+<sub>Generated from the check registry by `scripts/gendocs` — do not edit by hand.</sub>

--- a/docs/checks/README.md
+++ b/docs/checks/README.md
@@ -60,6 +60,15 @@ Every diagnostic `goconcurrencylint` can emit, with its stable code. The code is
 |------|------|-------------|
 | [GCL5001](GCL5001.md) | `pool-non-pointer-value` | A non-pointer value is placed in a sync.Pool (a Put argument or a New return), so every call boxes it into an interface and heap-allocates — defeating the pool. |
 
+## Channels
+
+| Code | Slug | Description |
+|------|------|-------------|
+| [GCL6001](GCL6001.md) | `close-of-nil-channel` | close() is called on a channel that is nil on every path reaching the call, which panics at runtime. |
+| [GCL6002](GCL6002.md) | `close-of-closed-channel` | close() is called on a channel that is already closed on every path reaching the call, which panics at runtime. |
+| [GCL6003](GCL6003.md) | `send-on-closed-channel` | A value is sent on a channel that is already closed on every path reaching the send, which panics at runtime. |
+| [GCL6004](GCL6004.md) | `nil-channel-op` | A send or receive is performed on a channel that is nil on every path reaching the operation, which blocks the goroutine forever. |
+
 ## Cross-cutting
 
 | Code | Slug | Description |

--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -16,6 +16,7 @@
 //	├── once.SubAnalyzer ───────┤── requires filesetup.Analyzer   │
 //	├── cond.SubAnalyzer ───────┤                                 │
 //	├── pool.SubAnalyzer ───────┤                                 │
+//	├── channel.SubAnalyzer ────┤                                 │
 //	└── copycheck.Analyzer ─────┘                                 └── requires inspect.Analyzer
 //
 // "A requires B" means B runs first and exposes its Result through
@@ -27,6 +28,7 @@ package analyzer
 
 import (
 	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/internal/cond"
+	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/internal/channel"
 	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/internal/copycheck"
 	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/internal/mutex"
 	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/internal/once"
@@ -37,7 +39,7 @@ import (
 
 var Analyzer = &analysis.Analyzer{
 	Name: "goconcurrencylint",
-	Doc:  "Detects misuse of sync.Mutex, sync.RWMutex, sync.WaitGroup, sync.Once, sync.Cond and sync.Pool, plus copy-by-value of sync primitives.",
+	Doc:  "Detects misuse of sync.Mutex, sync.RWMutex, sync.WaitGroup, sync.Once, sync.Cond, sync.Pool and channels, plus copy-by-value of sync primitives.",
 	Run:  run,
 	Requires: []*analysis.Analyzer{
 		mutex.SubAnalyzer,
@@ -45,6 +47,7 @@ var Analyzer = &analysis.Analyzer{
 		once.SubAnalyzer,
 		cond.SubAnalyzer,
 		pool.SubAnalyzer,
+		channel.SubAnalyzer,
 		copycheck.Analyzer,
 	},
 }
@@ -56,6 +59,7 @@ func run(pass *analysis.Pass) (any, error) {
 		once.SubAnalyzer,
 		cond.SubAnalyzer,
 		pool.SubAnalyzer,
+		channel.SubAnalyzer,
 		copycheck.Analyzer,
 	}
 	for _, sub := range subs {

--- a/pkg/analyzer/analyzer_integration_test.go
+++ b/pkg/analyzer/analyzer_integration_test.go
@@ -15,6 +15,7 @@ func TestAnalyzerFixtures(t *testing.T) {
 		{name: "once", packages: []string{"once"}},
 		{name: "cond", packages: []string{"cond"}},
 		{name: "pool", packages: []string{"pool"}},
+		{name: "channel", packages: []string{"channel"}},
 		{name: "synccopy", packages: []string{"synccopy"}},
 		{name: "packagelevel", packages: []string{"packagelevel"}},
 		{name: "ignoredirective", packages: []string{"ignoredirective"}},

--- a/pkg/analyzer/internal/channel/analyzer.go
+++ b/pkg/analyzer/internal/channel/analyzer.go
@@ -1,0 +1,586 @@
+package channel
+
+import (
+	"go/ast"
+	"go/token"
+	"go/types"
+
+	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/internal/common"
+	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/internal/common/category"
+	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/internal/common/report"
+)
+
+// checker runs the channel state machine over one function scope (a FuncDecl or
+// FuncLit body). It tracks only channel variables declared inside that scope;
+// variables from an enclosing scope, parameters and package-scope channels are
+// left Unknown and never reported.
+type checker struct {
+	ec       report.Reporter
+	info     *types.Info
+	poisoned map[types.Object]bool
+}
+
+func newChecker(ec report.Reporter, info *types.Info) *checker {
+	return &checker{ec: ec, info: info}
+}
+
+// analyzeBody walks body once to find variables that must not be tracked
+// precisely (poisonedVars), then interprets the body from an empty state.
+func (c *checker) analyzeBody(body *ast.BlockStmt) {
+	c.poisoned = poisonedVars(body, c.info)
+	c.evalBlock(body.List, state{})
+}
+
+// evalBlock threads the state sequentially through the statements of a block.
+func (c *checker) evalBlock(stmts []ast.Stmt, s state) state {
+	for _, stmt := range stmts {
+		s = c.evalStmt(stmt, s)
+	}
+	return s
+}
+
+// evalStmt applies one statement to the incoming state and returns the outgoing
+// state. Statements the analysis does not model (go/defer bodies, returns,
+// increments) pass the state through unchanged.
+func (c *checker) evalStmt(stmt ast.Stmt, s state) state {
+	switch n := stmt.(type) {
+	case *ast.DeclStmt:
+		c.evalDecl(n, s)
+	case *ast.AssignStmt:
+		return c.evalAssign(n, s)
+	case *ast.SendStmt:
+		return c.evalSend(n, s, false)
+	case *ast.ExprStmt:
+		return c.evalExprStmt(n, s)
+	case *ast.BlockStmt:
+		return c.evalBlock(n.List, s)
+	case *ast.IfStmt:
+		return c.evalIf(n, s)
+	case *ast.ForStmt:
+		return c.evalFor(n, s)
+	case *ast.RangeStmt:
+		return c.evalRange(n, s)
+	case *ast.SwitchStmt:
+		return c.evalSwitch(n, s)
+	case *ast.TypeSwitchStmt:
+		if n.Init != nil {
+			s = c.evalStmt(n.Init, s)
+		}
+		return c.evalCaseBodies(n.Body, s)
+	case *ast.SelectStmt:
+		return c.evalSelect(n, s)
+	case *ast.LabeledStmt:
+		return c.evalStmt(n.Stmt, s)
+	}
+	return s
+}
+
+// evalDecl handles `var ch chan T` declarations: a var with no initializer is a
+// nil channel; one initialized from make is Open; anything else is Unknown.
+func (c *checker) evalDecl(n *ast.DeclStmt, s state) {
+	gd, ok := n.Decl.(*ast.GenDecl)
+	if !ok || gd.Tok != token.VAR {
+		return
+	}
+	for _, spec := range gd.Specs {
+		vs, ok := spec.(*ast.ValueSpec)
+		if !ok {
+			continue
+		}
+		for i, nameIdent := range vs.Names {
+			obj := c.info.Defs[nameIdent]
+			if obj == nil || !common.IsChannel(obj.Type()) || c.poisoned[obj] {
+				continue
+			}
+			switch {
+			case len(vs.Values) == 0:
+				s[obj] = Nil // zero value of a channel type is nil
+			case len(vs.Values) == len(vs.Names):
+				s[obj] = c.rhsState(vs.Values[i])
+			default:
+				s[obj] = Unknown // multi-value initializer we cannot split
+			}
+		}
+	}
+}
+
+// evalAssign checks any receive on the right-hand side for a nil-channel
+// operation and updates the state of channel-typed left-hand variables.
+func (c *checker) evalAssign(n *ast.AssignStmt, s state) state {
+	for _, rhs := range n.Rhs {
+		c.checkReceiveExpr(rhs, s, false)
+	}
+	return c.applyAssignLHS(n, s)
+}
+
+// applyAssignLHS updates the state of channel-typed left-hand variables from
+// the assignment's right-hand side: make(chan ...) is Open, nil is Nil, and
+// anything else — including a value received from a channel — is Unknown. It is
+// shared by ordinary assignments and select comm clauses so that a variable
+// assigned inside `case v = <-ch:` is no longer treated as its old state.
+func (c *checker) applyAssignLHS(n *ast.AssignStmt, s state) state {
+	aligned := len(n.Lhs) == len(n.Rhs)
+	for i, lhs := range n.Lhs {
+		ident, ok := lhs.(*ast.Ident)
+		if !ok || ident.Name == "_" {
+			continue
+		}
+		obj := c.info.ObjectOf(ident)
+		if obj == nil || !common.IsChannel(obj.Type()) || c.poisoned[obj] {
+			continue
+		}
+		if aligned {
+			s[obj] = c.rhsState(n.Rhs[i])
+		} else {
+			s[obj] = Unknown
+		}
+	}
+	return s
+}
+
+// rhsState classifies the value assigned to a channel variable: make(chan ...)
+// yields Open, an explicit nil yields Nil, and everything else is Unknown.
+func (c *checker) rhsState(rhs ast.Expr) chanState {
+	switch e := common.UnwrapParenExpr(rhs).(type) {
+	case *ast.CallExpr:
+		if ident, ok := e.Fun.(*ast.Ident); ok && ident.Name == "make" {
+			if _, isBuiltin := c.info.ObjectOf(ident).(*types.Builtin); isBuiltin {
+				return Open
+			}
+		}
+	case *ast.Ident:
+		if e.Name == "nil" {
+			return Nil
+		}
+	}
+	return Unknown
+}
+
+// evalExprStmt handles the two channel operations that appear as bare
+// statements: close(ch) and a discarded receive <-ch.
+func (c *checker) evalExprStmt(n *ast.ExprStmt, s state) state {
+	switch e := common.UnwrapParenExpr(n.X).(type) {
+	case *ast.CallExpr:
+		if c.isCloseCall(e) {
+			return c.evalClose(e, s)
+		}
+	case *ast.UnaryExpr:
+		if e.Op == token.ARROW {
+			c.checkReceive(e.X, s, false)
+		}
+	}
+	return s
+}
+
+// isCloseCall reports whether call is the builtin close(x) with a single
+// argument, guarding against a same-named user function.
+func (c *checker) isCloseCall(call *ast.CallExpr) bool {
+	ident, ok := call.Fun.(*ast.Ident)
+	if !ok || ident.Name != "close" || len(call.Args) != 1 {
+		return false
+	}
+	_, isBuiltin := c.info.ObjectOf(ident).(*types.Builtin)
+	return isBuiltin
+}
+
+// evalClose reports close() on a nil (GCL6001) or already-closed (GCL6002)
+// channel and transitions the variable to Closed.
+func (c *checker) evalClose(call *ast.CallExpr, s state) state {
+	obj, name, ok := c.chanObject(call.Args[0])
+	if !ok {
+		return s
+	}
+	switch s.get(obj) {
+	case Nil:
+		c.ec.AddError(call.Pos(), category.CloseOfNilChannel,
+			"close of nil channel '"+name+"' panics at runtime")
+	case Closed:
+		c.ec.AddError(call.Pos(), category.CloseOfClosedChannel,
+			"close of already-closed channel '"+name+"' panics at runtime")
+	}
+	if !c.poisoned[obj] {
+		s[obj] = Closed
+	}
+	return s
+}
+
+// evalSend reports a send on a closed (GCL6003) or nil (GCL6004) channel. A nil
+// send inside a select comm clause is a deliberate way to disable a case and is
+// not reported, but a send on a closed channel panics even there.
+func (c *checker) evalSend(n *ast.SendStmt, s state, inSelectComm bool) state {
+	obj, name, ok := c.chanObject(n.Chan)
+	if !ok {
+		return s
+	}
+	switch s.get(obj) {
+	case Closed:
+		c.ec.AddError(n.Pos(), category.SendOnClosedChannel,
+			"send on closed channel '"+name+"' panics at runtime")
+	case Nil:
+		if !inSelectComm {
+			c.ec.AddError(n.Pos(), category.NilChannelOperation,
+				"send on nil channel '"+name+"' blocks forever")
+		}
+	}
+	return s
+}
+
+// checkReceiveExpr reports a nil-channel receive when expr is a top-level
+// receive (v := <-ch). Receives nested deeper in an expression are not tracked.
+func (c *checker) checkReceiveExpr(expr ast.Expr, s state, inSelectComm bool) {
+	if u, ok := common.UnwrapParenExpr(expr).(*ast.UnaryExpr); ok && u.Op == token.ARROW {
+		c.checkReceive(u.X, s, inSelectComm)
+	}
+}
+
+// checkReceive reports a receive on a nil channel (GCL6004), unless it is a
+// select comm clause, where a nil channel deliberately disables the case.
+func (c *checker) checkReceive(chanExpr ast.Expr, s state, inSelectComm bool) {
+	obj, name, ok := c.chanObject(chanExpr)
+	if !ok || inSelectComm {
+		return
+	}
+	if s.get(obj) == Nil {
+		c.ec.AddError(chanExpr.Pos(), category.NilChannelOperation,
+			"receive on nil channel '"+name+"' blocks forever")
+	}
+}
+
+// evalIf evaluates both arms from a clone of the incoming state and merges the
+// results, so a variable only stays concrete when both arms agree.
+//
+// It also applies nil-guard narrowing: `if ch != nil { ... }` proves ch is not
+// nil inside the then-branch, and `if ch == nil { ... }` proves it inside the
+// else-branch (and the fall-through when the then-branch exits). Narrowing only
+// ever clears a Nil state to Unknown — it never introduces Nil — so it can only
+// suppress reports, never create them. This models the ubiquitous
+// lazily-initialised channel guarded by an explicit nil check.
+func (c *checker) evalIf(n *ast.IfStmt, s state) state {
+	if n.Init != nil {
+		s = c.evalStmt(n.Init, s)
+	}
+
+	thenClear := map[types.Object]bool{}
+	elseClear := map[types.Object]bool{}
+	c.nonNilInThen(n.Cond, thenClear)
+	c.nonNilInElse(n.Cond, elseClear)
+
+	thenIn := s.clone()
+	clearNil(thenIn, thenClear)
+	thenS := c.evalBlock(n.Body.List, thenIn)
+
+	elseIn := s.clone()
+	clearNil(elseIn, elseClear)
+	var elseS state
+	if n.Else != nil {
+		elseS = c.evalStmt(n.Else, elseIn)
+	} else {
+		elseS = elseIn
+	}
+
+	// When one arm cannot fall through (it returns/continues/breaks/panics),
+	// the state after the if is only the other arm's — carrying that arm's
+	// nil-guard narrowing forward. This is what makes `if ch == nil { return }`
+	// followed by an operation on ch safe: the continuation runs only when ch
+	// is non-nil.
+	if blockTerminates(n.Body) {
+		return elseS
+	}
+	if elseTerminates(n.Else) {
+		return thenS
+	}
+	return merge(thenS, elseS)
+}
+
+// nonNilInThen collects channel objects guaranteed non-nil when cond is true
+// (the then-branch): a bare `ch != nil`, and every such guard in an && chain.
+func (c *checker) nonNilInThen(cond ast.Expr, out map[types.Object]bool) {
+	be, ok := common.UnwrapParenExpr(cond).(*ast.BinaryExpr)
+	if !ok {
+		return
+	}
+	switch be.Op {
+	case token.NEQ:
+		if obj := c.nilCompObject(be.X, be.Y); obj != nil {
+			out[obj] = true
+		}
+	case token.LAND:
+		c.nonNilInThen(be.X, out)
+		c.nonNilInThen(be.Y, out)
+	}
+}
+
+// nonNilInElse collects channel objects guaranteed non-nil when cond is false
+// (the else-branch): a bare `ch == nil`, and every such guard in an || chain.
+func (c *checker) nonNilInElse(cond ast.Expr, out map[types.Object]bool) {
+	be, ok := common.UnwrapParenExpr(cond).(*ast.BinaryExpr)
+	if !ok {
+		return
+	}
+	switch be.Op {
+	case token.EQL:
+		if obj := c.nilCompObject(be.X, be.Y); obj != nil {
+			out[obj] = true
+		}
+	case token.LOR:
+		c.nonNilInElse(be.X, out)
+		c.nonNilInElse(be.Y, out)
+	}
+}
+
+// nilCompObject returns the channel variable object compared against nil in
+// `ch == nil` / `ch != nil` (either operand order), or nil when the expression
+// is not a nil comparison of a tracked channel identifier.
+func (c *checker) nilCompObject(x, y ast.Expr) types.Object {
+	if isNilIdent(x) {
+		if obj, _, ok := c.chanObject(y); ok {
+			return obj
+		}
+	}
+	if isNilIdent(y) {
+		if obj, _, ok := c.chanObject(x); ok {
+			return obj
+		}
+	}
+	return nil
+}
+
+// isNilIdent reports whether expr is the predeclared nil identifier.
+func isNilIdent(expr ast.Expr) bool {
+	ident, ok := common.UnwrapParenExpr(expr).(*ast.Ident)
+	return ok && ident.Name == "nil"
+}
+
+// clearNil lifts the listed objects from Nil to Unknown, used to apply
+// nil-guard narrowing. Non-nil states are left untouched.
+func clearNil(s state, objs map[types.Object]bool) {
+	for obj := range objs {
+		if s.get(obj) == Nil {
+			s[obj] = Unknown
+		}
+	}
+}
+
+// blockTerminates reports whether b's straight-line flow cannot fall through to
+// the following statement because its last statement transfers control away
+// (return, continue, break, goto, or panic).
+func blockTerminates(b *ast.BlockStmt) bool {
+	if b == nil || len(b.List) == 0 {
+		return false
+	}
+	return stmtTerminates(b.List[len(b.List)-1])
+}
+
+// elseTerminates reports whether an if statement's else arm cannot fall
+// through. An `else if` terminates only when both of its own arms do.
+func elseTerminates(els ast.Stmt) bool {
+	switch e := els.(type) {
+	case *ast.BlockStmt:
+		return blockTerminates(e)
+	case *ast.IfStmt:
+		return blockTerminates(e.Body) && e.Else != nil && elseTerminates(e.Else)
+	}
+	return false
+}
+
+// stmtTerminates reports whether stmt transfers control away from the current
+// straight-line path.
+func stmtTerminates(stmt ast.Stmt) bool {
+	switch s := stmt.(type) {
+	case *ast.ReturnStmt:
+		return true
+	case *ast.BranchStmt:
+		return s.Tok == token.CONTINUE || s.Tok == token.BREAK || s.Tok == token.GOTO
+	case *ast.ExprStmt:
+		if call, ok := s.X.(*ast.CallExpr); ok {
+			if id, ok := call.Fun.(*ast.Ident); ok && id.Name == "panic" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// evalFor evaluates the loop body once from the entry state (reporting any
+// operation that is already bad on entry) and merges with the entry state to
+// model zero iterations. It does not carry body-end state into a next iteration,
+// so a cross-iteration re-close is missed rather than risking a false positive.
+func (c *checker) evalFor(n *ast.ForStmt, s state) state {
+	if n.Init != nil {
+		s = c.evalStmt(n.Init, s)
+	}
+	bodyS := c.evalBlock(n.Body.List, s.clone())
+	return merge(s, bodyS)
+}
+
+// evalRange treats `range ch` as a receive (a range over a nil channel blocks
+// forever) and evaluates the body like a for loop.
+func (c *checker) evalRange(n *ast.RangeStmt, s state) state {
+	if common.IsChannel(c.info.TypeOf(n.X)) {
+		c.checkReceive(n.X, s, false)
+	}
+	// A channel-typed range variable takes a value of unknown state each
+	// iteration, so it must not keep any prior (e.g. nil) state.
+	c.markUnknown(n.Key, s)
+	c.markUnknown(n.Value, s)
+	bodyS := c.evalBlock(n.Body.List, s.clone())
+	return merge(s, bodyS)
+}
+
+// markUnknown sets a channel-typed identifier's state to Unknown, used where a
+// variable is bound to a value the analysis cannot follow (a range variable).
+func (c *checker) markUnknown(expr ast.Expr, s state) {
+	ident, ok := expr.(*ast.Ident)
+	if !ok || ident.Name == "_" {
+		return
+	}
+	obj := c.info.ObjectOf(ident)
+	if obj == nil || !common.IsChannel(obj.Type()) || c.poisoned[obj] {
+		return
+	}
+	s[obj] = Unknown
+}
+
+// evalSwitch evaluates the init and merges every case body.
+func (c *checker) evalSwitch(n *ast.SwitchStmt, s state) state {
+	if n.Init != nil {
+		s = c.evalStmt(n.Init, s)
+	}
+	return c.evalCaseBodies(n.Body, s)
+}
+
+// evalCaseBodies merges the states of all case bodies. When there is no default
+// clause the switch may match nothing, so the entry state is merged in too.
+func (c *checker) evalCaseBodies(body *ast.BlockStmt, s state) state {
+	var acc state
+	hasDefault := false
+	for _, clause := range body.List {
+		cc, ok := clause.(*ast.CaseClause)
+		if !ok {
+			continue
+		}
+		if cc.List == nil {
+			hasDefault = true
+		}
+		branch := c.evalBlock(cc.Body, s.clone())
+		if acc == nil {
+			acc = branch
+		} else {
+			acc = merge(acc, branch)
+		}
+	}
+	if acc == nil {
+		return s
+	}
+	if !hasDefault {
+		acc = merge(acc, s)
+	}
+	return acc
+}
+
+// evalSelect evaluates each comm clause (suppressing nil-channel reports on the
+// communication itself) and its body, then merges all branches.
+func (c *checker) evalSelect(n *ast.SelectStmt, s state) state {
+	var acc state
+	for _, clause := range n.Body.List {
+		cc, ok := clause.(*ast.CommClause)
+		if !ok {
+			continue
+		}
+		branch := s.clone()
+		if cc.Comm != nil {
+			branch = c.evalComm(cc.Comm, branch)
+		}
+		branch = c.evalBlock(cc.Body, branch)
+		if acc == nil {
+			acc = branch
+		} else {
+			acc = merge(acc, branch)
+		}
+	}
+	if acc == nil {
+		return s
+	}
+	return acc
+}
+
+// evalComm evaluates the communication operation of a select case. A nil send
+// or receive here is legitimate (it disables the case), so nil reports are
+// suppressed; a send on a closed channel still panics and is reported.
+func (c *checker) evalComm(comm ast.Stmt, s state) state {
+	switch cm := comm.(type) {
+	case *ast.SendStmt:
+		return c.evalSend(cm, s, true)
+	case *ast.ExprStmt:
+		if u, ok := common.UnwrapParenExpr(cm.X).(*ast.UnaryExpr); ok && u.Op == token.ARROW {
+			c.checkReceive(u.X, s, true)
+		}
+	case *ast.AssignStmt:
+		for _, rhs := range cm.Rhs {
+			c.checkReceiveExpr(rhs, s, true)
+		}
+		return c.applyAssignLHS(cm, s)
+	}
+	return s
+}
+
+// chanObject resolves a channel expression to its variable object and name when
+// it is a plain identifier. Selectors, index expressions and other shapes are
+// not tracked, so they resolve to Unknown and are never reported.
+func (c *checker) chanObject(expr ast.Expr) (types.Object, string, bool) {
+	ident, ok := common.UnwrapParenExpr(expr).(*ast.Ident)
+	if !ok {
+		return nil, "", false
+	}
+	obj := c.info.ObjectOf(ident)
+	if obj == nil {
+		return nil, "", false
+	}
+	return obj, ident.Name, true
+}
+
+// poisonedVars returns the channel variables in body that the analysis must not
+// track precisely: those whose address is taken (a callee may reassign or make
+// them through the pointer) and those assigned inside a nested function literal
+// (a closure or goroutine may reassign them, racing with the outer flow).
+func poisonedVars(body *ast.BlockStmt, info *types.Info) map[types.Object]bool {
+	poisoned := map[types.Object]bool{}
+
+	var walk func(n ast.Node, inFuncLit bool)
+	walk = func(n ast.Node, inFuncLit bool) {
+		ast.Inspect(n, func(node ast.Node) bool {
+			switch e := node.(type) {
+			case *ast.FuncLit:
+				// Descend into the literal with the flag set; the manual
+				// recursion handles the subtree, so stop this Inspect branch.
+				walk(e.Body, true)
+				return false
+			case *ast.UnaryExpr:
+				if e.Op == token.AND {
+					markChannelObject(poisoned, info, e.X)
+				}
+			case *ast.AssignStmt:
+				if inFuncLit && e.Tok == token.ASSIGN {
+					for _, lhs := range e.Lhs {
+						markChannelObject(poisoned, info, lhs)
+					}
+				}
+			}
+			return true
+		})
+	}
+	walk(body, false)
+	return poisoned
+}
+
+// markChannelObject adds expr's object to set when expr is a plain identifier
+// bound to a channel variable.
+func markChannelObject(set map[types.Object]bool, info *types.Info, expr ast.Expr) {
+	ident, ok := common.UnwrapParenExpr(expr).(*ast.Ident)
+	if !ok {
+		return
+	}
+	if obj := info.ObjectOf(ident); obj != nil && common.IsChannel(obj.Type()) {
+		set[obj] = true
+	}
+}

--- a/pkg/analyzer/internal/channel/chanstate.go
+++ b/pkg/analyzer/internal/channel/chanstate.go
@@ -1,0 +1,83 @@
+// Package channel detects misuse of Go channels: closing a nil or
+// already-closed channel, sending on a closed channel, and sending or
+// receiving on a nil channel.
+//
+// The analysis is a small abstract interpretation over one function scope. It
+// tracks the state of each channel variable declared in that scope and reports
+// only when a variable is provably in a bad concrete state (Nil or Closed) on
+// every path reaching an operation. Any disagreement between converging paths
+// collapses to Unknown, which is never reported, so the checks do not fire on
+// speculative bugs.
+package channel
+
+import (
+	"go/types"
+	"maps"
+)
+
+// chanState is the abstract state of a tracked channel variable at a program
+// point. States form a flat lattice whose top is Unknown: merging two distinct
+// states yields Unknown.
+type chanState int
+
+const (
+	// Unknown is the top of the lattice: the variable may hold any value, so no
+	// diagnostic is emitted for it. It is the state of anything the analysis
+	// cannot follow precisely — parameters, package-scope channels, struct
+	// fields, values returned from calls, and variables that escape into a
+	// closure or have their address taken.
+	Unknown chanState = iota
+	// Nil means the variable is a nil channel: declared with `var ch chan T`
+	// (or explicitly assigned nil) and never assigned a channel from make on
+	// this path.
+	Nil
+	// Open means the variable holds a channel from make that has not been
+	// closed on this path.
+	Open
+	// Closed means close() has run on the variable on every path to this point.
+	// Closed is terminal: nothing reopens a closed channel, so the only way out
+	// is reassigning the variable, which the analysis observes locally.
+	Closed
+)
+
+// state maps a tracked channel variable (by its types.Object, so shadowed
+// declarations stay distinct) to its abstract state. A variable absent from the
+// map is Unknown.
+type state map[types.Object]chanState
+
+// get returns the abstract state of obj, defaulting to Unknown.
+func (s state) get(obj types.Object) chanState {
+	if cs, ok := s[obj]; ok {
+		return cs
+	}
+	return Unknown
+}
+
+// clone returns an independent copy so branches can be evaluated without
+// mutating the state of the joining path.
+func (s state) clone() state {
+	out := make(state, len(s))
+	maps.Copy(out, s)
+	return out
+}
+
+// merge combines the states of two converging control-flow paths. A variable
+// with the same state on both paths keeps it; any disagreement — including a
+// variable tracked on only one path — becomes Unknown, so the analysis never
+// reports a state that is not guaranteed on every path.
+func merge(a, b state) state {
+	out := make(state, len(a))
+	for k, v := range a {
+		if b.get(k) == v {
+			out[k] = v
+		} else {
+			out[k] = Unknown
+		}
+	}
+	for k := range b {
+		if _, seen := a[k]; !seen {
+			out[k] = Unknown
+		}
+	}
+	return out
+}

--- a/pkg/analyzer/internal/channel/sub_analyzer.go
+++ b/pkg/analyzer/internal/channel/sub_analyzer.go
@@ -1,0 +1,57 @@
+package channel
+
+import (
+	"go/ast"
+	"reflect"
+
+	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/internal/common/report"
+	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/internal/filesetup"
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/inspect"
+	"golang.org/x/tools/go/ast/inspector"
+)
+
+// SubAnalyzer drives the channel misuse checks as an independent
+// analysis.Analyzer. Like the other sub-analyzers it returns its diagnostics as
+// Result so the umbrella Analyzer re-emits them (and analysistest observes them
+// through the umbrella).
+//
+// It visits every function scope — top-level declarations and function literals
+// alike — and analyzes each body on its own, tracking only the channel
+// variables declared inside that scope. A function literal is therefore checked
+// as its own scope; the enclosing body does not descend into it, but it does
+// consider variables the literal reassigns when deciding what to track (see
+// poisonedVars).
+var SubAnalyzer = &analysis.Analyzer{
+	Name:       "goconcurrencylint_channel",
+	Doc:        "Detects channel misuse: close of a nil or closed channel, send on a closed channel, and send/receive on a nil channel.",
+	Run:        run,
+	Requires:   []*analysis.Analyzer{inspect.Analyzer, filesetup.Analyzer},
+	ResultType: reflect.TypeFor[[]analysis.Diagnostic](),
+}
+
+func run(pass *analysis.Pass) (any, error) {
+	insp := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
+	files := pass.ResultOf[filesetup.Analyzer].(*filesetup.Result)
+	ec := &report.ErrorCollector{}
+
+	nodeFilter := []ast.Node{(*ast.FuncDecl)(nil), (*ast.FuncLit)(nil)}
+	insp.Preorder(nodeFilter, func(n ast.Node) {
+		var body *ast.BlockStmt
+		switch fn := n.(type) {
+		case *ast.FuncDecl:
+			body = fn.Body
+		case *ast.FuncLit:
+			body = fn.Body
+		}
+		if body == nil {
+			return
+		}
+		if files.IsGenerated(pass.Fset.File(body.Pos())) {
+			return
+		}
+		newChecker(ec, pass.TypesInfo).analyzeBody(body)
+	})
+
+	return ec.Diagnostics(pass, files.IgnoreFunc()), nil
+}

--- a/pkg/analyzer/internal/common/category/category.go
+++ b/pkg/analyzer/internal/common/category/category.go
@@ -8,6 +8,7 @@
 //	GCL3xxx  sync.Once
 //	GCL4xxx  sync.Cond
 //	GCL5xxx  sync.Pool
+//	GCL6xxx  channels (close/send/receive)
 //	GCL9xxx  cross-cutting (applies to several primitives)
 //
 // Every check also keeps a legacy kebab-case slug (e.g. lock-without-unlock).
@@ -65,6 +66,12 @@ const (
 	// sync.Pool checks (GCL5xxx).
 	PoolNonPointerValue Category = "GCL5001"
 
+	// Channel checks (GCL6xxx).
+	CloseOfNilChannel    Category = "GCL6001"
+	CloseOfClosedChannel Category = "GCL6002"
+	SendOnClosedChannel  Category = "GCL6003"
+	NilChannelOperation  Category = "GCL6004"
+
 	// Cross-cutting checks (GCL9xxx).
 	SyncPrimitiveCopy Category = "GCL9001"
 )
@@ -77,6 +84,7 @@ const (
 	primOnce  = "sync.Once"
 	primCond  = "sync.Cond"
 	primPool  = "sync.Pool"
+	primChan  = "channel"
 	primAll   = "sync.Mutex, sync.RWMutex, sync.WaitGroup, sync.Once, sync.Cond, sync.Pool, sync.Map"
 )
 
@@ -565,6 +573,49 @@ pool.Put(buf) // []byte is not pointer-shaped: this allocates on every Put`,
 var pool sync.Pool
 buf := make([]byte, 1024)
 pool.Put(&buf) // store a pointer so nothing is boxed`},
+
+	{CloseOfNilChannel, "close-of-nil-channel", primChan,
+		"close() is called on a channel that is nil on every path reaching the call, which panics at runtime.",
+		"Closing a nil channel panics with \"close of nil channel\"; the variable was declared but never assigned a channel from make.",
+		`
+var ch chan int
+close(ch) // ch is nil: panics with "close of nil channel"`,
+		`
+ch := make(chan int)
+close(ch)`},
+
+	{CloseOfClosedChannel, "close-of-closed-channel", primChan,
+		"close() is called on a channel that is already closed on every path reaching the call, which panics at runtime.",
+		"Closing an already-closed channel panics with \"close of closed channel\"; a channel must be closed exactly once.",
+		`
+ch := make(chan int)
+close(ch)
+close(ch) // already closed: panics with "close of closed channel"`,
+		`
+ch := make(chan int)
+close(ch)`},
+
+	{SendOnClosedChannel, "send-on-closed-channel", primChan,
+		"A value is sent on a channel that is already closed on every path reaching the send, which panics at runtime.",
+		"Sending on a closed channel panics with \"send on closed channel\"; closing signals that no more values will ever be sent.",
+		`
+ch := make(chan int, 1)
+close(ch)
+ch <- 1 // channel already closed: panics with "send on closed channel"`,
+		`
+ch := make(chan int, 1)
+ch <- 1
+close(ch)`},
+
+	{NilChannelOperation, "nil-channel-op", primChan,
+		"A send or receive is performed on a channel that is nil on every path reaching the operation, which blocks the goroutine forever.",
+		"Send and receive on a nil channel block forever; the variable was declared but never assigned a channel from make. A nil channel inside a select is a legitimate way to disable a case and is not flagged.",
+		`
+var ch chan int
+ch <- 1 // ch is nil: this goroutine blocks forever`,
+		`
+ch := make(chan int, 1)
+ch <- 1`},
 
 	{SyncPrimitiveCopy, "sync-primitive-copy", primAll,
 		"A sync primitive (or a struct embedding one) is copied by value.",

--- a/pkg/analyzer/internal/common/common.go
+++ b/pkg/analyzer/internal/common/common.go
@@ -73,6 +73,19 @@ func IsPool(typ types.Type) bool {
 	return MatchesPkgAndName(typ, "sync", "Pool")
 }
 
+// IsChannel returns true if the given type is a channel type (chan T,
+// chan<- T or <-chan T), after resolving aliases and a single pointer
+// indirection. Channels are not a sync type, but the channel checks reason
+// about their state the same way the mutex checks reason about lock state.
+func IsChannel(typ types.Type) bool {
+	if typ == nil {
+		return false
+	}
+	typ = types.Unalias(DerefOnceAndUnalias(typ))
+	_, ok := typ.Underlying().(*types.Chan)
+	return ok
+}
+
 // MatchesPkgAndName reports whether typ is a named type declared in pkg
 // whose name matches any of names.
 //

--- a/pkg/analyzer/message_code_test.go
+++ b/pkg/analyzer/message_code_test.go
@@ -17,7 +17,7 @@ import (
 // prefix.
 func TestDiagnosticMessageCarriesCode(t *testing.T) {
 	results := analysistest.Run(t, analysistest.TestData(), Analyzer,
-		"mutex", "waitgroup", "once", "cond", "pool", "synccopy", "packagelevel", "ignoredirective", "generated")
+		"mutex", "waitgroup", "once", "cond", "pool", "channel", "synccopy", "packagelevel", "ignoredirective", "generated")
 
 	total := 0
 	for _, res := range results {

--- a/pkg/analyzer/testdata/src/channel/channel_cases.go
+++ b/pkg/analyzer/testdata/src/channel/channel_cases.go
@@ -1,0 +1,249 @@
+package channel
+
+// ========== close-of-nil-channel (GCL6001) ==========
+
+// Bad: closing a nil channel panics.
+func BadCloseNil() {
+	var ch chan int
+	close(ch) // want "close of nil channel 'ch'"
+}
+
+// Good: the channel is made before it is closed.
+func GoodCloseMade() {
+	ch := make(chan int)
+	close(ch)
+}
+
+// ========== close-of-closed-channel (GCL6002) ==========
+
+// Bad: closing the same channel twice panics.
+func BadDoubleClose() {
+	ch := make(chan int)
+	close(ch)
+	close(ch) // want "close of already-closed channel 'ch'"
+}
+
+// Bad: a parameter's state is unknown on entry, but once this function has
+// closed it, closing again is a definite double close.
+func BadParamDoubleClose(ch chan int) {
+	close(ch)
+	close(ch) // want "close of already-closed channel 'ch'"
+}
+
+// Good: reassigning a fresh channel between closes is fine.
+func GoodReassignAfterClose() {
+	ch := make(chan int)
+	close(ch)
+	ch = make(chan int)
+	close(ch)
+}
+
+// ========== send-on-closed-channel (GCL6003) ==========
+
+// Bad: sending on a closed channel panics.
+func BadSendOnClosed() {
+	ch := make(chan int, 1)
+	close(ch)
+	ch <- 1 // want "send on closed channel 'ch'"
+}
+
+// Bad: a send on a closed channel panics even inside a select case.
+func BadSelectSendOnClosed() {
+	ch := make(chan int, 1)
+	close(ch)
+	select {
+	case ch <- 1: // want "send on closed channel 'ch'"
+	default:
+	}
+}
+
+// Good: send before closing.
+func GoodSendThenClose() {
+	ch := make(chan int, 1)
+	ch <- 1
+	close(ch)
+}
+
+// ========== nil-channel-op (GCL6004) ==========
+
+// Bad: sending on a nil channel blocks forever.
+func BadSendOnNil() {
+	var ch chan int
+	ch <- 1 // want "send on nil channel 'ch'"
+}
+
+// Bad: an explicit nil assignment is tracked like the zero value.
+func BadSendAfterNilAssign() {
+	ch := make(chan int, 1)
+	ch = nil
+	ch <- 1 // want "send on nil channel 'ch'"
+}
+
+// Bad: receiving on a nil channel blocks forever.
+func BadRecvOnNil() {
+	var ch chan int
+	<-ch // want "receive on nil channel 'ch'"
+}
+
+// Bad: ranging over a nil channel blocks forever.
+func BadRangeOnNil() {
+	var ch chan int
+	for range ch { // want "receive on nil channel 'ch'"
+	}
+}
+
+// Good: a made channel is fine to send and receive on.
+func GoodSendRecv() {
+	ch := make(chan int, 1)
+	ch <- 1
+	<-ch
+}
+
+// ========== false-positive guards ==========
+
+// A close reached on only one branch is not a guaranteed double close.
+func GuardConditionalClose(cond bool) {
+	ch := make(chan int)
+	if cond {
+		close(ch)
+	}
+	close(ch)
+}
+
+// A nil channel inside a select is a deliberate way to disable a case, so
+// neither the send nor the receive comm clause is flagged.
+func GuardNilSelectComm() {
+	var ch chan int
+	select {
+	case ch <- 1:
+	default:
+	}
+	select {
+	case <-ch:
+	default:
+	}
+}
+
+// A channel that escapes into a goroutine that may reassign it is not tracked,
+// so the send is not flagged even though the outer flow left it nil.
+func GuardClosureReassign() {
+	var ch chan int
+	go func() {
+		ch = make(chan int, 1)
+	}()
+	ch <- 1
+}
+
+// A shadowing declaration must not taint the outer channel: the outer ch is
+// open, so closing it once is fine and must not be read as close-of-nil.
+func GuardShadowNoNilFP() {
+	ch := make(chan int)
+	{
+		var ch chan int
+		_ = ch
+	}
+	close(ch)
+}
+
+// A lone close of a parameter is not flagged: its incoming state is unknown.
+func GuardParamSingleClose(ch chan int) {
+	close(ch)
+}
+
+// A channel accessed through a struct field is not tracked (aliasing is
+// unknown), so repeated closes are not flagged.
+type hub struct{ ch chan int }
+
+func GuardFieldChannel(h *hub) {
+	close(h.ch)
+	close(h.ch)
+}
+
+// Each loop iteration closes a different channel from the slice, so a single
+// close per iteration is not a double close.
+func GuardLoopSingleClose(chs []chan int) {
+	for _, ch := range chs {
+		close(ch)
+	}
+}
+
+// A deferred close runs at return, so a send before it is on an open channel.
+func GuardDeferClose() {
+	ch := make(chan int, 1)
+	defer close(ch)
+	ch <- 1
+}
+
+// A channel variable assigned inside a select comm clause takes the received
+// value, so a later receive or close on it must not be read as a nil-channel
+// operation. Regression: net/http's transport_test.go uses exactly this shape.
+func GuardSelectCommAssign(reqerrc chan error, putidlec chan chan struct{}) {
+	var idlec chan struct{}
+	select {
+	case <-reqerrc:
+		return
+	case idlec = <-putidlec:
+	}
+	<-idlec
+	close(idlec)
+}
+
+// An `if ch != nil` guard proves the channel is non-nil inside the branch, so
+// the send is not a nil-channel operation. Regression: go-ethereum's
+// chain_freezer.go and history_indexer.go guard channel ops this way.
+func GuardIfNotNilThenSend(trigger chan chan struct{}) {
+	var triggered chan struct{}
+	if triggered != nil {
+		triggered <- struct{}{}
+		triggered = nil
+	}
+	select {
+	case triggered = <-trigger:
+	default:
+	}
+}
+
+// An `if ch == nil { return }` guard means the code after it runs only when the
+// channel is non-nil, so the later close is not close-of-nil. Regression:
+// consul's leader.go closes weAreLeaderCh exactly like this.
+func GuardIfNilReturnThenClose(made bool) {
+	var ch chan struct{}
+	if made {
+		ch = make(chan struct{})
+	}
+	if ch == nil {
+		return
+	}
+	close(ch)
+}
+
+// The consul leader-loop shape: a lazily-made channel closed in a different
+// branch, guarded by a nil check, all inside a for/select.
+func GuardLeaderLoopShape(notify <-chan bool, quit <-chan struct{}) {
+	var leaderCh chan struct{}
+	for {
+		select {
+		case isLeader := <-notify:
+			if isLeader {
+				if leaderCh != nil {
+					continue
+				}
+				leaderCh = make(chan struct{})
+			} else {
+				if leaderCh == nil {
+					continue
+				}
+				close(leaderCh)
+				leaderCh = nil
+			}
+		case <-quit:
+			return
+		}
+	}
+}
+
+// An inline ignore directive silences the diagnostic on its line.
+func GuardIgnoreDirective() {
+	var ch chan int
+	close(ch) // goconcurrencylint:ignore GCL6001
+}

--- a/scripts/gendocs/main.go
+++ b/scripts/gendocs/main.go
@@ -43,6 +43,7 @@ var groups = []group{
 	{'3', "sync.Once"},
 	{'4', "sync.Cond"},
 	{'5', "sync.Pool"},
+	{'6', "Channels"},
 	{'9', "Cross-cutting"},
 }
 


### PR DESCRIPTION
Add a channel sub-analyzer that flags four guaranteed-wrong channel operations:

-   GCL6001 close-of-nil-channel     close(ch) on a nil channel   (panic)
-   GCL6002 close-of-closed-channel  double close                 (panic)
-   GCL6003 send-on-closed-channel   send after close             (panic)
-   GCL6004 nil-channel-op           send/receive/range on nil    (deadlock)