### PR TITLE
fix: remove waitgroup/mutex false positives found on real repos

### DIFF
--- a/pkg/analyzer/internal/mutex/branches.go
+++ b/pkg/analyzer/internal/mutex/branches.go
@@ -209,7 +209,61 @@ func (c *Checker) analyzeIfStatement(stmt *ast.IfStmt, stats map[string]*Stats) 
 		copyStatsMap(stats, elseBase)
 		return
 	}
+
+	// No explicit else: the implicit else path carries elseBase, which differs
+	// from the incoming stats only when the condition itself acquires a lock —
+	// an inline TryLock, e.g. `if !mu.TryLock() { mu.Lock() }`. When the then
+	// branch re-acquires so that both the TryLock-success path and the fallback
+	// Lock() path hold the mutex, the two states converge and there is no
+	// imbalance to report; propagate the held state so a later defer Unlock
+	// matches. Gated on a TryLock condition so no other `if` shape changes
+	// behaviour, and reached only for a non-terminating then branch so a then
+	// that returns while holding the lock still leaves stats on the else path.
+	if c.conditionAcquiresLock(stmt.Cond) && c.canMergeBranchStates(thenStats, elseBase) {
+		copyStatsMap(stats, thenStats)
+		return
+	}
+
 	c.reportUnmatchedLocksInBranch(stats, thenStats, "if")
+}
+
+// tryLockConditionTarget returns the tracked mutex a bare TryLock/TryRLock
+// condition acquires on its success branch, along with the call node. ok is
+// false when cond is not such a call. A leading `!` is the caller's concern:
+// negation swaps the branches, it does not change which lock the call acquires.
+func (c *Checker) tryLockConditionTarget(cond ast.Expr) (call *ast.CallExpr, varName, method string, ok bool) {
+	call, isCall := cond.(*ast.CallExpr)
+	if !isCall {
+		return nil, "", "", false
+	}
+	sel, isSel := call.Fun.(*ast.SelectorExpr)
+	if !isSel {
+		return nil, "", "", false
+	}
+	name := common.GetVarName(sel.X)
+	switch sel.Sel.Name {
+	case "TryLock":
+		if c.mutexNames[name] || c.rwMutexNames[name] {
+			return call, name, "TryLock", true
+		}
+	case "TryRLock":
+		if c.rwMutexNames[name] {
+			return call, name, "TryRLock", true
+		}
+	}
+	return nil, "", "", false
+}
+
+// conditionAcquiresLock reports whether cond is a TryLock/TryRLock call (or its
+// negation) on a tracked mutex — a condition whose evaluation leaves the lock
+// held on the success branch, so the implicit else path is not the incoming
+// state.
+func (c *Checker) conditionAcquiresLock(cond ast.Expr) bool {
+	if unary, ok := cond.(*ast.UnaryExpr); ok && unary.Op == token.NOT {
+		return c.conditionAcquiresLock(unary.X)
+	}
+	_, _, _, ok := c.tryLockConditionTarget(cond)
+	return ok
 }
 
 func (c *Checker) branchInitialStatsForCondition(cond ast.Expr, stats map[string]*Stats) (map[string]*Stats, map[string]*Stats) {
@@ -225,28 +279,18 @@ func (c *Checker) branchInitialStatsForCondition(cond ast.Expr, stats map[string
 		return thenStats, elseStats
 	}
 
-	call, ok := cond.(*ast.CallExpr)
+	call, varName, method, ok := c.tryLockConditionTarget(cond)
 	if !ok {
 		return thenStats, elseStats
 	}
 
-	sel, ok := call.Fun.(*ast.SelectorExpr)
-	if !ok {
-		return thenStats, elseStats
-	}
-
-	varName := common.GetVarName(sel.X)
-	switch sel.Sel.Name {
+	switch method {
 	case "TryLock":
-		if c.mutexNames[varName] || c.rwMutexNames[varName] {
-			thenStats[varName].lock++
-			thenStats[varName].lockPos = append(thenStats[varName].lockPos, call.Pos())
-		}
+		thenStats[varName].lock++
+		thenStats[varName].lockPos = append(thenStats[varName].lockPos, call.Pos())
 	case "TryRLock":
-		if c.rwMutexNames[varName] {
-			thenStats[varName].rlock++
-			thenStats[varName].rlockPos = append(thenStats[varName].rlockPos, call.Pos())
-		}
+		thenStats[varName].rlock++
+		thenStats[varName].rlockPos = append(thenStats[varName].rlockPos, call.Pos())
 	}
 
 	return thenStats, elseStats

--- a/pkg/analyzer/internal/mutex/lifecycle.go
+++ b/pkg/analyzer/internal/mutex/lifecycle.go
@@ -4,6 +4,7 @@ import (
 	"go/ast"
 	"go/token"
 	"go/types"
+	"slices"
 	"strings"
 
 	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/internal/common"
@@ -256,13 +257,16 @@ func (l *lifecycleResolver) returnsFuncFor(mutexName string, methodNames []strin
 }
 
 // returnsClosureReleasingLock reports whether the function hands the release of
-// mutexName to its caller through a returned closure. Two shapes are covered:
-// the closure is returned directly (return func() { mu.Unlock() }) or it is a
-// field value of a returned composite literal — the guard/RAII pattern
-// (return Guard{release: func() { mu.Unlock() }}). In both cases the acquiring
-// function is not expected to unlock before returning, so the lock is not a
-// leak. The closure must call the matching unlock on the same mutex; a closure
-// that merely mentions it does not qualify.
+// mutexName to its caller instead of unlocking before it returns, so the lock is
+// not a leak. Three shapes are covered:
+//   - a closure returned directly: return func() { mu.Unlock() }
+//   - a closure in a returned composite literal — the guard/RAII pattern:
+//     return Guard{release: func() { mu.Unlock() }}
+//   - the bound unlock method returned directly: return mu.Unlock
+//
+// Handing back the bound method delegates release exactly like returning a
+// closure that calls it. The returned value must release the same mutex; a
+// value that merely mentions it does not qualify.
 func (l *lifecycleResolver) returnsClosureReleasingLock(mutexName string, unlockMethods []string) bool {
 	if l.function == nil || l.function.Body == nil {
 		return false
@@ -289,7 +293,58 @@ func (l *lifecycleResolver) returnsClosureReleasingLock(mutexName string, unlock
 		}
 	}
 
+	// The bound unlock method returned directly: return mu.Unlock.
+	if l.returnsUnlockMethodValue(l.function, mutexName, unlockMethods) {
+		return true
+	}
+
 	return false
+}
+
+// returnsUnlockMethodValue reports whether fn hands back the bound unlock method
+// of mutexName (return mu.Unlock), either returned directly or through a local
+// variable that is later returned (u := mu.Unlock; return u).
+func (l *lifecycleResolver) returnsUnlockMethodValue(fn *ast.FuncDecl, mutexName string, unlockMethods []string) bool {
+	if fn == nil || fn.Body == nil {
+		return false
+	}
+
+	isUnlockValue := func(expr ast.Expr) bool {
+		sel, ok := expr.(*ast.SelectorExpr)
+		if !ok || common.GetVarName(sel.X) != mutexName {
+			return false
+		}
+		return slices.Contains(unlockMethods, sel.Sel.Name)
+	}
+
+	localValues := make(map[string]ast.Expr)
+	found := false
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		if found {
+			return false
+		}
+		switch node := n.(type) {
+		case *ast.AssignStmt:
+			for i, lhs := range node.Lhs {
+				if ident, ok := lhs.(*ast.Ident); ok && i < len(node.Rhs) {
+					localValues[ident.Name] = node.Rhs[i]
+				}
+			}
+		case *ast.ReturnStmt:
+			for _, result := range node.Results {
+				if isUnlockValue(result) {
+					found = true
+					return false
+				}
+				if ident, ok := result.(*ast.Ident); ok && isUnlockValue(localValues[ident.Name]) {
+					found = true
+					return false
+				}
+			}
+		}
+		return true
+	})
+	return found
 }
 
 // returnedFuncLits returns the function literals fn hands back to its caller,

--- a/pkg/analyzer/internal/waitgroup/analyzer.go
+++ b/pkg/analyzer/internal/waitgroup/analyzer.go
@@ -441,13 +441,21 @@ func functionBodyUsesWaitGroupName(body *ast.BlockStmt, wgName string) bool {
 		if !ok {
 			return true
 		}
-		sel, ok := call.Fun.(*ast.SelectorExpr)
-		if !ok {
-			return true
-		}
-		if common.GetVarName(sel.X) == wgName && (sel.Sel.Name == "Add" || sel.Sel.Name == "Done" || sel.Sel.Name == "Wait" || sel.Sel.Name == "Go") {
+		if sel, ok := call.Fun.(*ast.SelectorExpr); ok &&
+			common.GetVarName(sel.X) == wgName &&
+			(sel.Sel.Name == "Add" || sel.Sel.Name == "Done" || sel.Sel.Name == "Wait" || sel.Sel.Name == "Go") {
 			found = true
 			return false
+		}
+		// The waitgroup may be delegated to a helper — `helper(wg)` or
+		// `helper(&wg)` — that performs the Done on the caller's behalf. Treat
+		// passing the waitgroup as an argument as a use so the interprocedural
+		// resolution keeps following it into the helper.
+		for _, arg := range call.Args {
+			if isWaitGroupArgument(arg, wgName) {
+				found = true
+				return false
+			}
 		}
 		return true
 	})

--- a/pkg/analyzer/internal/waitgroup/collect.go
+++ b/pkg/analyzer/internal/waitgroup/collect.go
@@ -22,7 +22,7 @@ func (c *Checker) findDeferDoneCalls(stats map[string]*Stats) {
 		if call, ok := deferStmt.Call.Fun.(*ast.SelectorExpr); ok {
 			if call.Sel.Name == "Done" {
 				wgName := common.GetVarName(call.X)
-				if c.waitGroupNames[wgName] {
+				if c.waitGroupNames[wgName] && c.isWaitGroupReceiver(call.X) {
 					stats[wgName].deferDoneCalls = append(stats[wgName].deferDoneCalls, deferStmt.Call.Pos())
 				}
 			}
@@ -47,7 +47,7 @@ func (c *Checker) findDoneInFunctionLiteral(body *ast.BlockStmt, stats map[strin
 
 			if sel, ok := call.Fun.(*ast.SelectorExpr); ok && sel.Sel.Name == "Done" {
 				wgName := common.GetVarName(sel.X)
-				if c.waitGroupNames[wgName] {
+				if c.waitGroupNames[wgName] && c.isWaitGroupReceiver(sel.X) {
 					stats[wgName].deferDoneCalls = append(stats[wgName].deferDoneCalls, call.Pos())
 				}
 			}
@@ -216,6 +216,9 @@ func (c *Checker) handleExpressionStatement(stmt *ast.ExprStmt, stats map[string
 	if !c.waitGroupNames[wgName] {
 		return
 	}
+	if !c.isWaitGroupReceiver(sel.X) {
+		return
+	}
 
 	switch sel.Sel.Name {
 	case "Add":
@@ -227,6 +230,24 @@ func (c *Checker) handleExpressionStatement(stmt *ast.ExprStmt, stats map[string
 	case "Wait":
 		c.handleWaitCall(call, wgName, stats)
 	}
+}
+
+// isWaitGroupReceiver confirms that selector receiver x statically has type
+// sync.WaitGroup (or *sync.WaitGroup). waitGroupNames is keyed by bare variable
+// name, so two identically-named variables of different types in the same
+// function — e.g. a real sync.WaitGroup and a custom type that also exposes
+// Add/Done/Wait — would otherwise be conflated and the custom type's calls
+// miscounted. When the type cannot be resolved we fall back to the name-based
+// decision to avoid regressing inputs without full type information.
+func (c *Checker) isWaitGroupReceiver(x ast.Expr) bool {
+	if c.typesInfo == nil {
+		return true
+	}
+	typ := c.typesInfo.TypeOf(x)
+	if typ == nil {
+		return true
+	}
+	return common.IsWaitGroup(typ)
 }
 
 func (c *Checker) handleImmediatelyInvokedFunction(stmt *ast.ExprStmt, forStack []*ast.ForStmt, stats map[string]*Stats, alreadyReported map[token.Pos]bool) bool {

--- a/pkg/analyzer/internal/waitgroup/done_guaranteed.go
+++ b/pkg/analyzer/internal/waitgroup/done_guaranteed.go
@@ -13,14 +13,19 @@ type doneCallInfo struct {
 	hasGuaranteedDone bool
 }
 
-// goroutineRelatedToWaitGroup checks if a goroutine is related to a WaitGroup
-func goroutineRelatedToWaitGroup(goStmt *ast.GoStmt, wgName string) bool {
+// goroutineRelatedToWaitGroup checks if a goroutine references the WaitGroup
+// named wgName. The reference must resolve to an actual sync.WaitGroup: a
+// same-named variable of a different type (e.g. a custom Add/Done/Decr
+// look-alike, as in tailscale's syncs.WaitGroupChan) must not make the
+// goroutine "related", otherwise its missing Done() would be blamed on an
+// unrelated real WaitGroup's Add().
+func (c *Checker) goroutineRelatedToWaitGroup(goStmt *ast.GoStmt, wgName string) bool {
 	if fnLit, ok := goStmt.Call.Fun.(*ast.FuncLit); ok {
 		found := false
 		ast.Inspect(fnLit.Body, func(n ast.Node) bool {
 			if call, ok := n.(*ast.CallExpr); ok {
 				if sel, ok := call.Fun.(*ast.SelectorExpr); ok {
-					if common.GetVarName(sel.X) == wgName {
+					if common.GetVarName(sel.X) == wgName && c.isWaitGroupReceiver(sel.X) {
 						found = true
 						return false
 					}
@@ -35,7 +40,7 @@ func goroutineRelatedToWaitGroup(goStmt *ast.GoStmt, wgName string) bool {
 
 func (c *Checker) goroutineDoneInfo(goStmt *ast.GoStmt, wgName string) (doneCallInfo, bool) {
 	if fnLit, ok := goStmt.Call.Fun.(*ast.FuncLit); ok {
-		if !goroutineRelatedToWaitGroup(goStmt, wgName) {
+		if !c.goroutineRelatedToWaitGroup(goStmt, wgName) {
 			return doneCallInfo{}, false
 		}
 		return c.analyzeDoneCallsWithVisited(fnLit.Body, wgName, make(map[token.Pos]bool)), true
@@ -64,6 +69,19 @@ func (c *Checker) analyzeDoneCallsWithVisited(block *ast.BlockStmt, wgName strin
 			if c.worker.isSimpleDeferDone(s, wgName) || c.worker.isCallbackDeferDone(s, wgName) || c.worker.isDeferPanicRecoveryPattern(s, wgName) || c.worker.isDeferFuncWithDone(s, wgName) {
 				info.hasAnyDone = true
 				if !mightExitEarly {
+					info.hasGuaranteedDone = true
+					return info
+				}
+			}
+
+			// A deferred helper may Done on our behalf, e.g.
+			// `defer e.handleWorkerPanic(ctx, &e.workerWg)` whose body calls
+			// wg.Done(). Follow it with the same interprocedural resolution used
+			// for plain calls below; a deferred guaranteed Done runs on every
+			// exit path, exactly like a direct `defer wg.Done()`.
+			if helperInfo, related := c.analyzeRelatedCall(s.Call, wgName, visited); related {
+				info.hasAnyDone = info.hasAnyDone || helperInfo.hasAnyDone
+				if helperInfo.hasGuaranteedDone && !mightExitEarly {
 					info.hasGuaranteedDone = true
 					return info
 				}

--- a/pkg/analyzer/internal/waitgroup/goroutine_donepos.go
+++ b/pkg/analyzer/internal/waitgroup/goroutine_donepos.go
@@ -2,7 +2,7 @@ package waitgroup
 
 import (
 	"go/ast"
-	"go/token"
+	"go/types"
 
 	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/internal/common"
 	"github.com/sanbricio/goconcurrencylint/pkg/analyzer/internal/common/category"
@@ -26,9 +26,9 @@ func (g *goroutineInspector) checkWaitAndDoneInSameGoroutine(fn *ast.FuncDecl) {
 
 		for wgName := range g.waitGroupNames {
 			positions := g.collectWaitDonePositions(fnLit.Body, wgName)
-			for _, waitPos := range positions.waits {
-				if waitDependsOnDoneInSameGoroutine(waitPos, positions) {
-					g.reporter.AddError(waitPos, category.WaitDeadlock, "waitgroup '"+wgName+"' Wait will deadlock: same goroutine has pending Done")
+			for _, wait := range positions.waits {
+				if waitDependsOnDoneInSameGoroutine(wait, positions) {
+					g.reporter.AddError(wait.pos, category.WaitDeadlock, "waitgroup '"+wgName+"' Wait will deadlock: same goroutine has pending Done")
 				}
 			}
 		}
@@ -37,13 +37,30 @@ func (g *goroutineInspector) checkWaitAndDoneInSameGoroutine(fn *ast.FuncDecl) {
 	})
 }
 
-func waitDependsOnDoneInSameGoroutine(waitPos token.Pos, positions waitDonePositions) bool {
-	for _, donePos := range positions.dones {
-		if donePos > waitPos {
+func waitDependsOnDoneInSameGoroutine(wait wgCallSite, positions waitDonePositions) bool {
+	for _, done := range positions.dones {
+		if done.pos > wait.pos && sameWaitGroupObject(wait.obj, done.obj) {
 			return true
 		}
 	}
-	return len(positions.deferDones) > 0
+	for _, deferDone := range positions.deferDones {
+		if sameWaitGroupObject(wait.obj, deferDone.obj) {
+			return true
+		}
+	}
+	return false
+}
+
+// sameWaitGroupObject reports whether two receiver objects denote the same
+// WaitGroup. A nil object (an unresolved receiver, e.g. a field access) falls
+// back to "same" so we keep the prior name-based behaviour rather than dropping
+// a real deadlock; two resolved objects must be identical to match, which is
+// what tells a shadowing inner `var wg` apart from an outer one.
+func sameWaitGroupObject(a, b types.Object) bool {
+	if a == nil || b == nil {
+		return true
+	}
+	return a == b
 }
 
 func (g *goroutineInspector) collectWaitDonePositions(block *ast.BlockStmt, wgName string) waitDonePositions {
@@ -65,7 +82,7 @@ func (g *goroutineInspector) collectWaitDonePositions(block *ast.BlockStmt, wgNa
 			if g.shouldSkipCall(e) {
 				return
 			}
-			recordWaitDoneCall(e, wgName, &positions)
+			g.recordWaitDoneCall(e, wgName, &positions)
 			if fnLit, ok := e.Fun.(*ast.FuncLit); ok && fnLit.Body != nil {
 				visitStmts(fnLit.Body.List)
 			}
@@ -92,7 +109,7 @@ func (g *goroutineInspector) collectWaitDonePositions(block *ast.BlockStmt, wgNa
 				return
 			}
 			if g.deferInvokesDone != nil && g.deferInvokesDone(s, wgName) {
-				positions.deferDones = append(positions.deferDones, s.Call.Pos())
+				positions.deferDones = append(positions.deferDones, wgCallSite{pos: s.Call.Pos(), obj: g.deferDoneObject(s, wgName)})
 			}
 		case *ast.AssignStmt:
 			for _, expr := range s.Rhs {
@@ -182,7 +199,7 @@ func visitMainFlowElse(stmt ast.Stmt, visitStmt func(ast.Stmt), visitStmts func(
 	}
 }
 
-func recordWaitDoneCall(call *ast.CallExpr, wgName string, positions *waitDonePositions) {
+func (g *goroutineInspector) recordWaitDoneCall(call *ast.CallExpr, wgName string, positions *waitDonePositions) {
 	sel, ok := call.Fun.(*ast.SelectorExpr)
 	if !ok || common.GetVarName(sel.X) != wgName {
 		return
@@ -190,8 +207,30 @@ func recordWaitDoneCall(call *ast.CallExpr, wgName string, positions *waitDonePo
 
 	switch sel.Sel.Name {
 	case "Wait":
-		positions.waits = append(positions.waits, call.Pos())
+		positions.waits = append(positions.waits, wgCallSite{pos: call.Pos(), obj: g.wgObject(sel.X)})
 	case "Done":
-		positions.dones = append(positions.dones, call.Pos())
+		positions.dones = append(positions.dones, wgCallSite{pos: call.Pos(), obj: g.wgObject(sel.X)})
 	}
+}
+
+// wgObject resolves the WaitGroup variable a receiver expression refers to.
+// Only plain identifiers are resolved; field accesses and other shapes return
+// nil so the caller falls back to name-based matching.
+func (g *goroutineInspector) wgObject(expr ast.Expr) types.Object {
+	if g.typesInfo == nil {
+		return nil
+	}
+	if ident, ok := expr.(*ast.Ident); ok {
+		return g.typesInfo.ObjectOf(ident)
+	}
+	return nil
+}
+
+// deferDoneObject resolves the WaitGroup object of a `defer wg.Done()`. Wrapped
+// forms (a deferred closure) resolve to nil and fall back to name matching.
+func (g *goroutineInspector) deferDoneObject(deferStmt *ast.DeferStmt, wgName string) types.Object {
+	if sel, ok := deferStmt.Call.Fun.(*ast.SelectorExpr); ok && common.GetVarName(sel.X) == wgName {
+		return g.wgObject(sel.X)
+	}
+	return nil
 }

--- a/pkg/analyzer/internal/waitgroup/goroutine_inspector.go
+++ b/pkg/analyzer/internal/waitgroup/goroutine_inspector.go
@@ -18,10 +18,20 @@ type inGoroutineChecker func(token.Pos) bool
 type mainFlowChecker func(token.Pos) bool
 type builtinPanicChecker func(*ast.Ident) bool
 
+// wgCallSite is a Wait/Done call recorded with the WaitGroup object its
+// receiver resolves to. The object lets the same-goroutine deadlock check pair
+// a Wait with a Done only when both name the same WaitGroup, so a shadowing
+// inner `var wg` is not conflated with an outer `wg` of the same name. obj is
+// nil when the receiver cannot be resolved to a variable (e.g. a field access).
+type wgCallSite struct {
+	pos token.Pos
+	obj types.Object
+}
+
 type waitDonePositions struct {
-	waits      []token.Pos
-	dones      []token.Pos
-	deferDones []token.Pos
+	waits      []wgCallSite
+	dones      []wgCallSite
+	deferDones []wgCallSite
 }
 
 // goroutineInspector groups diagnostics that reason about WaitGroup behavior

--- a/pkg/analyzer/testdata/src/mutex/mutex_basic_cases.go
+++ b/pkg/analyzer/testdata/src/mutex/mutex_basic_cases.go
@@ -171,6 +171,18 @@ func BadNegatedTryLockFalsePathUnlock() {
 	mu.Unlock()
 }
 
+// Negated TryLock with a blocking fallback: when TryLock fails the branch
+// block-acquires, so the mutex is held on both the TryLock-success path and the
+// fallback path when the deferred Unlock runs. Mirrors minio
+// internal/grid/muxclient.go close(). Must stay CLEAN.
+func GoodNegatedTryLockBlockingFallback() {
+	var mu sync.Mutex
+	if !mu.TryLock() {
+		mu.Lock()
+	}
+	defer mu.Unlock()
+}
+
 // TryLock used as a plain statement ignores whether the lock was acquired.
 func BadTryLockIgnoredReturn() {
 	var mu sync.Mutex

--- a/pkg/analyzer/testdata/src/mutex/mutex_lock_escape_cases.go
+++ b/pkg/analyzer/testdata/src/mutex/mutex_lock_escape_cases.go
@@ -38,6 +38,20 @@ func (c *closureLocker) LockFunc() func() {
 	}
 }
 
+// Good: the bound unlock method is returned directly, so the caller owns the
+// release. Mirrors minio cmd/local-locker.go getMutex() (`return l.mutex.Unlock`).
+func (c *closureLocker) LockReturningUnlockMethod() func() {
+	c.mu.Lock()
+	return c.mu.Unlock
+}
+
+// Good: the bound unlock method handed back through a local variable.
+func (c *closureLocker) LockReturningUnlockViaLocal() func() {
+	c.mu.Lock()
+	unlock := c.mu.Unlock
+	return unlock
+}
+
 // Bad: the closure that unlocks is never returned or called, so the lock still
 // leaks and must be flagged.
 func (c *closureLocker) BadLockClosureNotReturned() {

--- a/pkg/analyzer/testdata/src/waitgroup/waitgroup_extended_cases.go
+++ b/pkg/analyzer/testdata/src/waitgroup/waitgroup_extended_cases.go
@@ -545,6 +545,29 @@ func BadWaitAndDoneInSameGoroutine() {
 	}()
 }
 
+// GoodShadowedWaitGroupNotConflatedWithOuterDone mirrors minio cmd/erasure.go: a
+// worker goroutine defers Done on an OUTER wg while an inner wg (same name,
+// shadowed) is fully balanced and waited on. The inner Wait must not be blamed
+// for the outer wg's pending Done — the two names resolve to different objects.
+func GoodShadowedWaitGroupNotConflatedWithOuterDone(disks []int, work chan int) {
+	var wg sync.WaitGroup
+	wg.Add(len(disks))
+	for range disks {
+		go func() {
+			defer wg.Done() // outer wg
+			for range work {
+				var wg sync.WaitGroup // shadows the outer wg
+				wg.Add(1)
+				go func() {
+					defer wg.Done() // inner wg
+				}()
+				wg.Wait() // inner wg — must stay CLEAN, not a deadlock
+			}
+		}()
+	}
+	wg.Wait()
+}
+
 func BadParentDoneForWorkerGoroutine() {
 	var wg sync.WaitGroup
 	wg.Add(1)

--- a/pkg/analyzer/testdata/src/waitgroup/waitgroup_interproc_cases.go
+++ b/pkg/analyzer/testdata/src/waitgroup/waitgroup_interproc_cases.go
@@ -1,0 +1,43 @@
+package waitgroup
+
+import "sync"
+
+// workerHost exercises interprocedural Done detection where the Done happens two
+// levels deep: a worker goroutine defers a helper that receives the WaitGroup by
+// address and calls Done. Mirrors tidb pkg/executor/parallel_apply.go.
+type workerHost struct {
+	workerWg sync.WaitGroup
+}
+
+// GoodDelegatedDoneViaHelperMethod must be CLEAN: the Add is balanced by the
+// helper's Done, reached through `go h.worker()` → `defer h.finishWorker(&wg)`.
+func (h *workerHost) GoodDelegatedDoneViaHelperMethod() {
+	h.workerWg.Add(1)
+	go h.worker()
+	h.workerWg.Wait()
+}
+
+func (h *workerHost) worker() {
+	defer h.finishWorker(&h.workerWg)
+}
+
+func (h *workerHost) finishWorker(wg *sync.WaitGroup) {
+	wg.Done()
+}
+
+// BadDelegatedHelperNeverDones proves the delegation-following does not
+// over-suppress: the worker delegates to a helper that receives the WaitGroup
+// but never calls Done, so the Add is genuinely unbalanced and must be flagged.
+func (h *workerHost) BadDelegatedHelperNeverDones() {
+	h.workerWg.Add(1) // want "waitgroup 'h.workerWg' has Add without corresponding Done"
+	go h.brokenWorker()
+	h.workerWg.Wait()
+}
+
+func (h *workerHost) brokenWorker() {
+	defer h.noopHelper(&h.workerWg)
+}
+
+func (h *workerHost) noopHelper(wg *sync.WaitGroup) {
+	_ = wg // receives the WaitGroup but never calls Done
+}

--- a/pkg/analyzer/testdata/src/waitgroup/waitgroup_name_collision_cases.go
+++ b/pkg/analyzer/testdata/src/waitgroup/waitgroup_name_collision_cases.go
@@ -1,0 +1,54 @@
+package waitgroup
+
+import "sync"
+
+// wgChanLike mimics tailscale's syncs.WaitGroupChan: its method set includes
+// Add(int), but completion is signaled via Decr(), not Done(). It is NOT a
+// sync.WaitGroup, so its Add must never be tracked by the WaitGroup checker.
+type wgChanLike struct{ c chan struct{} }
+
+func newWGChanLike() *wgChanLike { return &wgChanLike{c: make(chan struct{})} }
+func (w *wgChanLike) Add(n int)  { _ = n }
+func (w *wgChanLike) Decr()      {}
+
+// GoodSameNameWaitGroupAndLookalike reproduces tailscale net/netcheck.GetReport:
+// a custom wgChanLike and a real sync.WaitGroup share the name "wg" in one
+// function. waitGroupNames is keyed by bare name, so before the type guard the
+// look-alike's Add(len(plan)) was blamed as add-without-done. Neither Add here
+// is unbalanced; the function must stay clean.
+func GoodSameNameWaitGroupAndLookalike(plan, need []int) {
+	wg := newWGChanLike()
+	wg.Add(len(plan))
+	for range plan {
+		go func() { wg.Decr() }()
+	}
+
+	{
+		var wg sync.WaitGroup
+		wg.Add(len(need))
+		for _, n := range need {
+			go func(n int) {
+				defer wg.Done()
+				_ = n
+			}(n)
+		}
+		wg.Wait()
+	}
+}
+
+// BadSameNameRealWaitGroupStillFlagged proves the type guard does not
+// over-suppress: a real sync.WaitGroup that genuinely misses its Done is still
+// flagged even when a same-named look-alike lives in the same function.
+func BadSameNameRealWaitGroupStillFlagged(plan []int) {
+	wg := newWGChanLike()
+	wg.Add(len(plan))
+	for range plan {
+		go func() { wg.Decr() }()
+	}
+
+	{
+		var wg sync.WaitGroup
+		wg.Add(1) // want "waitgroup 'wg' has Add without corresponding Done"
+		wg.Wait()
+	}
+}


### PR DESCRIPTION
## What

Removes five false-positive classes in the WaitGroup and Mutex analyzers, all
surfaced by running the integration suite against 20 real-world repos
(kubernetes, minio, grpc-go, tailscale, bbolt, tidb, containerd, …).

## Fixes

**WaitGroup**
- **GCL2001 name collision** — a real `sync.WaitGroup` and a same-named look-alike
  (tailscale `syncs.WaitGroupChan`, completion via `Decr` not `Done`) in one
  function were merged because tracking is keyed by bare name. Added an
  `isWaitGroupReceiver` type guard at the collect chokepoints.
- **GCL2011 shadowing** — a shadowed inner `wg` was conflated with an outer one
  of the same name (minio `cmd/erasure.go`). Wait/Done are now paired by
  `types.Object` identity, not name.
- **GCL2001 delegated Done** — `go e.worker()` → `defer e.finish(&e.wg)` →
  `wg.Done()` (tidb `parallel_apply.go`) is now followed interprocedurally.

**Mutex**
- **GCL1001/GCL1003 inline TryLock fallback** — `if !mu.TryLock() { mu.Lock() };
  defer mu.Unlock()` (minio `muxclient.go`) no longer flags; the no-else branch
  now carries the TryLock-success state. TryLock-condition detection extracted to
  `tryLockConditionTarget` (DRY).
- **GCL1001 returned unlock method** — `getMutex(){ mu.Lock(); return mu.Unlock }`
  (minio `local-locker.go`) recognised as delegating release to the caller,
  alongside the existing closure/guard shapes.

## Verification

- Full suite green. Seven regression fixtures added, **each with a matching `Bad`
  case** proving detection is not over-suppressed (the fixes only ever suppress).
- Base-vs-patched diff across 20 repos: only the four targeted FP groups drop,
  **zero new findings**; kubernetes/grpc-go/tailscale/bbolt/containerd/consul
  byte-identical.
- `go vet` clean; the linter is self-clean on its own source.

## Notes

- This run also surfaced a **genuine lock leak** in minio
  `cmd/batch-handlers.go` (`updateAfter` returns holding `ri.mu` on the `default`
  error path) — tracked separately for an upstream report.
- A cross-method field-lock lifecycle suppression (bbolt `beginTx`/`removeTx`,
  tailscale `Lockable`) was prototyped and **deliberately dropped**: no safe
  heuristic distinguishes an intentional cross-method lock lifecycle from a real
  leak (e.g. `Lock()` with no unlock in a type whose other method unlocks, or an
  async `go release()`), so it silenced genuine true positives. Those FPs are left
  in place rather than trade them for false negatives.
